### PR TITLE
feat: Add Cursor support with auto-generated .mdc rules

### DIFF
--- a/.github/workflows/build-cursor-rules.yml
+++ b/.github/workflows/build-cursor-rules.yml
@@ -1,0 +1,32 @@
+name: Build Cursor rules
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "scripts/build-cursor-rules.sh"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Cursor rules from skills
+        run: bash scripts/build-cursor-rules.sh
+
+      - name: Commit updated Cursor rules
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cursor/rules/
+          if git diff --cached --quiet; then
+            echo "No changes to Cursor rules"
+          else
+            git commit -m "chore: Rebuild Cursor rules from skills [skip ci]"
+            git push
+          fi

--- a/.github/workflows/build-cursor-rules.yml
+++ b/.github/workflows/build-cursor-rules.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "skills/**"
       - "scripts/build-cursor-rules.sh"
+  pull_request:
+    paths:
+      - "skills/**"
+      - "scripts/build-cursor-rules.sh"
 
 permissions:
   contents: write
@@ -15,11 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Build Cursor rules from skills
         run: bash scripts/build-cursor-rules.sh
 
       - name: Commit updated Cursor rules
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@ This repository contains public Netlify skills — factual platform reference fo
 ## Repository Structure
 
 - `context/` — Steering guides (e.g., POWER.md for Kiro deployments)
+- `.claude-plugin/` — Plugin marketplace config for Claude Code installation
 - `skills/` — Netlify platform skills (source of truth for all agent formats)
 - `cursor/rules/` — Auto-generated Cursor `.mdc` rule files (do NOT edit directly)
 - `scripts/build-cursor-rules.sh` — Converts `skills/` → `cursor/rules/`
-- `.github/workflows/build-cursor-rules.yml` — Runs the build on push to main
+- `.github/workflows/build-cursor-rules.yml` — Runs the build on push to main and PRs
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,27 @@ This repository contains public Netlify skills — factual platform reference fo
 ## Repository Structure
 
 - `context/` — Steering guides (e.g., POWER.md for Kiro deployments)
-- `skills/` — Netlify platform skills for Claude Code and other AI agents
+- `skills/` — Netlify platform skills (source of truth for all agent formats)
+- `cursor/rules/` — Auto-generated Cursor `.mdc` rule files (do NOT edit directly)
+- `scripts/build-cursor-rules.sh` — Converts `skills/` → `cursor/rules/`
+- `.github/workflows/build-cursor-rules.yml` — Runs the build on push to main
 
 ## Skills
 
-The `skills/` directory contains 11 skills covering Netlify platform primitives. See `skills/CLAUDE.md` for a guide on when to use each skill.
+The `skills/` directory contains skills covering Netlify platform primitives. See `skills/CLAUDE.md` for a guide on when to use each skill.
+
+## Cursor Rules
+
+The `cursor/rules/` directory is **auto-generated** from `skills/` and must never be edited directly. A GitHub Actions workflow rebuilds these files whenever `skills/` changes on `main`. To rebuild locally:
+
+```bash
+bash scripts/build-cursor-rules.sh
+```
 
 ## Contributing
 
 Skills should be factual and platform-focused — not opinionated about frameworks, ORMs, or workflow preferences. They help any agent work correctly with Netlify primitives.
 
 Each skill follows the standard SKILL.md format with YAML frontmatter (`name` and `description`). Keep SKILL.md files under 500 lines. Use `references/` subdirectories for detailed content.
+
+**Important:** Always edit files in `skills/`. Never edit files in `cursor/rules/` — they are overwritten by CI.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ Add the marketplace and install the plugin:
 
 This installs all Netlify skills into Claude Code. The included `skills/CLAUDE.md` acts as a router — it tells the agent which skill to read based on what you're building.
 
+### Cursor
+
+Add Netlify rules to your project:
+
+```bash
+git clone --depth 1 https://github.com/netlify/context-and-tools.git /tmp/netlify-skills && \
+  mkdir -p .cursor/rules && \
+  cp /tmp/netlify-skills/cursor/rules/*.mdc .cursor/rules/ && \
+  rm -rf /tmp/netlify-skills
+```
+
+This copies pre-built `.mdc` rule files into `.cursor/rules/`, where Cursor automatically discovers them. A router rule (`netlify-skills-router.mdc`) is included to help the agent pick the right skill for the task.
+
 ### Other AI agents
 
 Each `SKILL.md` file is a self-contained reference with YAML frontmatter (`name` and `description`) and markdown body. Feed them into any agent's context as needed.
