### PR TITLE
Marketplace submission updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,7 @@
       "name": "netlify-skills",
       "description": "Netlify platform skills — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
       "source": "./",
+      "strict": false,
       "skills": [
         "./skills/netlify-functions",
         "./skills/netlify-edge-functions",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,21 @@
     {
       "name": "netlify-skills",
       "description": "Netlify platform skills — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
-      "version": "1.0.0",
-      "source": {
-        "source": "github",
-        "repo": "netlify/context-and-tools"
-      }
+      "source": "./",
+      "skills": [
+        "./skills/netlify-functions",
+        "./skills/netlify-edge-functions",
+        "./skills/netlify-blobs",
+        "./skills/netlify-db",
+        "./skills/netlify-image-cdn",
+        "./skills/netlify-forms",
+        "./skills/netlify-frameworks",
+        "./skills/netlify-caching",
+        "./skills/netlify-config",
+        "./skills/netlify-cli-and-deploy",
+        "./skills/netlify-deploy",
+        "./skills/netlify-ai-gateway"
+      ]
     }
   ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Netlify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,18 @@
+{
+  "name": "netlify-skills",
+  "version": "1.0.0",
+  "skills": [
+    "skills/netlify-functions",
+    "skills/netlify-edge-functions",
+    "skills/netlify-blobs",
+    "skills/netlify-db",
+    "skills/netlify-image-cdn",
+    "skills/netlify-forms",
+    "skills/netlify-frameworks",
+    "skills/netlify-caching",
+    "skills/netlify-config",
+    "skills/netlify-cli-and-deploy",
+    "skills/netlify-deploy",
+    "skills/netlify-ai-gateway"
+  ]
+}


### PR DESCRIPTION
Prepare the repo for listing on multiple skill marketplaces and registries.

- marketplace.json: Add explicit skills array listing all 12 skills and set strict: false to match Anthropic's marketplace format (for Claude Code plugin marketplace and
SkillsMP discovery)
- gemini-extension.json: Add manifest at repo root for Gemini CLI gallery auto-indexing
- LICENSE: Add MIT license

