### PR TITLE
Add supported model list to AI Gateway skill

### DIFF
--- a/cursor/rules/netlify-ai-gateway.mdc
+++ b/cursor/rules/netlify-ai-gateway.mdc
@@ -1,9 +1,11 @@
 ---
-description: Guide for using Netlify AI Gateway to access AI models. Use when adding AI capabilities (text generation, image generation, embeddings) to a Netlify project. Covers supported providers (OpenAI, Anthropic, Google), SDK configuration via base URL override, environment variables, and usage from Netlify Functions.
+description: Guide for using Netlify AI Gateway to access AI models. Use when adding AI capabilities or selecting/changing AI models. Must be read before choosing a model. Covers supported providers (OpenAI, Anthropic, Google), SDK setup, environment variables, and the list of available models.
 alwaysApply: false
 ---
 
 # Netlify AI Gateway
+
+> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model will cause runtime errors.
 
 Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
 
@@ -114,4 +116,4 @@ With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are 
 
 ## Available Models
 
-The gateway supports models from OpenAI, Anthropic, and Google. Use standard model identifiers (e.g., `gpt-4o-mini`, `claude-sonnet-4-5-20250929`, `gemini-2.5-flash`). Available models may change — refer to Netlify's AI Gateway documentation for the current list.
+For the list of supported models, see https://docs.netlify.com/build/ai-gateway/overview/.

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -38,8 +38,8 @@ Read `netlify-frameworks/SKILL.md` for adapter/plugin setup. Framework-specific 
 **Controlling CDN caching behavior?**
 Read `netlify-caching/SKILL.md` for cache headers, stale-while-revalidate, cache tags, and purge.
 
-**Adding AI capabilities?**
-Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup with OpenAI, Anthropic, or Google SDKs.
+**Adding AI capabilities or choosing an AI model?**
+Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup, supported models, and provider SDKs.
 
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -34,8 +34,8 @@ Read `netlify-frameworks/SKILL.md` for adapter/plugin setup. Framework-specific 
 **Controlling CDN caching behavior?**
 Read `netlify-caching/SKILL.md` for cache headers, stale-while-revalidate, cache tags, and purge.
 
-**Adding AI capabilities?**
-Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup with OpenAI, Anthropic, or Google SDKs.
+**Adding AI capabilities or choosing an AI model?**
+Read `netlify-ai-gateway/SKILL.md` for AI Gateway setup, supported models, and provider SDKs.
 
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.

--- a/skills/netlify-ai-gateway/SKILL.md
+++ b/skills/netlify-ai-gateway/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: netlify-ai-gateway
-description: Guide for using Netlify AI Gateway to access AI models. Use when adding AI capabilities (text generation, image generation, embeddings) to a Netlify project. Covers supported providers (OpenAI, Anthropic, Google), SDK configuration via base URL override, environment variables, and usage from Netlify Functions.
+description: Guide for using Netlify AI Gateway to access AI models. Use when adding AI capabilities or selecting/changing AI models. Must be read before choosing a model. Covers supported providers (OpenAI, Anthropic, Google), SDK setup, environment variables, and the list of available models.
 ---
 
 # Netlify AI Gateway
+
+> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model will cause runtime errors.
 
 Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
 
@@ -114,4 +116,4 @@ With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are 
 
 ## Available Models
 
-The gateway supports models from OpenAI, Anthropic, and Google. Use standard model identifiers (e.g., `gpt-4o-mini`, `claude-sonnet-4-5-20250929`, `gemini-2.5-flash`). Available models may change — refer to Netlify's AI Gateway documentation for the current list.
+For the list of supported models, see https://docs.netlify.com/build/ai-gateway/overview/.


### PR DESCRIPTION
Update the public AI Gateway skill so agents know which models are available through AI Gateway before selecting one.

- Updated skill description to trigger on model selection, not just adding AI features
- Added warning that only listed models are supported
- Replaced vague "refer to docs" with the full model list
- Updated skill router to mention model selection

Resolves EX-1904