@@ -57,3 +70,11 @@ Each `SKILL.md` file is a self-contained reference with YAML frontmatter (`name`
 Keep skills focused on Netlify platform primitives. Each skill should answer "how does this Netlify feature work?" rather than "how should I structure my project?"
 
 Follow the existing format: YAML frontmatter with `name` and `description`, markdown body, code examples with TypeScript where applicable. Use `references/` subdirectories for content that would push a SKILL.md past 500 lines.
+
+### Cursor rules are generated — do not edit them directly
+
+The `cursor/rules/` directory is auto-generated from `skills/` by a GitHub Actions workflow. Always edit the source files in `skills/` — the workflow rebuilds Cursor rules on every push to `main` that changes `skills/`. To test locally, run:
+
+```bash
+bash scripts/build-cursor-rules.sh
+```

--- a/cursor/rules/netlify-ai-gateway.mdc
+++ b/cursor/rules/netlify-ai-gateway.mdc
@@ -1,0 +1,117 @@
+---
+description: Guide for using Netlify AI Gateway to access AI models. Use when adding AI capabilities (text generation, image generation, embeddings) to a Netlify project. Covers supported providers (OpenAI, Anthropic, Google), SDK configuration via base URL override, environment variables, and usage from Netlify Functions.
+alwaysApply: false
+---
+
+# Netlify AI Gateway
+
+Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
+
+## How It Works
+
+The AI Gateway acts as a proxy — you use standard provider SDKs (OpenAI, Anthropic, Google) but point them at Netlify's gateway URL instead of the provider's API. Netlify handles authentication, rate limiting, and monitoring.
+
+## Setup
+
+1. Enable AI on your site in the Netlify UI
+2. The environment variable `OPENAI_BASE_URL` is set automatically by Netlify
+3. Install the provider SDK you want to use
+
+No provider API keys are needed — Netlify's gateway handles authentication.
+
+## Using OpenAI SDK
+
+```bash
+npm install openai
+```
+
+```typescript
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+// OPENAI_BASE_URL is auto-configured — no API key or base URL needed
+
+const completion = await openai.chat.completions.create({
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+## Using Anthropic SDK
+
+```bash
+npm install @anthropic-ai/sdk
+```
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: Netlify.env.get("ANTHROPIC_BASE_URL"),
+});
+
+const message = await client.messages.create({
+  model: "claude-sonnet-4-5-20250929",
+  max_tokens: 1024,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+## Using Google AI SDK
+
+```bash
+npm install @google/generative-ai
+```
+
+```typescript
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const genAI = new GoogleGenerativeAI("placeholder");
+// Configure base URL via environment variable
+
+const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+const result = await model.generateContent("Hello!");
+```
+
+## In a Netlify Function
+
+```typescript
+import type { Config, Context } from "@netlify/functions";
+import OpenAI from "openai";
+
+export default async (req: Request, context: Context) => {
+  const { prompt } = await req.json();
+  const openai = new OpenAI();
+
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  return Response.json({
+    response: completion.choices[0].message.content,
+  });
+};
+
+export const config: Config = {
+  path: "/api/ai",
+  method: "POST",
+};
+```
+
+## Environment Variables
+
+| Variable | Provider | Set by |
+|---|---|---|
+| `OPENAI_BASE_URL` | OpenAI | Netlify (automatic) |
+| `ANTHROPIC_BASE_URL` | Anthropic | Netlify (automatic) |
+
+These are configured automatically when AI is enabled on the site. No manual setup required.
+
+## Local Development
+
+With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are injected automatically. The AI Gateway is accessible during local development after the site has been deployed at least once.
+
+## Available Models
+
+The gateway supports models from OpenAI, Anthropic, and Google. Use standard model identifiers (e.g., `gpt-4o-mini`, `claude-sonnet-4-5-20250929`, `gemini-2.5-flash`). Available models may change — refer to Netlify's AI Gateway documentation for the current list.

--- a/cursor/rules/netlify-blobs.mdc
+++ b/cursor/rules/netlify-blobs.mdc
@@ -1,0 +1,99 @@
+---
+description: Guide for using Netlify Blobs object storage. Use when storing files, images, documents, or simple key-value data without a full database. Covers getStore(), CRUD operations, metadata, listing, deploy-scoped vs site-scoped stores, and local development.
+alwaysApply: false
+---
+
+# Netlify Blobs
+
+Netlify Blobs is zero-config object storage available from any Netlify compute (functions, edge functions, framework server routes). No provisioning required.
+
+```bash
+npm install @netlify/blobs
+```
+
+## Getting a Store
+
+```typescript
+import { getStore } from "@netlify/blobs";
+
+const store = getStore({ name: "my-store" });
+
+// Use "strong" consistency when you need immediate reads after writes
+const store = getStore({ name: "my-store", consistency: "strong" });
+```
+
+## CRUD Operations
+
+These are the **only** store methods. Do not invent others.
+
+### Create / Update
+
+```typescript
+// String or binary data
+await store.set("key", "value");
+await store.set("key", fileBuffer);
+
+// With metadata
+await store.set("key", data, {
+  metadata: { contentType: "image/png", uploadedAt: new Date().toISOString() },
+});
+
+// JSON data
+await store.setJSON("key", { name: "Example", count: 42 });
+```
+
+### Read
+
+```typescript
+// Text (default)
+const text = await store.get("key");                    // string | null
+
+// Typed retrieval
+const json = await store.get("key", { type: "json" });  // object | null
+const stream = await store.get("key", { type: "stream" });
+const blob = await store.get("key", { type: "blob" });
+const buffer = await store.get("key", { type: "arrayBuffer" });
+
+// With metadata
+const result = await store.getWithMetadata("key");
+// { data: any, etag: string, metadata: object } | null
+
+// Metadata only (no data download)
+const meta = await store.getMetadata("key");
+// { etag: string, metadata: object } | null
+```
+
+### Delete
+
+```typescript
+await store.delete("key");
+```
+
+### List
+
+```typescript
+const { blobs } = await store.list();
+// blobs: [{ etag: string, key: string }, ...]
+
+// Filter by prefix
+const { blobs } = await store.list({ prefix: "uploads/" });
+```
+
+## Store Types
+
+- **Site-scoped** (`getStore()`): Persist across all deploys. Use for most cases.
+- **Deploy-scoped** (`getDeployStore()`): Tied to a specific deploy lifecycle.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Max object size | 5 GB |
+| Store name max length | 64 bytes |
+| Key max length | 600 bytes |
+
+## Local Development
+
+Local dev uses a sandboxed store (separate from production). For Vite-based projects, install `@netlify/vite-plugin` to enable local Blobs access. Otherwise, use `netlify dev`.
+
+**Common error**: "The environment has not been configured to use Netlify Blobs" — install `@netlify/vite-plugin` or run via `netlify dev`.

--- a/cursor/rules/netlify-caching.mdc
+++ b/cursor/rules/netlify-caching.mdc
@@ -1,0 +1,136 @@
+---
+description: Guide for controlling caching on Netlify's CDN. Use when configuring cache headers, setting up stale-while-revalidate, implementing on-demand cache purge, or understanding Netlify's CDN caching behavior. Covers Cache-Control, Netlify-CDN-Cache-Control, cache tags, durable cache, and framework-specific caching patterns.
+alwaysApply: false
+---
+
+# Caching on Netlify
+
+## Default Behavior
+
+**Static assets** are cached automatically:
+- CDN: cached for 1 year, invalidated on every deploy
+- Browser: always revalidates (`max-age=0, must-revalidate`)
+- No configuration needed
+
+**Dynamic responses** (functions, edge functions, proxied) are **not cached by default**. Add cache headers explicitly.
+
+## Cache-Control Headers
+
+Three headers control caching, from most to least specific:
+
+| Header | Who sees it | Use case |
+|---|---|---|
+| `Netlify-CDN-Cache-Control` | Netlify CDN only (stripped before browser) | CDN-only caching |
+| `CDN-Cache-Control` | All CDN caches (stripped before browser) | Multi-CDN setups |
+| `Cache-Control` | Browser and all caches | General caching |
+
+### Common Patterns
+
+```typescript
+// Cache at CDN for 1 hour, browser always revalidates
+return new Response(body, {
+  headers: {
+    "Netlify-CDN-Cache-Control": "public, s-maxage=3600, must-revalidate",
+    "Cache-Control": "public, max-age=0, must-revalidate",
+  },
+});
+
+// Stale-while-revalidate (serve stale for 2 min while refreshing)
+return new Response(body, {
+  headers: {
+    "Netlify-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=120",
+  },
+});
+
+// Durable cache (shared across edge nodes, serverless functions only)
+return new Response(body, {
+  headers: {
+    "Netlify-CDN-Cache-Control": "public, durable, max-age=60, stale-while-revalidate=120",
+  },
+});
+```
+
+### Immutable Assets
+
+For fingerprinted files (hash in filename):
+
+```toml
+# netlify.toml
+[[headers]]
+for = "/assets/*"
+[headers.values]
+Cache-Control = "public, max-age=31536000, immutable"
+```
+
+## Cache Tags and On-Demand Purge
+
+Tag responses for selective cache invalidation:
+
+```typescript
+return new Response(body, {
+  headers: {
+    "Netlify-Cache-ID": "product,listing",
+    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
+  },
+});
+```
+
+Purge by tag:
+
+```typescript
+import { purgeCache } from "@netlify/functions";
+
+export default async () => {
+  await purgeCache({ tags: ["product"] });
+  return new Response("Purged", { status: 202 });
+};
+```
+
+Purge entire site:
+
+```typescript
+await purgeCache();
+```
+
+Responses with `Netlify-Cache-ID` are **excluded from automatic deploy-based invalidation** — they must be purged explicitly.
+
+## Cache Key Variation
+
+Customize what creates separate cache entries:
+
+```typescript
+return new Response(body, {
+  headers: {
+    "Netlify-Vary": "cookie=ab_test|is_logged_in",
+    // Other options: query=param1|param2, header=X-Custom, country=us|de, language=en|fr
+  },
+});
+```
+
+## Framework-Specific Caching
+
+### Next.js
+ISR uses Netlify's durable cache automatically (runtime 5.5.0+). `revalidatePath` and `revalidateTag` trigger cache purge.
+
+### Astro / Remix
+Full control over cache headers in server routes. Set `Netlify-CDN-Cache-Control` in responses for CDN caching.
+
+### Nuxt
+Default Nitro preset handles caching. ISR-style patterns use `routeRules` with `swr` or `isr` options.
+
+### Vite SPA
+Static assets are cached by default. API responses from Netlify Functions need explicit cache headers.
+
+## Debugging
+
+Check the `Cache-Status` response header:
+- `HIT` — served from cache
+- `MISS` — generated fresh
+- `REVALIDATED` — stale content was revalidated
+
+## Constraints
+
+- Basic auth disables caching for the entire site
+- Durable cache is serverless functions only (not edge functions)
+- Same URL must return identical `Netlify-Vary` headers across responses
+- Deploy invalidation is scoped to deploy context (production vs preview)

--- a/cursor/rules/netlify-cli-and-deploy.mdc
+++ b/cursor/rules/netlify-cli-and-deploy.mdc
@@ -1,0 +1,151 @@
+---
+description: Guide for using the Netlify CLI and deploying sites. Use when installing the CLI, linking sites, deploying (Git-based or manual), managing environment variables, or running local development. Covers netlify dev, netlify deploy, Git vs non-Git workflows, and environment variable management.
+alwaysApply: false
+---
+
+# Netlify CLI and Deployment
+
+## Installation
+
+```bash
+npm install -g netlify-cli    # Global (for local dev)
+npm install netlify-cli -D    # Local (for CI)
+```
+
+Requires Node.js 18.14.0+.
+
+## Authentication
+
+```bash
+netlify login       # Opens browser for OAuth
+netlify status      # Check auth + linked site status
+```
+
+For CI, set `NETLIFY_AUTH_TOKEN` environment variable instead.
+
+## Linking a Site
+
+Check if already linked with `netlify status`. If not:
+
+```bash
+# Interactive
+netlify link
+
+# By Git remote (if using Git)
+netlify link --git-remote-url https://github.com/org/repo
+
+# Create new site
+netlify init           # With Git CI/CD setup
+netlify init --manual  # Without Git CI/CD
+```
+
+Site ID is stored in `.netlify/state.json`. Add `.netlify` to `.gitignore`.
+
+## Deploying
+
+### Git-Based Deploys (Continuous Deployment)
+
+Set up with `netlify init`. Automatic deploys trigger on push/PR:
+- Push to production branch → production deploy
+- Open PR → deploy preview with unique URL
+- Push to other branches → branch deploy
+
+Build runs on Netlify's servers. Configure build settings in `netlify.toml`.
+
+### Manual / Local Deploys (No Git Required)
+
+Build locally, then upload:
+
+```bash
+netlify deploy          # Draft deploy (preview URL)
+netlify deploy --prod   # Production deploy
+netlify deploy --dir=dist  # Specify output directory
+```
+
+This works without Git — useful for prototypes, local-only projects, or CI pipelines.
+
+## Local Development
+
+### Option 1: netlify dev
+
+```bash
+netlify dev
+```
+
+Wraps your framework's dev server and provides:
+- Environment variable injection
+- Functions and edge functions
+- Redirects and headers processing
+
+### Option 2: Netlify Vite Plugin (Vite-based projects)
+
+For projects using Vite (React SPA, TanStack Start, SvelteKit, Remix), the Vite plugin provides Netlify platform primitives directly in the framework's dev server:
+
+```bash
+npm install @netlify/vite-plugin
+```
+
+```typescript
+// vite.config.ts
+import netlify from "@netlify/vite-plugin";
+export default defineConfig({ plugins: [netlify()] });
+```
+
+Then run your normal dev command (`npm run dev`) — no `netlify dev` wrapper needed. This gives you access to Blobs, DB, Functions, and environment variables during development.
+
+See the **netlify-frameworks** skill for framework-specific local dev guidance.
+
+## Environment Variables
+
+### CLI Management
+
+```bash
+# Set
+netlify env:set API_KEY "value"
+netlify env:set API_KEY "value" --secret              # Hidden from logs
+netlify env:set API_KEY "value" --context production   # Context-specific
+
+# Get
+netlify env:get API_KEY
+
+# List
+netlify env:list
+netlify env:list --plain > .env                        # Export to file
+
+# Import from file
+netlify env:import .env
+
+# Delete
+netlify env:unset API_KEY
+```
+
+### Context Scoping
+
+Variables can be scoped to deploy contexts:
+
+```bash
+netlify env:set API_URL "https://api.prod.com" --context production
+netlify env:set API_URL "https://api.staging.com" --context deploy-preview
+netlify env:set DEBUG "true" --context branch:feature-x
+```
+
+### Accessing in Code
+
+- **Server-side (Functions)**: Use `Netlify.env.get("VAR")` (preferred) or `process.env.VAR`
+- **Client-side (Vite)**: Only `VITE_`-prefixed vars via `import.meta.env.VITE_VAR`
+- **Client-side (Astro)**: Only `PUBLIC_`-prefixed vars via `import.meta.env.PUBLIC_VAR`
+
+**Never use `VITE_` or `PUBLIC_` prefix for secrets** — these are exposed to the browser.
+
+## Useful Commands
+
+| Command | Description |
+|---|---|
+| `netlify status` | Auth and site link status |
+| `netlify dev` | Start local dev server |
+| `netlify build` | Run build locally (mimics Netlify environment) |
+| `netlify deploy` | Draft deploy |
+| `netlify deploy --prod` | Production deploy |
+| `netlify dev:exec <cmd>` | Run command with Netlify environment loaded |
+| `netlify env:list` | List environment variables |
+| `netlify clone org/repo` | Clone, link, and set up in one step |

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -1,0 +1,175 @@
+---
+description: Reference for netlify.toml configuration. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, environment variables, or any site-level configuration. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
+alwaysApply: false
+---
+
+# Netlify Configuration (netlify.toml)
+
+Place `netlify.toml` at the repository root (or at the base directory for monorepos).
+
+## Build Settings
+
+```toml
+[build]
+  base = "project/"          # Base directory (default: root)
+  command = "npm run build"  # Build command
+  publish = "dist/"          # Output directory
+```
+
+## Redirects
+
+```toml
+# Basic redirect
+[[redirects]]
+from = "/old"
+to = "/new"
+status = 301              # 301 (default), 302, 200 (rewrite), 404
+
+# SPA catch-all
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200
+
+# Splat (wildcard)
+[[redirects]]
+from = "/blog/*"
+to = "/news/:splat"
+
+# Path parameters
+[[redirects]]
+from = "/users/:id"
+to = "/api/users/:id"
+status = 200
+
+# Force (override existing files)
+[[redirects]]
+from = "/app/*"
+to = "/index.html"
+status = 200
+force = true
+
+# Proxy to external service
+[[redirects]]
+from = "/api/*"
+to = "https://api.example.com/:splat"
+status = 200
+[redirects.headers]
+  X-Custom = "value"
+
+# Country/language conditions
+[[redirects]]
+from = "/*"
+to = "/fr/:splat"
+status = 200
+conditions = { Country = ["FR"], Language = ["fr"] }
+```
+
+**Rule order matters** — Netlify processes the first matching rule. Place specific rules before general ones.
+
+## Headers
+
+```toml
+[[headers]]
+for = "/*"
+[headers.values]
+  X-Frame-Options = "DENY"
+  X-Content-Type-Options = "nosniff"
+
+[[headers]]
+for = "/assets/*"
+[headers.values]
+  Cache-Control = "public, max-age=31536000, immutable"
+```
+
+Headers apply only to files served from Netlify's CDN (not to function or edge function responses — set those in code).
+
+## Deploy Contexts
+
+Override settings per deploy context:
+
+```toml
+[context.production]
+command = "npm run build"
+environment = { NODE_ENV = "production" }
+
+[context.deploy-preview]
+command = "npm run build:preview"
+
+[context.branch-deploy]
+command = "npm run build:staging"
+
+[context.dev]
+environment = { NODE_ENV = "development" }
+
+# Specific branch
+[context."staging"]
+command = "npm run build:staging"
+```
+
+## Environment Variables
+
+```toml
+[build.environment]
+NODE_VERSION = "20"
+
+[context.production.environment]
+API_URL = "https://api.prod.com"
+
+[context.deploy-preview.environment]
+API_URL = "https://api.staging.com"
+```
+
+**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values. See the **netlify-cli-and-deploy** skill for CLI environment variable management.
+
+## Functions Configuration
+
+```toml
+[functions]
+directory = "netlify/functions"   # Default
+node_bundler = "esbuild"
+
+# Scheduled function
+[functions."cleanup"]
+schedule = "@daily"
+```
+
+## Edge Functions Configuration
+
+```toml
+[[edge_functions]]
+path = "/admin"
+function = "auth"
+
+# Import map for Deno URL imports
+[functions]
+deno_import_map = "./import_map.json"
+```
+
+## Dev Server
+
+```toml
+[dev]
+command = "npm start"       # Dev server command
+port = 8888                 # Netlify Dev port
+targetPort = 3000           # Your app's dev server port
+framework = "#auto"         # "#auto", "#static", "#custom"
+```
+
+## Plugins
+
+```toml
+[[plugins]]
+package = "@netlify/plugin-lighthouse"
+[plugins.inputs]
+  audits = ["performance", "accessibility"]
+```
+
+## Image CDN
+
+```toml
+[images]
+remote_images = ["https://example\\.com/.*"]
+```
+
+See the **netlify-image-cdn** skill for full Image CDN usage.

--- a/cursor/rules/netlify-db.mdc
+++ b/cursor/rules/netlify-db.mdc
@@ -1,0 +1,136 @@
+---
+description: Guide for using Netlify DB (managed Neon Postgres). Use when the project needs a relational database, structured data storage, SQL queries, or data that will grow over time. Covers provisioning, raw SQL via @netlify/neon, Drizzle ORM integration, migrations, and deploy preview branching. Also covers when to use Netlify Blobs instead.
+alwaysApply: false
+---
+
+# Netlify DB
+
+Netlify DB provisions a managed Neon Postgres database automatically. No Neon account required.
+
+## When to Use DB vs Blobs
+
+**Use Netlify DB when:**
+- Storing structured, relational data
+- Data will grow over time
+- Need queries, filtering, joins, or aggregations
+
+**Use Netlify Blobs instead when:**
+- Storing files (images, documents, exports)
+- A handful of records with no growth expectation
+- Simple key-value storage with no relational needs
+- Want zero dependencies beyond `@netlify/blobs`
+
+See the **netlify-blobs** skill for Blobs usage.
+
+## Setup
+
+```bash
+npm install @netlify/neon
+netlify db init    # Provisions database and sets up Drizzle ORM
+```
+
+Prerequisites: logged into Netlify CLI and site linked (`netlify link`).
+
+## Raw SQL via @netlify/neon
+
+`@netlify/neon` wraps `@neondatabase/serverless`. No connection string needed — it auto-configures.
+
+```typescript
+import { neon } from "@netlify/neon";
+const sql = neon();
+
+const users = await sql("SELECT * FROM users");
+await sql("INSERT INTO users (name) VALUES ($1)", ["Jane"]);
+await sql("UPDATE users SET name = $1 WHERE id = $2", ["Jane", 1]);
+await sql("DELETE FROM users WHERE id = $1", [1]);
+```
+
+## Drizzle ORM Integration
+
+For most projects, use Drizzle ORM on top of Netlify DB.
+
+### drizzle.config.ts
+
+```typescript
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  dbCredentials: { url: process.env.NETLIFY_DATABASE_URL! },
+  schema: "./db/schema.ts",
+  out: "./migrations",
+  migrations: { prefix: "timestamp" }, // Avoids conflicts across branches
+});
+```
+
+### db/index.ts
+
+```typescript
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import * as schema from "./schema";
+
+const sql = neon(process.env.NETLIFY_DATABASE_URL!);
+export const db = drizzle(sql, { schema });
+export * from "./schema";
+```
+
+### Schema Example
+
+```typescript
+// db/schema.ts
+import { integer, pgTable, varchar, text, boolean, timestamp } from "drizzle-orm/pg-core";
+
+export const items = pgTable("items", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  title: varchar({ length: 255 }).notNull(),
+  description: text(),
+  isActive: boolean("is_active").notNull().default(true),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+export type Item = typeof items.$inferSelect;
+export type NewItem = typeof items.$inferInsert;
+```
+
+### Query Patterns
+
+```typescript
+import { db, items } from "../db";
+import { eq } from "drizzle-orm";
+
+const all = await db.select().from(items);
+const [one] = await db.select().from(items).where(eq(items.id, id)).limit(1);
+const [created] = await db.insert(items).values({ title: "New" }).returning();
+const [updated] = await db.update(items).set({ title: "Updated" }).where(eq(items.id, id)).returning();
+await db.delete(items).where(eq(items.id, id));
+```
+
+## Migrations
+
+```json
+{
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "netlify dev:exec drizzle-kit migrate",
+    "db:push": "netlify dev:exec drizzle-kit push",
+    "db:studio": "netlify dev:exec drizzle-kit studio"
+  }
+}
+```
+
+Workflow: modify schema, run `db:generate`, then `db:migrate`.
+
+## Deploy Preview Branching
+
+Netlify DB supports branching — production branch gets the production database, all other branches and deploy previews get a separate preview branch. Develop and test migrations on preview, merge to main, then apply to production.
+
+## Environment Variables
+
+- `NETLIFY_DATABASE_URL` — Auto-set by Netlify when database is provisioned
+- Retrieve manually: `netlify env:get NETLIFY_DATABASE_URL`
+
+## Local Development
+
+Run `netlify dev` or use `@netlify/vite-plugin` to get database access locally. Use `netlify dev:exec` to run migration commands with the proper environment.

--- a/cursor/rules/netlify-edge-functions.mdc
+++ b/cursor/rules/netlify-edge-functions.mdc
@@ -1,0 +1,126 @@
+---
+description: Guide for writing Netlify Edge Functions. Use when building middleware, geolocation-based logic, request/response manipulation, authentication checks, A/B testing, or any low-latency edge compute. Covers Deno runtime, context.next() middleware pattern, geolocation, and when to choose edge vs serverless.
+alwaysApply: false
+---
+
+# Netlify Edge Functions
+
+Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
+
+## Syntax
+
+```typescript
+import type { Config, Context } from "@netlify/edge-functions";
+
+export default async (req: Request, context: Context) => {
+  return new Response("Hello from the edge!");
+};
+
+export const config: Config = {
+  path: "/hello",
+};
+```
+
+Place files in `netlify/edge-functions/`. Uses `.ts`, `.js`, `.tsx`, or `.jsx` extensions.
+
+## Config Object
+
+```typescript
+export const config: Config = {
+  path: "/api/*",                    // URLPattern path(s)
+  excludedPath: "/api/public/*",     // Exclusions
+  method: ["GET", "POST"],           // HTTP methods
+  onError: "bypass",                 // "fail" (default), "bypass", or "/error-page"
+  cache: "manual",                   // Enable response caching
+};
+```
+
+## Middleware Pattern
+
+Use `context.next()` to invoke the next handler in the chain and optionally modify the response:
+
+```typescript
+export default async (req: Request, context: Context) => {
+  // Before: modify request or short-circuit
+  if (!isAuthenticated(req)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Continue to origin/next function
+  const response = await context.next();
+
+  // After: modify response
+  response.headers.set("x-custom-header", "value");
+  return response;
+};
+```
+
+Return `undefined` to pass through without modification:
+
+```typescript
+export default async (req: Request, context: Context) => {
+  if (!shouldHandle(req)) return; // continues to next handler
+  return new Response("Handled");
+};
+```
+
+## Geolocation and IP
+
+```typescript
+export default async (req: Request, context: Context) => {
+  const { city, country, subdivision, timezone } = context.geo;
+  const ip = context.ip;
+
+  if (country?.code === "DE") {
+    return Response.redirect(new URL("/de", req.url));
+  }
+};
+```
+
+Local dev with mocked geo: `netlify dev --geo=mock --country=US`
+
+## Environment Variables
+
+Use `Netlify.env` (not `process.env` or `Deno.env`):
+
+```typescript
+const secret = Netlify.env.get("API_SECRET");
+```
+
+## Module Support
+
+- **Node.js builtins**: `import { randomBytes } from "node:crypto";`
+- **npm packages**: Install via npm and import by name
+- **Deno modules**: URL imports (e.g., `import X from "https://esm.sh/package"`)
+
+For URL imports, use an import map:
+
+```json
+// import_map.json
+{ "imports": { "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts" } }
+```
+
+```toml
+# netlify.toml
+[functions]
+  deno_import_map = "./import_map.json"
+```
+
+## When to Use Edge vs Serverless
+
+| Use Edge Functions for | Use Serverless Functions for |
+|---|---|
+| Low-latency responses | Long-running operations (up to 15 min) |
+| Request/response manipulation | Complex Node.js dependencies |
+| Geolocation-based logic | Database-heavy operations |
+| Auth checks and redirects | Background/scheduled tasks |
+| A/B testing, personalization | Tasks needing > 512 MB memory |
+
+## Limits
+
+| Resource | Limit |
+|---|---|
+| CPU time | 50 ms per request |
+| Memory | 512 MB per deployed set |
+| Response header timeout | 40 seconds |
+| Code size | 20 MB compressed |

--- a/cursor/rules/netlify-forms.mdc
+++ b/cursor/rules/netlify-forms.mdc
@@ -1,0 +1,151 @@
+---
+description: Guide for using Netlify Forms for HTML form handling. Use when adding contact forms, feedback forms, file upload forms, or any form that should be collected by Netlify. Covers the data-netlify attribute, spam filtering, AJAX submissions, file uploads, notifications, and the submissions API.
+alwaysApply: false
+---
+
+# Netlify Forms
+
+Netlify Forms collects HTML form submissions without server-side code. Form detection must be enabled in the Netlify UI (Forms section).
+
+## Basic Setup
+
+Add `data-netlify="true"` and a unique `name` to the form:
+
+```html
+<form name="contact" method="POST" data-netlify="true">
+  <label>Name: <input type="text" name="name" /></label>
+  <label>Email: <input type="email" name="email" /></label>
+  <label>Message: <textarea name="message"></textarea></label>
+  <button type="submit">Send</button>
+</form>
+```
+
+Netlify's build system detects the form and injects a hidden `form-name` input automatically. For a custom success page, add `action="/thank-you"` to the form tag.
+
+## JavaScript-Rendered Forms (React, Vue, etc.)
+
+For forms rendered by JavaScript frameworks, Netlify's build parser cannot detect the form in static HTML. You must either:
+
+**Option A:** Add a hidden HTML form to your `index.html` (or equivalent static file):
+
+```html
+<form name="contact" netlify netlify-honeypot="bot-field" hidden>
+  <input type="text" name="name" />
+  <input type="email" name="email" />
+  <textarea name="message"></textarea>
+</form>
+```
+
+**Option B:** Include a hidden `form-name` input in your component:
+
+```jsx
+<form name="contact" method="POST" data-netlify="true">
+  <input type="hidden" name="form-name" value="contact" />
+  {/* ... fields ... */}
+</form>
+```
+
+## AJAX Submissions
+
+### Vanilla JavaScript
+
+```javascript
+const form = document.querySelector("form");
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const formData = new FormData(form);
+  await fetch("/", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(formData).toString(),
+  });
+});
+```
+
+### React Example
+
+```tsx
+function ContactForm() {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const response = await fetch("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(formData as any).toString(),
+    });
+    if (response.ok) {
+      // Show success feedback
+    }
+  };
+
+  return (
+    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
+      <input type="hidden" name="form-name" value="contact" />
+      <input type="text" name="name" placeholder="Name" />
+      <input type="email" name="email" placeholder="Email" />
+      <textarea name="message" placeholder="Message" />
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+## Spam Filtering
+
+Netlify uses Akismet automatically. Add a honeypot field for extra protection:
+
+```html
+<form name="contact" method="POST" netlify-honeypot="bot-field" data-netlify="true">
+  <p style="display:none">
+    <label>Don't fill this out: <input name="bot-field" /></label>
+  </p>
+  <!-- visible fields -->
+</form>
+```
+
+For reCAPTCHA, add `data-netlify-recaptcha="true"` to the form and include `<div data-netlify-recaptcha="true"></div>` where the widget should appear.
+
+## File Uploads
+
+```html
+<form name="upload" enctype="multipart/form-data" data-netlify="true">
+  <input type="text" name="name" />
+  <input type="file" name="attachment" />
+  <button type="submit">Upload</button>
+</form>
+```
+
+For AJAX file uploads, use `FormData` directly — do **not** set `Content-Type` (the browser sets it with the correct boundary):
+
+```javascript
+await fetch("/", { method: "POST", body: new FormData(form) });
+```
+
+**Limits:** 8 MB max request size, 30-second timeout, one file per input field.
+
+## Notifications
+
+Configure in the Netlify UI under **Project configuration > Notifications**:
+
+- **Email**: Auto-sends on submission. Add `<input type="hidden" name="subject" value="Contact form" />` for custom subject lines.
+- **Slack**: Via Netlify App for Slack.
+- **Webhooks**: Trigger external services on submission.
+
+## Submissions API
+
+Access submissions programmatically:
+
+```
+GET /api/v1/forms/{form_id}/submissions
+Authorization: Bearer <PERSONAL_ACCESS_TOKEN>
+```
+
+Key endpoints:
+
+| Action | Method | Path |
+|---|---|---|
+| List forms | GET | `/api/v1/sites/{site_id}/forms` |
+| Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
+| Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
+| Delete submission | DELETE | `/api/v1/submissions/{id}` |

--- a/cursor/rules/netlify-frameworks-astro.mdc
+++ b/cursor/rules/netlify-frameworks-astro.mdc
@@ -1,0 +1,125 @@
+---
+description: Astro on Netlify. Reference for the netlify-frameworks skill.
+alwaysApply: false
+---
+# Astro on Netlify
+
+## Setup
+
+Install the Netlify adapter:
+
+```bash
+npx astro add netlify
+```
+
+This installs `@astrojs/netlify` and updates `astro.config.*` automatically.
+
+### Manual Setup
+
+```bash
+npm install @astrojs/netlify
+```
+
+```typescript
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import netlify from "@astrojs/netlify";
+
+export default defineConfig({
+  output: "server",  // or "hybrid" for mixed static/SSR
+  adapter: netlify(),
+});
+```
+
+## Output Modes
+
+| Mode | Behavior |
+|---|---|
+| `"static"` | Fully pre-rendered at build time (no adapter needed) |
+| `"server"` | All pages rendered on request (SSR) |
+| `"hybrid"` | Static by default, opt-in to SSR per page with `export const prerender = false` |
+
+## What the Adapter Does
+
+- Converts Astro server routes into Netlify Functions
+- Handles SSR, API routes, and middleware
+- Maps Astro's routing to Netlify's function routing
+- You do **not** write raw Netlify Functions for Astro's server routes
+
+## API Routes
+
+Astro API routes (in `src/pages/api/`) are handled by the adapter:
+
+```typescript
+// src/pages/api/items.ts
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ items: [] }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const data = await request.json();
+  return new Response(JSON.stringify({ created: data }), { status: 201 });
+};
+```
+
+## Forms (HTML Pattern)
+
+Astro renders HTML server-side, so Netlify can detect forms directly:
+
+```astro
+---
+// src/pages/contact.astro
+---
+<form name="contact" method="POST" data-netlify="true">
+  <label>Name: <input type="text" name="name" /></label>
+  <label>Email: <input type="email" name="email" /></label>
+  <label>Message: <textarea name="message"></textarea></label>
+  <button type="submit">Send</button>
+</form>
+```
+
+For form submissions that should redirect back with feedback, handle the POST in an API route and redirect:
+
+```typescript
+// src/pages/api/contact.ts
+export const POST: APIRoute = async ({ request, redirect }) => {
+  const formData = await request.formData();
+  // Process form...
+  return redirect("/contact?success=true");
+};
+```
+
+## Custom 404
+
+Create `src/pages/404.astro`. Astro handles this automatically.
+
+## Local Development
+
+**Option A: Astro dev server** (simpler, but no Netlify primitives):
+
+```bash
+npm run dev    # astro dev
+```
+
+**Option B: netlify dev** (full Netlify environment including functions, env vars):
+
+```bash
+netlify dev
+```
+
+The Astro adapter's local dev experience with `netlify dev` varies — for Blobs and DB access, `netlify dev` is recommended. If using `@netlify/vite-plugin` alongside Astro, local platform primitives may also be available via the standard dev server, but this integration is less mature than with pure Vite projects.
+
+## Build and Deploy
+
+```toml
+# netlify.toml
+[build]
+command = "astro build"
+publish = "dist"
+```
+
+The adapter configures the publish directory and function routing automatically.

--- a/cursor/rules/netlify-frameworks-nextjs.mdc
+++ b/cursor/rules/netlify-frameworks-nextjs.mdc
@@ -1,0 +1,95 @@
+---
+description: Next.js on Netlify. Reference for the netlify-frameworks skill.
+alwaysApply: false
+---
+# Next.js on Netlify
+
+## Setup
+
+Next.js on Netlify uses the `@netlify/next` runtime, which is installed automatically. No manual adapter installation is required — Netlify detects Next.js and configures the build automatically.
+
+```toml
+# netlify.toml
+[build]
+command = "next build"
+publish = ".next"
+```
+
+## What the Runtime Does
+
+- Converts Next.js server-side features (SSR, API routes, middleware, ISR) into Netlify Functions and Edge Functions
+- Handles image optimization via Netlify Image CDN
+- Maps Next.js routing to Netlify's infrastructure
+- Supports App Router and Pages Router
+
+## Key Configuration
+
+### next.config.js
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "example.com" },
+    ],
+  },
+};
+
+module.exports = nextConfig;
+```
+
+Remote image patterns in `next.config.js` are automatically mapped to Netlify Image CDN's `remote_images` configuration.
+
+## API Routes
+
+Next.js API routes work automatically — they are deployed as Netlify Functions:
+
+```typescript
+// app/api/items/route.ts (App Router)
+export async function GET() {
+  return Response.json({ items: [] });
+}
+
+export async function POST(request: Request) {
+  const data = await request.json();
+  return Response.json({ created: data }, { status: 201 });
+}
+```
+
+## Middleware
+
+Next.js middleware is deployed as a Netlify Edge Function:
+
+```typescript
+// middleware.ts
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Runs at the edge on Netlify
+  return NextResponse.next();
+}
+```
+
+## ISR (Incremental Static Regeneration)
+
+ISR works on Netlify. Pages with `revalidate` are cached and revalidated using Netlify's CDN cache with `stale-while-revalidate`. On-demand revalidation via `revalidatePath` and `revalidateTag` triggers Netlify cache purge.
+
+## Local Development
+
+```bash
+npm run dev    # next dev — standard Next.js dev server
+```
+
+For Netlify-specific features (environment variables, edge middleware testing), use:
+
+```bash
+netlify dev
+```
+
+## Known Patterns
+
+- **Static export** (`output: "export"`): Works without the runtime — produces a fully static site
+- **Standalone mode** is not required; the Netlify runtime handles deployment automatically
+- Environment variables use the `NEXT_PUBLIC_` prefix for client-side access

--- a/cursor/rules/netlify-frameworks-tanstack.mdc
+++ b/cursor/rules/netlify-frameworks-tanstack.mdc
@@ -1,0 +1,64 @@
+---
+description: TanStack Start on Netlify. Reference for the netlify-frameworks skill.
+alwaysApply: false
+---
+# TanStack Start on Netlify
+
+## Setup
+
+TanStack Start uses the Netlify Vite plugin for deployment.
+
+```bash
+npm install @netlify/vite-plugin
+```
+
+```typescript
+// app.config.ts
+import { defineConfig } from "@tanstack/react-start/config";
+import netlify from "@netlify/vite-plugin";
+
+export default defineConfig({
+  vite: {
+    plugins: [netlify()],
+  },
+});
+```
+
+## What the Plugin Does
+
+- Handles SSR output for Netlify Functions
+- Enables Netlify platform primitives (Blobs, DB, env vars) in local dev
+- Maps TanStack Start's file-based routing to Netlify's infrastructure
+
+## Server Functions
+
+TanStack Start uses `createServerFn` for server-side logic. These are automatically handled by the Netlify Vite plugin — no raw Netlify Functions needed:
+
+```typescript
+import { createServerFn } from "@tanstack/react-start";
+
+const getItems = createServerFn({ method: "GET" }).handler(async () => {
+  // Server-side code — runs as Netlify Function in production
+  const items = await db.select().from(itemsTable);
+  return items;
+});
+```
+
+## Local Development
+
+```bash
+npm run dev    # Uses Vite plugin — Netlify primitives available
+```
+
+The Vite plugin provides Functions, Blobs, DB, and environment variables during local dev without needing `netlify dev`.
+
+## Build and Deploy
+
+```toml
+# netlify.toml
+[build]
+command = "npm run build"
+publish = ".output/public"
+```
+
+The Vite plugin configures the output structure for Netlify automatically.

--- a/cursor/rules/netlify-frameworks-vite.mdc
+++ b/cursor/rules/netlify-frameworks-vite.mdc
@@ -1,0 +1,110 @@
+---
+description: Vite + React on Netlify. Reference for the netlify-frameworks skill.
+alwaysApply: false
+---
+# Vite + React on Netlify
+
+## Setup
+
+Install the Netlify Vite plugin:
+
+```bash
+npm install @netlify/vite-plugin
+```
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import netlify from "@netlify/vite-plugin";
+
+export default defineConfig({
+  plugins: [react(), netlify()],
+});
+```
+
+## What the Plugin Does
+
+- Enables Netlify Functions, Blobs, DB, and environment variables in local dev
+- Handles build output for Netlify deployment
+- No need for `netlify dev` — run `npm run dev` directly
+
+## SPA Routing
+
+For client-side routing (React Router, etc.), add the catch-all redirect:
+
+```toml
+# netlify.toml
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200
+```
+
+## Netlify Functions
+
+Write functions in `netlify/functions/` as usual. The Vite plugin makes them available during local dev at their configured paths.
+
+```typescript
+// netlify/functions/api.ts
+import type { Config, Context } from "@netlify/functions";
+
+export default async (req: Request, context: Context) => {
+  return Response.json({ message: "Hello from API" });
+};
+
+export const config: Config = { path: "/api/hello" };
+```
+
+## Forms (AJAX Pattern)
+
+Since Vite + React renders forms client-side, include a hidden HTML form for Netlify to detect, and submit via AJAX:
+
+```tsx
+// In your React component
+function ContactForm() {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    await fetch("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(formData as any).toString(),
+    });
+  };
+
+  return (
+    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
+      <input type="hidden" name="form-name" value="contact" />
+      {/* fields */}
+    </form>
+  );
+}
+```
+
+Also add a hidden form in `index.html`:
+
+```html
+<form name="contact" netlify hidden>
+  <input type="text" name="name" />
+  <input type="email" name="email" />
+  <textarea name="message"></textarea>
+</form>
+```
+
+## Local Dev
+
+```bash
+npm run dev   # Uses Vite plugin — Netlify primitives available
+```
+
+No `netlify dev` wrapper needed. Functions, Blobs, DB, and environment variables all work.
+
+## Build and Deploy
+
+```toml
+# netlify.toml
+[build]
+command = "npm run build"
+publish = "dist"
+```

