### PR TITLE
Identity skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "netlify-skills",
-      "description": "Netlify platform skills — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
+      "description": "Netlify platform skills — functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
       "source": "./",
       "strict": false,
       "skills": [
@@ -22,7 +22,8 @@
         "./skills/netlify-config",
         "./skills/netlify-cli-and-deploy",
         "./skills/netlify-deploy",
-        "./skills/netlify-ai-gateway"
+        "./skills/netlify-ai-gateway",
+        "./skills/netlify-identity"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-skills",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Netlify platform skills for Claude Code",
   "author": {
     "name": "Netlify"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "netlify-skills",
-  "version": "1.0.0",
-  "description": "Netlify platform skills — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
+  "version": "1.1.0",
+  "description": "Netlify platform skills — functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
   "author": {
     "name": "Netlify"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/
+.DS_Store

--- a/cursor/rules/netlify-identity-advanced-patterns.mdc
+++ b/cursor/rules/netlify-identity-advanced-patterns.mdc
@@ -1,0 +1,110 @@
+---
+description: Advanced Identity Patterns. Reference for the netlify-identity skill.
+alwaysApply: false
+---
+# Advanced Identity Patterns
+
+## Password Recovery
+
+Three-step flow: request recovery email, handle the callback, then set a new password.
+
+```typescript
+import { requestPasswordRecovery, handleAuthCallback, updateUser, AuthError } from '@netlify/identity'
+
+// Step 1: Send recovery email
+async function handleForgotPassword(email: string) {
+  try {
+    await requestPasswordRecovery(email)
+    showSuccess('Check your email for a password reset link.')
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+
+// Step 2: handleAuthCallback() returns { type: 'recovery', user } — show password reset form
+// (See the handleAuthCallback switch in SKILL.md)
+
+// Step 3: Set new password
+async function handlePasswordReset(newPassword: string) {
+  try {
+    await updateUser({ password: newPassword })
+    showSuccess('Password updated.')
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+The recovery callback fires a `'recovery'` auth event, not `'login'`. The user is authenticated but should be prompted to set a new password before navigating away.
+
+## Invite Acceptance
+
+When a user clicks an invite link, `handleAuthCallback()` returns `{ type: 'invite', user: null, token }`. Use the token to accept the invite and set a password.
+
+```typescript
+import { acceptInvite, AuthError } from '@netlify/identity'
+
+async function handleAcceptInvite(token: string, password: string) {
+  try {
+    const user = await acceptInvite(token, password)
+    showSuccess(`Welcome, ${user.email}! Your account is ready.`)
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+## Email Change
+
+When a user verifies an email change, `handleAuthCallback()` returns `{ type: 'email_change', user }`. The user must be logged in when clicking the verification link.
+
+```typescript
+import { verifyEmailChange, AuthError } from '@netlify/identity'
+
+async function handleEmailChangeVerification(token: string) {
+  try {
+    const user = await verifyEmailChange(token)
+    showSuccess(`Email updated to ${user.email}`)
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+## Session Hydration
+
+`hydrateSession()` bridges server-set cookies to the browser session. Call it on page load when using server-side login (e.g., login inside a Netlify Function followed by a redirect).
+
+```typescript
+import { hydrateSession } from '@netlify/identity'
+
+const user = await hydrateSession()
+if (user) {
+  // Browser session is now in sync with server-set cookies
+}
+```
+
+`getUser()` auto-hydrates from the `nf_jwt` cookie if no browser session exists, so explicit `hydrateSession()` is only needed when you want to restore the full session (including token refresh timers) after a server-side login.
+
+## SSR Integration Patterns
+
+For SSR frameworks, the recommended pattern is:
+
+- **Browser-side** for auth mutations: `login()`, `signup()`, `logout()`, `oauthLogin()`
+- **Server-side** for reading auth state: `getUser()`, `getSettings()`, `getIdentityConfig()`
+
+Browser-side auth mutations set the `nf_jwt` cookie and localStorage, and emit `onAuthChange` events. The server reads the cookie on the next request.
+
+The library also supports server-side mutations (`login()`, `signup()`, `logout()` inside Netlify Functions), but these require the Netlify Functions runtime to set cookies. After a server-side mutation, use a full page navigation so the browser sends the new cookie.
+
+Always use `window.location.href` (not framework router navigation) after server-side auth mutations in Next.js, TanStack Start, and SvelteKit. Remix `redirect()` is safe because Remix actions return real HTTP responses.
+
+## Full API Reference
+
+For the complete API reference — all function signatures, type definitions, OAuth helpers, admin operations, session management, auth events, and framework-specific examples — read the package README:
+
+```
+node_modules/@netlify/identity/README.md
+```
+
+The README is shipped with the npm package and is always in sync with the installed version.

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -15,7 +15,7 @@ Netlify Identity is a user management service for signups, logins, password reco
 npm install @netlify/identity
 ```
 
-Identity is automatically enabled when the deploy includes Identity code. Default settings:
+Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in the UI. These are the default settings:
 
 - **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
 - **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -31,7 +31,7 @@ Log in from the browser:
 ```typescript
 import { login, getUser } from '@netlify/identity'
 
-const user = await login('jane@example.com', 'password123')
+const user = await login('user@example.com', '<password>')
 console.log(`Hello, ${user.name}`)
 
 // Later, check auth state

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -1,0 +1,335 @@
+---
+description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity`. Never use `netlify-identity-widget` or `gotrue-js` — they are deprecated.
+alwaysApply: false
+---
+
+# Netlify Identity
+
+Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+
+**Always use `@netlify/identity`.** Never use `netlify-identity-widget` or `gotrue-js` — they are deprecated. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+
+## Setup
+
+```bash
+npm install @netlify/identity
+```
+
+Identity is automatically enabled when the deploy includes Identity code. Default settings:
+
+- **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
+- **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.
+
+### Local Development
+
+Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+
+## Quick Start
+
+Log in from the browser:
+
+```typescript
+import { login, getUser } from '@netlify/identity'
+
+const user = await login('jane@example.com', 'password123')
+console.log(`Hello, ${user.name}`)
+
+// Later, check auth state
+const currentUser = await getUser()
+```
+
+Protect a Netlify Function:
+
+```typescript
+// netlify/functions/protected.mts
+import { getUser } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
+
+export default async (req: Request, context: Context) => {
+  const user = await getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+  return Response.json({ id: user.id, email: user.email })
+}
+```
+
+## Core API
+
+Import and use headless functions directly:
+
+```typescript
+import {
+  getUser,
+  handleAuthCallback,
+  login,
+  logout,
+  signup,
+  oauthLogin,
+  onAuthChange,
+  getSettings,
+} from '@netlify/identity'
+```
+
+### Login
+
+```typescript
+import { login, AuthError } from '@netlify/identity'
+
+async function handleLogin(email: string, password: string) {
+  try {
+    const user = await login(email, password)
+    showSuccess(`Welcome back, ${user.name ?? user.email}`)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      showError(error.status === 401 ? 'Invalid email or password.' : error.message)
+    }
+  }
+}
+```
+
+### Signup
+
+After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+
+```typescript
+import { signup, AuthError } from '@netlify/identity'
+
+async function handleSignup(email: string, password: string, name: string) {
+  try {
+    const user = await signup(email, password, { full_name: name })
+    if (user.emailVerified) {
+      // Autoconfirm ON — user is logged in immediately
+      showSuccess('Account created. You are now logged in.')
+    } else {
+      // Autoconfirm OFF — confirmation email sent
+      showSuccess('Check your email to confirm your account.')
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
+    }
+  }
+}
+```
+
+### Logout
+
+```typescript
+import { logout } from '@netlify/identity'
+
+await logout()
+```
+
+### OAuth
+
+OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+
+```typescript
+import { oauthLogin } from '@netlify/identity'
+
+// Step 1: Redirect to provider (navigates away — never returns)
+function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
+  oauthLogin(provider)
+}
+```
+
+Enable providers in **Project configuration > Identity > External providers** before using OAuth.
+
+### Handling Callbacks
+
+Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
+
+```typescript
+import { handleAuthCallback, AuthError } from '@netlify/identity'
+
+async function processCallback() {
+  try {
+    const result = await handleAuthCallback()
+    if (!result) return // No callback hash — normal page load
+
+    switch (result.type) {
+      case 'oauth':
+        showSuccess(`Logged in as ${result.user?.email}`)
+        break
+      case 'confirmation':
+        showSuccess('Email confirmed. You are now logged in.')
+        break
+      case 'recovery':
+        // User is authenticated but must set a new password
+        showPasswordResetForm(result.user)
+        break
+      case 'invite':
+        // User must set a password to accept the invite
+        showInviteAcceptForm(result.token)
+        break
+      case 'email_change':
+        showSuccess('Email address updated.')
+        break
+    }
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+### Auth State
+
+```typescript
+import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
+
+// Check current user (never throws — returns null if not authenticated)
+const user = await getUser()
+
+// Subscribe to auth state changes (returns unsubscribe function)
+const unsubscribe = onAuthChange((event, user) => {
+  switch (event) {
+    case AUTH_EVENTS.LOGIN:
+      console.log('Logged in:', user?.email)
+      break
+    case AUTH_EVENTS.LOGOUT:
+      console.log('Logged out')
+      break
+    case AUTH_EVENTS.TOKEN_REFRESH:
+      break
+    case AUTH_EVENTS.USER_UPDATED:
+      console.log('Profile updated:', user?.email)
+      break
+    case AUTH_EVENTS.RECOVERY:
+      console.log('Password recovery initiated')
+      break
+  }
+})
+```
+
+### Settings-Driven UI
+
+Fetch the project's Identity settings to conditionally render signup forms and OAuth buttons.
+
+```typescript
+import { getSettings } from '@netlify/identity'
+
+const settings = await getSettings()
+// settings.autoconfirm — boolean
+// settings.disableSignup — boolean
+// settings.providers — Record<AuthProvider, boolean>
+
+if (!settings.disableSignup) showSignupForm()
+
+for (const [provider, enabled] of Object.entries(settings.providers)) {
+  if (enabled) showOAuthButton(provider)
+}
+```
+
+## Minimal React Example
+
+```tsx
+import { useEffect, useState } from 'react'
+import {
+  getUser,
+  handleAuthCallback,
+  login,
+  logout,
+  oauthLogin,
+  onAuthChange,
+} from '@netlify/identity'
+
+function App() {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    ;(async () => {
+      await handleAuthCallback()
+      setUser(await getUser())
+      setLoading(false)
+    })()
+    return onAuthChange((_event, currentUser) => setUser(currentUser))
+  }, [])
+
+  const handleLogin = async (email, password) => {
+    const currentUser = await login(email, password)
+    setUser(currentUser)
+  }
+
+  const handleGoogleLogin = () => oauthLogin('google')
+
+  const handleSignOut = async () => {
+    await logout()
+    setUser(null)
+  }
+
+  if (loading) return <p>Loading...</p>
+  // Render login form or user details based on `user` state
+}
+```
+
+## Error Handling
+
+`@netlify/identity` throws two error classes:
+
+- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
+- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
+
+`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Invalid credentials or expired token |
+| 403 | Action not allowed (e.g., signups disabled) |
+| 422 | Validation error (e.g., weak password, malformed email) |
+| 404 | User or resource not found |
+
+## Identity Event Functions
+
+Special serverless functions that trigger on Identity lifecycle events. These use the **legacy named `handler` export** (not the modern default export).
+
+**Event names:** `identity-validate`, `identity-signup`, `identity-login`
+
+```typescript
+// netlify/functions/identity-signup.mts
+import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+
+const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+  const { user } = JSON.parse(event.body || '{}')
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      app_metadata: {
+        ...user.app_metadata,
+        roles: ['member'],
+      },
+    }),
+  }
+}
+
+export { handler }
+```
+
+The response body replaces `app_metadata` and/or `user_metadata` on the user record — include all fields you want to keep.
+
+## Roles and Authorization
+
+- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
+- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+
+### Role-Based Redirects
+
+```toml
+# netlify.toml
+[[redirects]]
+  from = "/admin/*"
+  to = "/admin/:splat"
+  status = 200
+  conditions = { Role = ["admin"] }
+
+[[redirects]]
+  from = "/admin/*"
+  to = "/"
+  status = 302
+```
+
+Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+
+## References
+
+- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -41,6 +41,9 @@ Read `netlify-caching/SKILL.md` for cache headers, stale-while-revalidate, cache
 **Adding AI capabilities?**
 Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup with OpenAI, Anthropic, or Google SDKs.
 
+**Adding user authentication, signups, logins, or access control?**
+Read `netlify-identity/SKILL.md` for Netlify Identity setup, OAuth, role-based access, and protecting routes and functions.
+
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-skills",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "skills": [
     "skills/netlify-functions",
     "skills/netlify-edge-functions",
@@ -13,6 +13,7 @@
     "skills/netlify-config",
     "skills/netlify-cli-and-deploy",
     "skills/netlify-deploy",
-    "skills/netlify-ai-gateway"
+    "skills/netlify-ai-gateway",
+    "skills/netlify-identity"
   ]
 }

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -37,6 +37,9 @@ Read `netlify-caching/SKILL.md` for cache headers, stale-while-revalidate, cache
 **Adding AI capabilities?**
 Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup with OpenAI, Anthropic, or Google SDKs.
 
+**Adding user authentication, signups, logins, or access control?**
+Read `netlify-identity/SKILL.md` for Netlify Identity setup, OAuth, role-based access, and protecting routes and functions.
+
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.
 

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -15,7 +15,7 @@ Netlify Identity is a user management service for signups, logins, password reco
 npm install @netlify/identity
 ```
 
-Identity is automatically enabled when the deploy includes Identity code. Default settings:
+Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in the UI. These are the default settings:
 
 - **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
 - **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: netlify-identity
+description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity`. Never use `netlify-identity-widget` or `gotrue-js` — they are deprecated.
+---
+
+# Netlify Identity
+
+Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+
+**Always use `@netlify/identity`.** Never use `netlify-identity-widget` or `gotrue-js` — they are deprecated. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+
+## Setup
+
+```bash
+npm install @netlify/identity
+```
+
+Identity is automatically enabled when the deploy includes Identity code. Default settings:
+
+- **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
+- **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.
+
+### Local Development
+
+Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+
+## Quick Start
+
+Log in from the browser:
+
+```typescript
+import { login, getUser } from '@netlify/identity'
+
+const user = await login('jane@example.com', 'password123')
+console.log(`Hello, ${user.name}`)
+
+// Later, check auth state
+const currentUser = await getUser()
+```
+
+Protect a Netlify Function:
+
+```typescript
+// netlify/functions/protected.mts
+import { getUser } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
+
+export default async (req: Request, context: Context) => {
+  const user = await getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+  return Response.json({ id: user.id, email: user.email })
+}
+```
+
+## Core API
+
+Import and use headless functions directly:
+
+```typescript
+import {
+  getUser,
+  handleAuthCallback,
+  login,
+  logout,
+  signup,
+  oauthLogin,
+  onAuthChange,
+  getSettings,
+} from '@netlify/identity'
+```
+
+### Login
+
+```typescript
+import { login, AuthError } from '@netlify/identity'
+
+async function handleLogin(email: string, password: string) {
+  try {
+    const user = await login(email, password)
+    showSuccess(`Welcome back, ${user.name ?? user.email}`)
+  } catch (error) {
+    if (error instanceof AuthError) {
+      showError(error.status === 401 ? 'Invalid email or password.' : error.message)
+    }
+  }
+}
+```
+
+### Signup
+
+After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+
+```typescript
+import { signup, AuthError } from '@netlify/identity'
+
+async function handleSignup(email: string, password: string, name: string) {
+  try {
+    const user = await signup(email, password, { full_name: name })
+    if (user.emailVerified) {
+      // Autoconfirm ON — user is logged in immediately
+      showSuccess('Account created. You are now logged in.')
+    } else {
+      // Autoconfirm OFF — confirmation email sent
+      showSuccess('Check your email to confirm your account.')
+    }
+  } catch (error) {
+    if (error instanceof AuthError) {
+      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
+    }
+  }
+}
+```
+
+### Logout
+
+```typescript
+import { logout } from '@netlify/identity'
+
+await logout()
+```
+
+### OAuth
+
+OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+
+```typescript
+import { oauthLogin } from '@netlify/identity'
+
+// Step 1: Redirect to provider (navigates away — never returns)
+function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
+  oauthLogin(provider)
+}
+```
+
+Enable providers in **Project configuration > Identity > External providers** before using OAuth.
+
+### Handling Callbacks
+
+Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
+
+```typescript
+import { handleAuthCallback, AuthError } from '@netlify/identity'
+
+async function processCallback() {
+  try {
+    const result = await handleAuthCallback()
+    if (!result) return // No callback hash — normal page load
+
+    switch (result.type) {
+      case 'oauth':
+        showSuccess(`Logged in as ${result.user?.email}`)
+        break
+      case 'confirmation':
+        showSuccess('Email confirmed. You are now logged in.')
+        break
+      case 'recovery':
+        // User is authenticated but must set a new password
+        showPasswordResetForm(result.user)
+        break
+      case 'invite':
+        // User must set a password to accept the invite
+        showInviteAcceptForm(result.token)
+        break
+      case 'email_change':
+        showSuccess('Email address updated.')
+        break
+    }
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+### Auth State
+
+```typescript
+import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
+
+// Check current user (never throws — returns null if not authenticated)
+const user = await getUser()
+
+// Subscribe to auth state changes (returns unsubscribe function)
+const unsubscribe = onAuthChange((event, user) => {
+  switch (event) {
+    case AUTH_EVENTS.LOGIN:
+      console.log('Logged in:', user?.email)
+      break
+    case AUTH_EVENTS.LOGOUT:
+      console.log('Logged out')
+      break
+    case AUTH_EVENTS.TOKEN_REFRESH:
+      break
+    case AUTH_EVENTS.USER_UPDATED:
+      console.log('Profile updated:', user?.email)
+      break
+    case AUTH_EVENTS.RECOVERY:
+      console.log('Password recovery initiated')
+      break
+  }
+})
+```
+
+### Settings-Driven UI
+
+Fetch the project's Identity settings to conditionally render signup forms and OAuth buttons.
+
+```typescript
+import { getSettings } from '@netlify/identity'
+
+const settings = await getSettings()
+// settings.autoconfirm — boolean
+// settings.disableSignup — boolean
+// settings.providers — Record<AuthProvider, boolean>
+
+if (!settings.disableSignup) showSignupForm()
+
+for (const [provider, enabled] of Object.entries(settings.providers)) {
+  if (enabled) showOAuthButton(provider)
+}
+```
+
+## Minimal React Example
+
+```tsx
+import { useEffect, useState } from 'react'
+import {
+  getUser,
+  handleAuthCallback,
+  login,
+  logout,
+  oauthLogin,
+  onAuthChange,
+} from '@netlify/identity'
+
+function App() {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    ;(async () => {
+      await handleAuthCallback()
+      setUser(await getUser())
+      setLoading(false)
+    })()
+    return onAuthChange((_event, currentUser) => setUser(currentUser))
+  }, [])
+
+  const handleLogin = async (email, password) => {
+    const currentUser = await login(email, password)
+    setUser(currentUser)
+  }
+
+  const handleGoogleLogin = () => oauthLogin('google')
+
+  const handleSignOut = async () => {
+    await logout()
+    setUser(null)
+  }
+
+  if (loading) return <p>Loading...</p>
+  // Render login form or user details based on `user` state
+}
+```
+
+## Error Handling
+
+`@netlify/identity` throws two error classes:
+
+- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
+- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
+
+`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Invalid credentials or expired token |
+| 403 | Action not allowed (e.g., signups disabled) |
+| 422 | Validation error (e.g., weak password, malformed email) |
+| 404 | User or resource not found |
+
+## Identity Event Functions
+
+Special serverless functions that trigger on Identity lifecycle events. These use the **legacy named `handler` export** (not the modern default export).
+
+**Event names:** `identity-validate`, `identity-signup`, `identity-login`
+
+```typescript
+// netlify/functions/identity-signup.mts
+import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+
+const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+  const { user } = JSON.parse(event.body || '{}')
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      app_metadata: {
+        ...user.app_metadata,
+        roles: ['member'],
+      },
+    }),
+  }
+}
+
+export { handler }
+```
+
+The response body replaces `app_metadata` and/or `user_metadata` on the user record — include all fields you want to keep.
+
+## Roles and Authorization
+
+- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
+- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+
+### Role-Based Redirects
+
+```toml
+# netlify.toml
+[[redirects]]
+  from = "/admin/*"
+  to = "/admin/:splat"
+  status = 200
+  conditions = { Role = ["admin"] }
+
+[[redirects]]
+  from = "/admin/*"
+  to = "/"
+  status = 302
+```
+
+Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+
+## References
+
+- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -31,7 +31,7 @@ Log in from the browser:
 ```typescript
 import { login, getUser } from '@netlify/identity'
 
-const user = await login('jane@example.com', 'password123')
+const user = await login('user@example.com', '<password>')
 console.log(`Hello, ${user.name}`)
 
 // Later, check auth state

--- a/skills/netlify-identity/references/advanced-patterns.md
+++ b/skills/netlify-identity/references/advanced-patterns.md
@@ -1,0 +1,106 @@
+# Advanced Identity Patterns
+
+## Password Recovery
+
+Three-step flow: request recovery email, handle the callback, then set a new password.
+
+```typescript
+import { requestPasswordRecovery, handleAuthCallback, updateUser, AuthError } from '@netlify/identity'
+
+// Step 1: Send recovery email
+async function handleForgotPassword(email: string) {
+  try {
+    await requestPasswordRecovery(email)
+    showSuccess('Check your email for a password reset link.')
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+
+// Step 2: handleAuthCallback() returns { type: 'recovery', user } — show password reset form
+// (See the handleAuthCallback switch in SKILL.md)
+
+// Step 3: Set new password
+async function handlePasswordReset(newPassword: string) {
+  try {
+    await updateUser({ password: newPassword })
+    showSuccess('Password updated.')
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+The recovery callback fires a `'recovery'` auth event, not `'login'`. The user is authenticated but should be prompted to set a new password before navigating away.
+
+## Invite Acceptance
+
+When a user clicks an invite link, `handleAuthCallback()` returns `{ type: 'invite', user: null, token }`. Use the token to accept the invite and set a password.
+
+```typescript
+import { acceptInvite, AuthError } from '@netlify/identity'
+
+async function handleAcceptInvite(token: string, password: string) {
+  try {
+    const user = await acceptInvite(token, password)
+    showSuccess(`Welcome, ${user.email}! Your account is ready.`)
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+## Email Change
+
+When a user verifies an email change, `handleAuthCallback()` returns `{ type: 'email_change', user }`. The user must be logged in when clicking the verification link.
+
+```typescript
+import { verifyEmailChange, AuthError } from '@netlify/identity'
+
+async function handleEmailChangeVerification(token: string) {
+  try {
+    const user = await verifyEmailChange(token)
+    showSuccess(`Email updated to ${user.email}`)
+  } catch (error) {
+    if (error instanceof AuthError) showError(error.message)
+  }
+}
+```
+
+## Session Hydration
+
+`hydrateSession()` bridges server-set cookies to the browser session. Call it on page load when using server-side login (e.g., login inside a Netlify Function followed by a redirect).
+
+```typescript
+import { hydrateSession } from '@netlify/identity'
+
+const user = await hydrateSession()
+if (user) {
+  // Browser session is now in sync with server-set cookies
+}
+```
+
+`getUser()` auto-hydrates from the `nf_jwt` cookie if no browser session exists, so explicit `hydrateSession()` is only needed when you want to restore the full session (including token refresh timers) after a server-side login.
+
+## SSR Integration Patterns
+
+For SSR frameworks, the recommended pattern is:
+
+- **Browser-side** for auth mutations: `login()`, `signup()`, `logout()`, `oauthLogin()`
+- **Server-side** for reading auth state: `getUser()`, `getSettings()`, `getIdentityConfig()`
+
+Browser-side auth mutations set the `nf_jwt` cookie and localStorage, and emit `onAuthChange` events. The server reads the cookie on the next request.
+
+The library also supports server-side mutations (`login()`, `signup()`, `logout()` inside Netlify Functions), but these require the Netlify Functions runtime to set cookies. After a server-side mutation, use a full page navigation so the browser sends the new cookie.
+
+Always use `window.location.href` (not framework router navigation) after server-side auth mutations in Next.js, TanStack Start, and SvelteKit. Remix `redirect()` is safe because Remix actions return real HTTP responses.
+
+## Full API Reference
+
+For the complete API reference — all function signatures, type definitions, OAuth helpers, admin operations, session management, auth events, and framework-specific examples — read the package README:
+
+```
+node_modules/@netlify/identity/README.md
+```
+
+The README is shipped with the npm package and is always in sync with the installed version.


### PR DESCRIPTION
## Summary

- Add a new Netlify Identity skill (skills/netlify-identity/) covering authentication, signups, logins, OAuth, role-based access control, and protecting routes/functions using @netlify/identity
- Advanced patterns (password recovery, invite acceptance, email change, session hydration, SSR integration) are in a references/advanced-patterns.md file to keep the main skill under 500 lines
- Update skills/CLAUDE.md router with an entry for the Identity skill
- Add .DS_Store to .gitignore

##  Notes

- The skill explicitly documents that Identity does not currently work with `netlify dev` — users must deploy to Netlify to test. This caveat should be removed once local dev support ships.
- Adapted from the internal agent-runner Identity skill, rewritten for general-purpose use (any supported agent, not agent-runner-specific)
- Deprecation of netlify-identity-widget and gotrue-js is called out prominently