### PR TITLE
chore: Add Cursor plugin manifest for marketplace submission

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "netlify-skills",
+  "version": "1.0.0",
+  "description": "Netlify platform skills — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
+  "author": {
+    "name": "Netlify"
+  },
+  "homepage": "https://www.netlify.com",
+  "repository": "https://github.com/netlify/context-and-tools",
+  "keywords": [
+    "netlify",
+    "deployment",
+    "serverless",
+    "edge-functions",
+    "cdn",
+    "hosting",
+    "jamstack",
+    "functions"
+  ],
+  "rules": "cursor/rules"
+}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,21 @@ This installs all Netlify skills into Claude Code. The included `skills/CLAUDE.m
 
 ### Cursor
 
-Add Netlify rules to your project:
+Install from the [Cursor plugin marketplace](https://cursor.com/marketplace):
+
+1. Open Cursor Settings (`Cmd+,` / `Ctrl+,`)
+2. Go to **Plugins**
+3. Search for **netlify-skills**
+4. Click **Install**
+
+Or install via the command palette: `Cmd+Shift+P` → **Plugins: Install Plugin** → search **netlify-skills**.
+
+This installs 21 `.mdc` rule files covering all Netlify platform primitives. A router rule (`netlify-skills-router.mdc`) is always active and directs the agent to the right skill for the task.
+
+<details>
+<summary>Manual installation (without the plugin marketplace)</summary>
+
+Copy pre-built rule files directly into your project:
 
 ```bash
 git clone --depth 1 https://github.com/netlify/context-and-tools.git /tmp/netlify-skills && \
@@ -56,7 +70,9 @@ git clone --depth 1 https://github.com/netlify/context-and-tools.git /tmp/netlif
   rm -rf /tmp/netlify-skills
 ```
 
-This copies pre-built `.mdc` rule files into `.cursor/rules/`, where Cursor automatically discovers them. A router rule (`netlify-skills-router.mdc`) is included to help the agent pick the right skill for the task.
+This copies `.mdc` rule files into `.cursor/rules/`, where Cursor automatically discovers them.
+
+</details>
 
 ### Other AI agents
 


### PR DESCRIPTION
## Summary                                                                                 
                                                          
- Adds .cursor-plugin/plugin.json manifest so the repo can be submitted to Cursor's official plugin marketplace
- Updates README with marketplace installation instructions (Settings → Plugins → search → install), keeping the manual git clone method in a collapsible details block

## Notes

- The manifest points rules to cursor/rules/, which already contains 21 auto-generated.mdc files
- No changes to skills, rules, or build pipeline — this just packages what already exists for Cursor's plugin system
- After merging, submit at https://cursor.com/marketplace/publish with the repo URL