--- a/cursor/rules/netlify-frameworks.mdc
+++ b/cursor/rules/netlify-frameworks.mdc
@@ -1,0 +1,66 @@
+---
+description: Guide for deploying web frameworks on Netlify. Use when setting up a framework project (Vite/React, Astro, TanStack Start, Next.js, Nuxt, SvelteKit, Remix) for Netlify deployment, configuring adapters or plugins, or troubleshooting framework-specific Netlify integration. Covers what Netlify needs from each framework and how adapters handle server-side rendering.
+alwaysApply: false
+---
+
+# Frameworks on Netlify
+
+Netlify supports any framework that produces static output. For frameworks with server-side capabilities (SSR, API routes, middleware), an adapter or plugin translates the framework's server-side code into Netlify Functions and Edge Functions automatically.
+
+## How It Works
+
+During build, the framework adapter writes files to `.netlify/v1/` — functions, edge functions, redirects, and configuration. Netlify reads these to deploy the site. You do not need to write Netlify Functions manually when using a framework adapter for server-side features.
+
+## Detecting Your Framework
+
+Check these files to determine the framework:
+
+| File | Framework |
+|---|---|
+| `astro.config.*` | Astro |
+| `next.config.*` | Next.js |
+| `nuxt.config.*` | Nuxt |
+| `vite.config.*` + `react-router` | Vite + React (SPA or Remix) |
+| `app.config.*` + `@tanstack/react-start` | TanStack Start |
+| `svelte.config.*` | SvelteKit |
+
+## Framework Reference Guides
+
+Each framework has specific adapter/plugin requirements and local dev patterns:
+
+- **Vite + React (SPA or with server routes)**: See [references/vite.md](references/vite.md)
+- **Astro**: See [references/astro.md](references/astro.md)
+- **TanStack Start**: See [references/tanstack.md](references/tanstack.md)
+- **Next.js**: See [references/nextjs.md](references/nextjs.md)
+
+## General Patterns
+
+### Client-Side Routing (SPA)
+
+For single-page apps with client-side routing, add a catch-all redirect:
+
+```toml
+# netlify.toml
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200
+```
+
+### Custom 404 Pages
+
+- **Static sites**: Create a `404.html` in your publish directory. Netlify serves it automatically for unmatched routes.
+- **SSR frameworks**: Handle 404s in the framework's routing (the adapter maps this to Netlify's function routing).
+
+### Environment Variables in Frameworks
+
+Each framework exposes environment variables to client-side code differently:
+
+| Framework | Client prefix | Access pattern |
+|---|---|---|
+| Vite / React | `VITE_` | `import.meta.env.VITE_VAR` |
+| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_VAR` |
+| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_VAR` |
+| Nuxt | `NUXT_PUBLIC_` | `useRuntimeConfig().public.var` |
+
+Server-side code in all frameworks can access variables via `process.env.VAR` or `Netlify.env.get("VAR")`.

