### PR TITLE
Fix Identity skill: dashboard path, registration default, no email toggle

### DIFF
--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -15,9 +15,9 @@ Netlify Identity is a user management service for signups, logins, password reco
 npm install @netlify/identity
 ```
 
-Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in the UI. These are the default settings:
+Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`). It is not under Integrations, and not a top-level sidebar item — it lives in the project's configuration pages. These are the default settings:
 
-- **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
+- **Registration** — Open (anyone can sign up). This is the default — no configuration needed to allow public signups or OAuth logins. Only change to Invite only in **Project configuration > Identity** if you explicitly want to restrict registration.
 - **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.
 
 ### Local Development
@@ -132,7 +132,9 @@ function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket'
 }
 ```
 
-Enable providers in **Project configuration > Identity > External providers** before using OAuth.
+Enable providers in **Project configuration > Identity > External providers** before using OAuth. Registration is open by default, so no additional signup-related configuration is needed for OAuth users to create accounts — only the provider itself must be enabled.
+
+Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, simply omit the email/password form from your UI; the front-end is the gate.
 
 ### Handling Callbacks
 
@@ -313,7 +315,7 @@ The response body replaces `app_metadata` and/or `user_metadata` on the user rec
 
 The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
 
-1. Go to **Identity** in the project sidebar in the Netlify dashboard
+1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
 2. Click **Invite users** and enter the admin user's email address
 3. After the user accepts the invite, click the user in the Identity list to open their detail page
 4. In the **Roles** field, add the `admin` role and save

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -134,6 +134,8 @@ function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket'
 
 Enable providers in **Project configuration > Identity > External providers** before using OAuth. Registration is open by default, so no additional signup-related configuration is needed for OAuth users to create accounts — only the provider itself must be enabled.
 
+Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, simply omit the email/password form from your UI; the front-end is the gate.
+
 ### Handling Callbacks
 
 Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -17,7 +17,7 @@ npm install @netlify/identity
 
 Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`). It is not under Integrations, and not a top-level sidebar item — it lives in the project's configuration pages. These are the default settings:
 
-- **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
+- **Registration** — Open (anyone can sign up). This is the default — no configuration needed to allow public signups or OAuth logins. Only change to Invite only in **Project configuration > Identity** if you explicitly want to restrict registration.
 - **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.
 
 ### Local Development
@@ -132,7 +132,7 @@ function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket'
 }
 ```
 
-Enable providers in **Project configuration > Identity > External providers** before using OAuth.
+Enable providers in **Project configuration > Identity > External providers** before using OAuth. Registration is open by default, so no additional signup-related configuration is needed for OAuth users to create accounts — only the provider itself must be enabled.
 
 ### Handling Callbacks
 

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -15,7 +15,7 @@ Netlify Identity is a user management service for signups, logins, password reco
 npm install @netlify/identity
 ```
 
-Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in the UI. These are the default settings:
+Identity is automatically enabled when a deploy created by a Netlify Agent Runner session includes Identity code. Otherwise, it must be manually enabled in **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`). It is not under Integrations, and not a top-level sidebar item — it lives in the project's configuration pages. These are the default settings:
 
 - **Registration** — Open (anyone can sign up). Change to Invite only in **Project configuration > Identity** if needed.
 - **Autoconfirm** — Off (new signups require email confirmation). Enable in **Project configuration > Identity** to skip confirmation during development.
@@ -313,7 +313,7 @@ The response body replaces `app_metadata` and/or `user_metadata` on the user rec
 
 The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
 
-1. Go to **Identity** in the project sidebar in the Netlify dashboard
+1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
 2. Click **Invite users** and enter the admin user's email address
 3. After the user accepts the invite, click the user in the Identity list to open their detail page
 4. In the **Roles** field, add the `admin` role and save


### PR DESCRIPTION
## Summary

Three small corrections to `skills/netlify-identity/SKILL.md` based on observed Claude misdirections in test runs:

- **Enable path** — Identity is enabled at **Project configuration > Identity** (`https://app.netlify.com/projects/<slug>/configuration/identity`), not under Integrations or as a top-level sidebar item. Updated both the Setup section and the First Admin User steps.
- **Open registration is the default** — Made explicit that public signups and OAuth account creation work out of the box. No Registration setting change is needed to allow Google (or any OAuth) users to sign up.
- **No "Email provider" toggle** — Clarified that only External providers are toggleable in Identity settings. Email/password is always available; restricting users to OAuth-only is a front-end decision, not a settings one.

## Test plan

- [ ] Verify `skills/netlify-identity/SKILL.md` renders cleanly
- [ ] Confirm CI rebuilds `cursor/rules/` and `codex/` from the updated skill on merge
