### PR TITLE
Fix: remove invalid root-level description field from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,5 @@
 {
   "name": "netlify-context-and-tools",
-  "description": "Netlify platform skills for AI coding agents",
   "owner": {
     "name": "Netlify"
   },


### PR DESCRIPTION
The root-level `description` field in `.claude-plugin/marketplace.json` is not recognized by the Claude plugin schema validator, causing the schema check to fail when this plugin is submitted to the Claude plugin marketplace.

The `description` field belongs inside each entry in the `plugins[]` array (where it already appears correctly), not at the root of the marketplace object.