--- a/cursor/rules/netlify-functions.mdc
+++ b/cursor/rules/netlify-functions.mdc
@@ -1,0 +1,168 @@
+---
+description: Guide for writing Netlify serverless functions. Use when creating API endpoints, background processing, scheduled tasks, or any server-side logic using Netlify Functions. Covers modern syntax (default export + Config), TypeScript, path routing, background functions, scheduled functions, streaming, and method routing.
+alwaysApply: false
+---
+
+# Netlify Functions
+
+## Modern Syntax
+
+Always use the modern default export + Config pattern. Never use the legacy `exports.handler` or named `handler` export.
+
+```typescript
+import type { Context, Config } from "@netlify/functions";
+
+export default async (req: Request, context: Context) => {
+  return new Response("Hello, world!");
+};
+
+export const config: Config = {
+  path: "/api/hello",
+};
+```
+
+The handler receives a standard Web API `Request` and returns a `Response`. The second argument is a Netlify `Context` object.
+
+## File Structure
+
+Place functions in `netlify/functions/`:
+
+```
+netlify/functions/
+  _shared/           # Non-function shared code (underscore prefix)
+    auth.ts
+    db.ts
+  items.ts           # -> /.netlify/functions/items (or custom path via config)
+  users/index.ts     # -> /.netlify/functions/users
+```
+
+Use `.ts` or `.mts` extensions. If both `.ts` and `.js` exist with the same name, the `.js` file takes precedence.
+
+## Path Routing
+
+Define custom paths via the `config` export:
+
+```typescript
+export const config: Config = {
+  path: "/api/items",                    // Static path
+  // path: "/api/items/:id",            // Path parameter
+  // path: ["/api/items", "/api/items/:id"], // Multiple paths
+  // excludedPath: "/api/items/special", // Excluded paths
+  // preferStatic: true,                // Don't override static files
+};
+```
+
+Without a `path` config, functions are available at `/.netlify/functions/{name}`. Setting a `path` makes the function available **only** at that path.
+
+Access path parameters via `context.params`:
+
+```typescript
+// config: { path: "/api/items/:id" }
+export default async (req: Request, context: Context) => {
+  const { id } = context.params;
+  // ...
+};
+```
+
+## Method Routing
+
+```typescript
+export default async (req: Request, context: Context) => {
+  switch (req.method) {
+    case "GET":    return handleGet(context.params.id);
+    case "POST":   return handlePost(await req.json());
+    case "DELETE": return handleDelete(context.params.id);
+    default:       return new Response("Method not allowed", { status: 405 });
+  }
+};
+
+export const config: Config = {
+  path: "/api/items/:id",
+  method: ["GET", "POST", "DELETE"],
+};
+```
+
+## Background Functions
+
+For long-running tasks (up to 15 minutes). The client receives an immediate `202` response; return values are ignored.
+
+Name the file with a `-background` suffix:
+
+```
+netlify/functions/process-background.ts
+```
+
+Store results externally (Netlify Blobs, database) for later retrieval.
+
+## Scheduled Functions
+
+Run on a cron schedule (UTC timezone):
+
+```typescript
+export default async (req: Request) => {
+  const { next_run } = await req.json();
+  console.log("Next invocation at:", next_run);
+};
+
+export const config: Config = {
+  schedule: "@hourly", // or cron: "0 * * * *"
+};
+```
+
+Shortcuts: `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`. Scheduled functions have a **30-second timeout** and only run on published deploys.
+
+## Streaming Responses
+
+Return a `ReadableStream` body for streamed responses (up to 20 MB):
+
+```typescript
+export default async (req: Request) => {
+  const stream = new ReadableStream({ /* ... */ });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+};
+```
+
+## Context Object
+
+| Property | Description |
+|---|---|
+| `context.params` | Path parameters from config |
+| `context.geo` | `{ city, country: {code, name}, latitude, longitude, subdivision, timezone, postalCode }` |
+| `context.ip` | Client IP address |
+| `context.cookies` | `.get()`, `.set()`, `.delete()` |
+| `context.deploy` | `{ context, id, published }` |
+| `context.site` | `{ id, name, url }` |
+| `context.account.id` | Team account ID |
+| `context.requestId` | Unique request ID |
+| `context.waitUntil(promise)` | Extend execution after response is sent |
+
+## Environment Variables
+
+Use `Netlify.env` (not `process.env`) inside functions:
+
+```typescript
+const apiKey = Netlify.env.get("API_KEY");
+```
+
+## Resource Limits
+
+| Resource | Limit |
+|---|---|
+| Synchronous timeout | 60 seconds |
+| Background timeout | 15 minutes |
+| Scheduled timeout | 30 seconds |
+| Memory | 1024 MB |
+| Buffered payload | 6 MB |
+| Streamed payload | 20 MB |
+
+## Framework Considerations
+
+Frameworks with server-side capabilities (Astro, Next.js, Nuxt, SvelteKit, TanStack Start) typically generate their own serverless functions via adapters. You usually do not write raw Netlify Functions in these projects — the framework adapter handles server-side rendering and API routes. Write Netlify Functions directly when:
+
+- Using a client-side-only framework (Vite + React SPA, vanilla JS)
+- Adding background or scheduled tasks to any project
+- Building standalone API endpoints outside the framework's routing
+
+See the **netlify-frameworks** skill for adapter setup.

--- a/cursor/rules/netlify-image-cdn-user-uploads.mdc
+++ b/cursor/rules/netlify-image-cdn-user-uploads.mdc
@@ -1,0 +1,160 @@
+---
+description: User-Uploaded Images Pipeline. Reference for the netlify-image-cdn skill.
+alwaysApply: false
+---
+# User-Uploaded Images Pipeline
+
+Compose Netlify Functions (upload handler) + Netlify Blobs (storage) + Image CDN (serving/transforming) to build a complete user-uploaded image pipeline.
+
+## Architecture
+
+1. **Upload** — A Netlify Function receives multipart form data, validates, and stores in Blobs
+2. **Storage** — Netlify Blobs stores the binary image with metadata
+3. **Serve** — A Netlify Function retrieves the blob and serves it at `/uploads/:key`
+4. **Transform** — A redirect maps `/img/:key` to `/.netlify/images?url=/uploads/:key` for CDN optimization
+
+## Dependencies
+
+```bash
+npm install @netlify/blobs
+```
+
+## Upload Handler
+
+```typescript
+// netlify/functions/upload.ts
+import type { Context, Config } from "@netlify/functions";
+import { getStore } from "@netlify/blobs";
+import { randomUUID } from "crypto";
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+const MAX_SIZE = 4 * 1024 * 1024; // 4 MB
+
+export default async (req: Request, context: Context) => {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const formData = await req.formData();
+  const image = formData.get("image") as File;
+
+  if (!image) return Response.json({ error: "No image provided" }, { status: 400 });
+  if (!ALLOWED_TYPES.includes(image.type)) return Response.json({ error: "Invalid type" }, { status: 400 });
+  if (image.size > MAX_SIZE) return Response.json({ error: "File too large" }, { status: 400 });
+
+  const extension = image.name.split(".").pop() || "jpg";
+  const key = `${randomUUID()}.${extension}`;
+  const store = getStore({ name: "images", consistency: "strong" });
+
+  await store.set(key, image, {
+    metadata: {
+      contentType: image.type,
+      originalFilename: image.name,
+      uploadedAt: new Date().toISOString(),
+    },
+  });
+
+  return Response.json({ success: true, key, url: `/img/${key}` });
+};
+
+export const config: Config = { path: "/api/upload", method: "POST" };
+```
+
+## Serve Handler
+
+```typescript
+// netlify/functions/serve-image.ts
+import type { Context, Config } from "@netlify/functions";
+import { getStore } from "@netlify/blobs";
+
+export default async (req: Request, context: Context) => {
+  const key = context.params.key;
+  const store = getStore({ name: "images", consistency: "strong" });
+
+  const result = await store.getWithMetadata(key, { type: "stream" });
+  if (!result) return new Response("Not found", { status: 404 });
+
+  return new Response(result.data, {
+    headers: {
+      "Content-Type": result.metadata?.contentType || "image/jpeg",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+};
+
+export const config: Config = { path: "/uploads/:key" };
+```
+
+## CDN Redirect
+
+```toml
+# netlify.toml
+
+# Basic optimized URL
+[[redirects]]
+from = "/img/:key"
+to = "/.netlify/images?url=/uploads/:key"
+status = 200
+
+# Thumbnail preset
+[[redirects]]
+from = "/img/thumb/:key"
+to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
+status = 200
+
+# Hero preset
+[[redirects]]
+from = "/img/hero/:key"
+to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
+status = 200
+```
+
+## Client-Side Upload (React Example)
+
+```tsx
+function ImageUpload({ onUpload }: { onUpload: (url: string) => void }) {
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const res = await fetch("/api/upload", { method: "POST", body: formData });
+    const { url } = await res.json();
+    onUpload(url);
+  };
+
+  return <input type="file" accept="image/*" onChange={handleChange} />;
+}
+```
+
+## Astro Upload (API Route)
+
+```typescript
+// src/pages/api/upload.ts
+import type { APIRoute } from "astro";
+import { getStore } from "@netlify/blobs";
+import { randomUUID } from "crypto";
+
+export const POST: APIRoute = async ({ request, redirect }) => {
+  const formData = await request.formData();
+  const image = formData.get("image") as File;
+  if (!image) return new Response("No image", { status: 400 });
+
+  const key = `${randomUUID()}.${image.name.split(".").pop() || "jpg"}`;
+  const store = getStore({ name: "images", consistency: "strong" });
+  await store.set(key, image, {
+    metadata: { contentType: image.type, originalFilename: image.name },
+  });
+
+  return redirect(`/gallery?uploaded=${key}`);
+};
+```
+
+## Key Points
+
+- Always validate file type and size on the server (client validation can be bypassed)
+- Use `strong` consistency on Blobs for immediate reads after writes
+- The serve handler's `Cache-Control: immutable` means the CDN caches the raw image permanently — Image CDN transformations layer on top
+- Without `fm` parameter, Netlify auto-serves AVIF or WebP based on browser support

--- a/cursor/rules/netlify-image-cdn.mdc
+++ b/cursor/rules/netlify-image-cdn.mdc
@@ -1,0 +1,80 @@
+---
+description: Guide for using Netlify Image CDN for image optimization and transformation. Use when serving optimized images, creating responsive image markup, setting up user-uploaded image pipelines, or configuring image transformations. Covers the /.netlify/images endpoint, query parameters, remote image allowlisting, clean URL rewrites, and composing uploads with Functions + Blobs.
+alwaysApply: false
+---
+
+# Netlify Image CDN
+
+Every Netlify site has a built-in `/.netlify/images` endpoint for on-the-fly image transformation. No configuration required for local images.
+
+## Basic Usage
+
+```html
+<img src="/.netlify/images?url=/photo.jpg&w=800&h=600&fit=cover&q=80" />
+```
+
+## Query Parameters
+
+| Param | Description | Values |
+|---|---|---|
+| `url` | Source image path (required) | Relative path or absolute URL |
+| `w` | Width in pixels | Any positive integer |
+| `h` | Height in pixels | Any positive integer |
+| `fit` | Resize behavior | `contain` (default), `cover`, `fill` |
+| `position` | Crop alignment (with `cover`) | `center` (default), `top`, `bottom`, `left`, `right` |
+| `fm` | Output format | `avif`, `webp`, `jpg`, `png`, `gif`, `blurhash` |
+| `q` | Quality (lossy formats) | 1-100 (default: 75) |
+
+When `fm` is omitted, Netlify auto-negotiates the best format based on browser support (preferring `webp`, then `avif`).
+
+## Remote Image Allowlisting
+
+External images must be explicitly allowed in `netlify.toml`:
+
+```toml
+[images]
+remote_images = ["https://example\\.com/.*", "https://cdn\\.images\\.com/.*"]
+```
+
+Values are regex patterns.
+
+## Clean URL Rewrites
+
+Create user-friendly image URLs with redirects:
+
+```toml
+# Basic optimization
+[[redirects]]
+from = "/img/*"
+to = "/.netlify/images?url=/:splat"
+status = 200
+
+# Preset: thumbnail
+[[redirects]]
+from = "/img/thumb/:key"
+to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
+status = 200
+
+# Preset: hero
+[[redirects]]
+from = "/img/hero/:key"
+to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
+status = 200
+```
+
+## Caching
+
+- Transformed images are cached at the CDN edge automatically
+- Cache invalidates on new deploys
+- Set cache headers on source images to control caching:
+
+```toml
+[[headers]]
+for = "/uploads/*"
+[headers.values]
+Cache-Control = "public, max-age=31536000, immutable"
+```
+
+## User-Uploaded Images
+
+Combine **Netlify Functions** (upload handler) + **Netlify Blobs** (storage) + **Image CDN** (serving/transforming) to build a complete user-uploaded image pipeline. See [references/user-uploads.md](references/user-uploads.md) for the full pattern.

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -1,0 +1,49 @@
+---
+description: Router for Netlify platform skills. Determines which Netlify skill to consult based on the task at hand.
+alwaysApply: true
+---
+# Netlify Skills
+
+This project deploys on Netlify. Use these skills for guidance on Netlify platform primitives. Each skill provides specific, factual reference for working with a Netlify feature.
+
+## When to Use Each Skill
+
+**Building API endpoints or server-side logic?**
+Read `netlify-functions/SKILL.md` for modern function syntax, routing, background/scheduled functions.
+
+**Need low-latency middleware, geo-based logic, or request manipulation?**
+Read `netlify-edge-functions/SKILL.md` for edge compute patterns.
+
+**Storing files, images, or simple key-value data?**
+Read `netlify-blobs/SKILL.md` for object storage API.
+
+**Need a relational database?**
+Read `netlify-db/SKILL.md` for Neon Postgres setup, Drizzle ORM, and migrations. It also covers when Blobs is a better fit.
+
+**Optimizing or transforming images?**
+Read `netlify-image-cdn/SKILL.md` for the image transformation endpoint and clean URL patterns. For user-uploaded images, see `netlify-image-cdn/references/user-uploads.md`.
+
+**Adding HTML forms?**
+Read `netlify-forms/SKILL.md` for form detection, AJAX submissions, spam filtering, and file uploads.
+
+**Configuring netlify.toml (redirects, headers, build settings)?**
+Read `netlify-config/SKILL.md` for the complete configuration reference.
+
+**Deploying, managing env vars, or running local dev?**
+Read `netlify-cli-and-deploy/SKILL.md` for CLI commands, Git vs manual deploys, and environment variable management.
+
+**Setting up a framework (Vite, Astro, TanStack, Next.js)?**
+Read `netlify-frameworks/SKILL.md` for adapter/plugin setup. Framework-specific details are in `netlify-frameworks/references/`.
+
+**Controlling CDN caching behavior?**
+Read `netlify-caching/SKILL.md` for cache headers, stale-while-revalidate, cache tags, and purge.
+
+**Adding AI capabilities?**
+Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup with OpenAI, Anthropic, or Google SDKs.
+
+## General Rules
+
+- Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)
+- Never hardcode secrets — use Netlify environment variables
+- Add `.netlify` to `.gitignore`
+- For framework-specific patterns, check the framework reference before writing custom Netlify Functions — the adapter may handle it

--- a/scripts/build-cursor-rules.sh
+++ b/scripts/build-cursor-rules.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+OUTPUT_DIR="$REPO_ROOT/cursor/rules"
+
+# Clean and recreate output directory
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Convert a SKILL.md to a Cursor .mdc rule file
+convert_skill() {
+  local skill_file="$1"
+  local output_name="$2"
+
+  # Extract description from YAML frontmatter
+  local description
+  description=$(awk '/^---$/{n++; next} n==1 && /^description:/{sub(/^description: */, ""); print}' "$skill_file")
+
+  # Extract body (everything after the closing --- of frontmatter)
+  local body
+  body=$(awk 'BEGIN{n=0} /^---$/{n++; next} n>=2{print}' "$skill_file")
+
+  cat > "$OUTPUT_DIR/$output_name.mdc" <<EOF
+---
+description: ${description}
+alwaysApply: false
+---
+${body}
+EOF
+}
+
+# Convert a reference markdown file to a Cursor .mdc rule file
+convert_reference() {
+  local ref_file="$1"
+  local skill_name="$2"
+  local ref_basename
+  ref_basename=$(basename "$ref_file" .md)
+  local output_name="${skill_name}-${ref_basename}"
+
+  # Use the first heading as a basis for the description
+  local title
+  title=$(awk '/^# /{sub(/^# */, ""); print; exit}' "$ref_file")
+
+  cat > "$OUTPUT_DIR/$output_name.mdc" <<EOF
+---
+description: ${title}. Reference for the ${skill_name} skill.
+alwaysApply: false
+---
+$(cat "$ref_file")
+EOF
+}
+
+# --- Convert skills ---
+for skill_dir in "$SKILLS_DIR"/netlify-*/; do
+  skill_file="$skill_dir/SKILL.md"
+  [ -f "$skill_file" ] || continue
+
+  skill_name=$(basename "$skill_dir")
+  convert_skill "$skill_file" "$skill_name"
+
+  # Convert any reference files
+  if [ -d "$skill_dir/references" ]; then
+    for ref_file in "$skill_dir"/references/*.md; do
+      [ -f "$ref_file" ] || continue
+      convert_reference "$ref_file" "$skill_name"
+    done
+  fi
+done
+
+# --- Convert the CLAUDE.md router ---
+if [ -f "$SKILLS_DIR/CLAUDE.md" ]; then
+  cat > "$OUTPUT_DIR/netlify-skills-router.mdc" <<EOF
+---
+description: Router for Netlify platform skills. Determines which Netlify skill to consult based on the task at hand.
+alwaysApply: true
+---
+$(cat "$SKILLS_DIR/CLAUDE.md")
+EOF
+fi
+
+echo "Built $(ls -1 "$OUTPUT_DIR"/*.mdc 2>/dev/null | wc -l | tr -d ' ') Cursor rules in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- Add `scripts/build-cursor-rules.sh` that converts `skills/` SKILL.md files into Cursor `.mdc` rule format, including reference files and a router rule
- Add GitHub Actions workflow (`.github/workflows/build-cursor-rules.yml`) that rebuilds Cursor rules on every push to `main` when `skills/` changes
- Add Cursor installation instructions to README (copy `.mdc` files to `.cursor/rules/`)
- Add contributor note: never edit `cursor/rules/` directly — always edit `skills/`
- Update `CLAUDE.md` with the new repo structure and Cursor rules documentation

The build generates 17 `.mdc` files from the 11 skills + 5 reference docs + 1 router.

## Test plan
- [x] Run `bash scripts/build-cursor-rules.sh` and verify `.mdc` files are generated in `cursor/rules/`
- [x] Verify each `.mdc` file has correct Cursor frontmatter (`description`, `alwaysApply`)
- [ ] Copy generated rules to a Cursor project's `.cursor/rules/` and verify they appear in Cursor
- [x] Verify the GitHub Actions workflow YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)