### PR TITLE
netlify-database skill: align with live docs, drop unsupported claims

### DIFF
--- a/codex/skills/netlify-database/SKILL.md
+++ b/codex/skills/netlify-database/SKILL.md
@@ -414,10 +414,9 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong adapter import path.** The Drizzle adapter is `drizzle-orm/netlify-db`. Some draft docs show `drizzle-orm/netlify-database`, but that path doesn't exist in the published package and will fail to resolve.
-3. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
-4. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
-5. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-6. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
-7. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
-8. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
+4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
+5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
+7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/codex/skills/netlify-database/references/migration-from-extension.md
+++ b/codex/skills/netlify-database/references/migration-from-extension.md
@@ -28,31 +28,37 @@ Goal: Netlify Database is online with the correct schema baseline. App still rea
 
 On a new branch:
 
-1. Run `netlify database init` to install `@netlify/database`, scaffold a starter migration, and verify the database is reachable:
+1. Run `netlify database init` to install `@netlify/database` and verify the database is reachable. **Decline the sample data prompt** — a separate baseline migration follows in the next step:
 
     ```bash
     netlify database init
     ```
 
-2. Replace the starter migration's SQL with the current shape of your source database. The fastest way is a schema-only export from the source, written into the `migration.sql` file that `init` created under `netlify/database/migrations/`:
+2. Create the baseline migration:
+
+    ```bash
+    netlify database migrations new -d baseline
+    ```
+
+3. Populate the new `migration.sql` with a schema-only dump of the source. What matters is that running this migration against an empty database leaves it with the right shape:
 
     ```bash
     pg_dump --schema-only --no-owner --no-privileges "$SOURCE_DATABASE_URL"
     ```
 
-    What matters is that running this migration against an empty database leaves it with the right shape. If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
+    If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
 
     > **Switching from the Netlify DB extension with Neon Auth?** The source contains a `neon_auth` schema with auth tables. Add `--schema=public` to exclude them. If you're switching auth providers too, handle that separately.
 
-3. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies your baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
+4. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies the baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
 
-4. Confirm the baseline applied cleanly:
+5. Confirm the baseline applied cleanly:
 
     ```bash
     netlify database status --branch <preview-branch>
     ```
 
-5. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
+6. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
 
 If the baseline fails on the preview, the deploy fails and production is unaffected. Iterate until a clean preview deploy confirms the schema is reproducible from nothing.
 
@@ -103,10 +109,10 @@ On a new branch:
     netlify database status --branch <preview-branch> --show-credentials
     ```
 
-6. Copy a snapshot of data from the source into the preview branch:
+6. Copy a snapshot of data from the source into the preview branch. Use `--data-only` because the schema is already in place via the baseline migration, and `--no-acl` because Netlify Database manages its own privileges:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PREVIEW_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PREVIEW_DATABASE_URL"
     ```
 
 7. Exercise the preview URL — click through reads and writes, validate the critical flows end-to-end. If something's off, iterate on the branch and push again. Each push gets a fresh preview branch, so the rehearsal can be repeated until the path is clean.
@@ -123,10 +129,10 @@ When the rehearsal is clean:
     netlify database status --show-credentials
     ```
 
-2. Export from the source and import into production Netlify Database:
+2. Export data from the source and import into production Netlify Database:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PRODUCTION_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PRODUCTION_DATABASE_URL"
     ```
 
 3. Merge the Phase 2 branch to trigger a production deploy. Once it completes, the app reads and writes through Netlify Database.

--- a/cursor/rules/netlify-database-legacy-extension.mdc
+++ b/cursor/rules/netlify-database-legacy-extension.mdc
@@ -16,7 +16,7 @@ These signals indicate the project is on the legacy extension, not the GA produc
 - `NETLIFY_DATABASE_URL` referenced in code or env files (note: different from the GA `NETLIFY_DB_URL`)
 - The Neon extension is installed under **Extensions** in the Netlify UI
 
-The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (and its `netlify database init` alias) now sets up Netlify Database (the GA product). If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
+The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (the short alias for `netlify database init`) now sets up Netlify Database (the GA product), not the extension. If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
 
 ## Keeping an extension project working
 
@@ -45,5 +45,6 @@ Common hallucinations to avoid:
 - Using `@netlify/neon` with `NETLIFY_DB_URL` (wrong env var)
 - Telling a user to "claim" their Netlify Database into a Neon account — that step only existed in the extension flow and is not part of Netlify Database (GA)
 - Recommending `netlify db init` to a legacy-extension user expecting it to reinstall the extension — the current CLI's `db init` sets up the GA product, not the extension
+- Assuming `netlify db <command>` still targets the extension. It's the short alias for `netlify database <command>` and runs the GA product.
 
 When in doubt, check `package.json` and the env vars actually set on the site before suggesting commands.

--- a/cursor/rules/netlify-database-migration-from-extension.mdc
+++ b/cursor/rules/netlify-database-migration-from-extension.mdc
@@ -86,17 +86,16 @@ On a new branch:
 
     > **Not using Drizzle?** The same flow works with any Postgres-compatible driver — see the native-driver section in `SKILL.md`.
 
-2. Update Drizzle config to point at the GA migrations directory. Use the `withNetlifyDB()` helper, or set `out` manually:
+2. Update Drizzle config to point at the GA migrations directory:
 
     ```typescript
     // drizzle.config.ts
     import { defineConfig } from "drizzle-kit";
-    import { withNetlifyDB } from "@netlify/database/drizzle";
 
     export default defineConfig({
       dialect: "postgresql",
       schema: "./db/schema.ts",
-      ...withNetlifyDB(),
+      out: "netlify/database/migrations",
       migrations: { prefix: "timestamp" },
     });
     ```

--- a/cursor/rules/netlify-database-migration-from-extension.mdc
+++ b/cursor/rules/netlify-database-migration-from-extension.mdc
@@ -32,31 +32,37 @@ Goal: Netlify Database is online with the correct schema baseline. App still rea
 
 On a new branch:
 
-1. Run `netlify database init` to install `@netlify/database`, scaffold a starter migration, and verify the database is reachable:
+1. Run `netlify database init` to install `@netlify/database` and verify the database is reachable. **Decline the sample data prompt** — a separate baseline migration follows in the next step:
 
     ```bash
     netlify database init
     ```
 
-2. Replace the starter migration's SQL with the current shape of your source database. The fastest way is a schema-only export from the source, written into the `migration.sql` file that `init` created under `netlify/database/migrations/`:
+2. Create the baseline migration:
+
+    ```bash
+    netlify database migrations new -d baseline
+    ```
+
+3. Populate the new `migration.sql` with a schema-only dump of the source. What matters is that running this migration against an empty database leaves it with the right shape:
 
     ```bash
     pg_dump --schema-only --no-owner --no-privileges "$SOURCE_DATABASE_URL"
     ```
 
-    What matters is that running this migration against an empty database leaves it with the right shape. If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
+    If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
 
     > **Switching from the Netlify DB extension with Neon Auth?** The source contains a `neon_auth` schema with auth tables. Add `--schema=public` to exclude them. If you're switching auth providers too, handle that separately.
 
-3. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies your baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
+4. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies the baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
 
-4. Confirm the baseline applied cleanly:
+5. Confirm the baseline applied cleanly:
 
     ```bash
     netlify database status --branch <preview-branch>
     ```
 
-5. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
+6. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
 
 If the baseline fails on the preview, the deploy fails and production is unaffected. Iterate until a clean preview deploy confirms the schema is reproducible from nothing.
 
@@ -107,10 +113,10 @@ On a new branch:
     netlify database status --branch <preview-branch> --show-credentials
     ```
 
-6. Copy a snapshot of data from the source into the preview branch:
+6. Copy a snapshot of data from the source into the preview branch. Use `--data-only` because the schema is already in place via the baseline migration, and `--no-acl` because Netlify Database manages its own privileges:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PREVIEW_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PREVIEW_DATABASE_URL"
     ```
 
 7. Exercise the preview URL — click through reads and writes, validate the critical flows end-to-end. If something's off, iterate on the branch and push again. Each push gets a fresh preview branch, so the rehearsal can be repeated until the path is clean.
@@ -127,10 +133,10 @@ When the rehearsal is clean:
     netlify database status --show-credentials
     ```
 
-2. Export from the source and import into production Netlify Database:
+2. Export data from the source and import into production Netlify Database:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PRODUCTION_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PRODUCTION_DATABASE_URL"
     ```
 
 3. Merge the Phase 2 branch to trigger a production deploy. Once it completes, the app reads and writes through Netlify Database.

--- a/cursor/rules/netlify-database-migrations.mdc
+++ b/cursor/rules/netlify-database-migrations.mdc
@@ -12,7 +12,7 @@ Prefer Drizzle Kit for generating migrations. Manual SQL migration files are an 
 
 The platform applies migrations to every Netlify-hosted database (preview branches and production) automatically on deploy. You never run `drizzle-kit migrate` against `NETLIFY_DB_URL` from a preview or production context. For local, use `netlify database migrations apply` — it targets the local development database only.
 
-`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: the connection is read-only, and schema changes out-of-band cause drift between the migration history and the actual database.
+`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: schema changes out-of-band cause drift between the migration history and the actual database.
 
 ## Schema migration workflow
 
@@ -53,8 +53,6 @@ netlify/database/migrations/
   20260418091500_add_items_is_active/
     migration.sql
 ```
-
-The migrations directory location can be overridden by setting `db.migrations.path` in `netlify.toml`.
 
 ## Iterating on a migration you haven't shipped yet
 

--- a/cursor/rules/netlify-database.mdc
+++ b/cursor/rules/netlify-database.mdc
@@ -414,10 +414,9 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong adapter import path.** The Drizzle adapter is `drizzle-orm/netlify-db`. Some draft docs show `drizzle-orm/netlify-database`, but that path doesn't exist in the published package and will fail to resolve.
-3. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
-4. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
-5. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-6. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
-7. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
-8. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
+4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
+5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
+7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/cursor/rules/netlify-database.mdc
+++ b/cursor/rules/netlify-database.mdc
@@ -46,7 +46,7 @@ This means:
 
 - Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
 - Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. The connection is read-only for a reason.
+- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
 - Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
 
 The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
@@ -339,7 +339,7 @@ netlify database connect --query "SELECT * FROM items LIMIT 10" --json
 netlify database connect --json
 ```
 
-The connection is read-only. **Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) or any mutating query through `netlify database connect`.** Schema changes go through migration files.
+**Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) through `netlify database connect`, `psql`, or any other direct connection.** Schema changes go through migration files — out-of-band DDL drifts the migration history from the actual schema.
 
 ### `netlify database migrations new`
 
@@ -389,17 +389,6 @@ Wipes the local development database — drops all schemas and tables. Only affe
 netlify database reset
 ```
 
-### Customizing the migrations directory
-
-The default is `netlify/database/migrations`. To override, set `db.migrations.path` in `netlify.toml`:
-
-```toml
-[db.migrations]
-  path = "db/migrations"
-```
-
-The CLI commands and the deploy both honor the override.
-
 ## Iterating on migrations
 
 When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
@@ -417,6 +406,6 @@ When a migration you generated needs to change, what you do depends on whether i
 2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
 3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
 4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+5. **Using `netlify database connect` to change schema.** Schema changes go through migration files — never DDL through `connect` or any direct connection.
 6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
 7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/cursor/rules/netlify-database.mdc
+++ b/cursor/rules/netlify-database.mdc
@@ -131,24 +131,10 @@ The connection is configured automatically — no connection string needed. If y
 
 ### Drizzle Kit config
 
-Create `drizzle.config.ts` at the project root. The simplest form uses the `withNetlifyDB()` helper, which sets the `out` directory to `netlify/database/migrations` (where the deploy applies migrations from):
+Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
 
 ```typescript
 // drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-import { withNetlifyDB } from "@netlify/database/drizzle";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  ...withNetlifyDB(),
-  migrations: { prefix: "timestamp" },
-});
-```
-
-If you'd rather configure `out` manually:
-
-```typescript
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
@@ -403,7 +389,7 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Set `out: "netlify/database/migrations"` in `drizzle.config.ts` — migrations outside that directory are not applied by the deploy.
 3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
 4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
 5. **Using `netlify database connect` to change schema.** Schema changes go through migration files — never DDL through `connect` or any direct connection.

--- a/skills/netlify-database/SKILL.md
+++ b/skills/netlify-database/SKILL.md
@@ -414,10 +414,9 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong adapter import path.** The Drizzle adapter is `drizzle-orm/netlify-db`. Some draft docs show `drizzle-orm/netlify-database`, but that path doesn't exist in the published package and will fail to resolve.
-3. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
-4. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
-5. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-6. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
-7. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
-8. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
+4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
+5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
+7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/skills/netlify-database/SKILL.md
+++ b/skills/netlify-database/SKILL.md
@@ -46,7 +46,7 @@ This means:
 
 - Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
 - Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. The connection is read-only for a reason.
+- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
 - Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
 
 The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
@@ -339,7 +339,7 @@ netlify database connect --query "SELECT * FROM items LIMIT 10" --json
 netlify database connect --json
 ```
 
-The connection is read-only. **Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) or any mutating query through `netlify database connect`.** Schema changes go through migration files.
+**Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) through `netlify database connect`, `psql`, or any other direct connection.** Schema changes go through migration files — out-of-band DDL drifts the migration history from the actual schema.
 
 ### `netlify database migrations new`
 
@@ -389,17 +389,6 @@ Wipes the local development database — drops all schemas and tables. Only affe
 netlify database reset
 ```
 
-### Customizing the migrations directory
-
-The default is `netlify/database/migrations`. To override, set `db.migrations.path` in `netlify.toml`:
-
-```toml
-[db.migrations]
-  path = "db/migrations"
-```
-
-The CLI commands and the deploy both honor the override.
-
 ## Iterating on migrations
 
 When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
@@ -417,6 +406,6 @@ When a migration you generated needs to change, what you do depends on whether i
 2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
 3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
 4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+5. **Using `netlify database connect` to change schema.** Schema changes go through migration files — never DDL through `connect` or any direct connection.
 6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
 7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/skills/netlify-database/SKILL.md
+++ b/skills/netlify-database/SKILL.md
@@ -131,24 +131,10 @@ The connection is configured automatically — no connection string needed. If y
 
 ### Drizzle Kit config
 
-Create `drizzle.config.ts` at the project root. The simplest form uses the `withNetlifyDB()` helper, which sets the `out` directory to `netlify/database/migrations` (where the deploy applies migrations from):
+Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
 
 ```typescript
 // drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-import { withNetlifyDB } from "@netlify/database/drizzle";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  ...withNetlifyDB(),
-  migrations: { prefix: "timestamp" },
-});
-```
-
-If you'd rather configure `out` manually:
-
-```typescript
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
@@ -403,7 +389,7 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Set `out: "netlify/database/migrations"` in `drizzle.config.ts` — migrations outside that directory are not applied by the deploy.
 3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
 4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
 5. **Using `netlify database connect` to change schema.** Schema changes go through migration files — never DDL through `connect` or any direct connection.

--- a/skills/netlify-database/references/legacy-extension.md
+++ b/skills/netlify-database/references/legacy-extension.md
@@ -12,7 +12,7 @@ These signals indicate the project is on the legacy extension, not the GA produc
 - `NETLIFY_DATABASE_URL` referenced in code or env files (note: different from the GA `NETLIFY_DB_URL`)
 - The Neon extension is installed under **Extensions** in the Netlify UI
 
-The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (and its `netlify database init` alias) now sets up Netlify Database (the GA product). If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
+The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (the short alias for `netlify database init`) now sets up Netlify Database (the GA product), not the extension. If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
 
 ## Keeping an extension project working
 
@@ -41,5 +41,6 @@ Common hallucinations to avoid:
 - Using `@netlify/neon` with `NETLIFY_DB_URL` (wrong env var)
 - Telling a user to "claim" their Netlify Database into a Neon account — that step only existed in the extension flow and is not part of Netlify Database (GA)
 - Recommending `netlify db init` to a legacy-extension user expecting it to reinstall the extension — the current CLI's `db init` sets up the GA product, not the extension
+- Assuming `netlify db <command>` still targets the extension. It's the short alias for `netlify database <command>` and runs the GA product.
 
 When in doubt, check `package.json` and the env vars actually set on the site before suggesting commands.

--- a/skills/netlify-database/references/migration-from-extension.md
+++ b/skills/netlify-database/references/migration-from-extension.md
@@ -82,17 +82,16 @@ On a new branch:
 
     > **Not using Drizzle?** The same flow works with any Postgres-compatible driver — see the native-driver section in `SKILL.md`.
 
-2. Update Drizzle config to point at the GA migrations directory. Use the `withNetlifyDB()` helper, or set `out` manually:
+2. Update Drizzle config to point at the GA migrations directory:
 
     ```typescript
     // drizzle.config.ts
     import { defineConfig } from "drizzle-kit";
-    import { withNetlifyDB } from "@netlify/database/drizzle";
 
     export default defineConfig({
       dialect: "postgresql",
       schema: "./db/schema.ts",
-      ...withNetlifyDB(),
+      out: "netlify/database/migrations",
       migrations: { prefix: "timestamp" },
     });
     ```

--- a/skills/netlify-database/references/migration-from-extension.md
+++ b/skills/netlify-database/references/migration-from-extension.md
@@ -28,31 +28,37 @@ Goal: Netlify Database is online with the correct schema baseline. App still rea
 
 On a new branch:
 
-1. Run `netlify database init` to install `@netlify/database`, scaffold a starter migration, and verify the database is reachable:
+1. Run `netlify database init` to install `@netlify/database` and verify the database is reachable. **Decline the sample data prompt** — a separate baseline migration follows in the next step:
 
     ```bash
     netlify database init
     ```
 
-2. Replace the starter migration's SQL with the current shape of your source database. The fastest way is a schema-only export from the source, written into the `migration.sql` file that `init` created under `netlify/database/migrations/`:
+2. Create the baseline migration:
+
+    ```bash
+    netlify database migrations new -d baseline
+    ```
+
+3. Populate the new `migration.sql` with a schema-only dump of the source. What matters is that running this migration against an empty database leaves it with the right shape:
 
     ```bash
     pg_dump --schema-only --no-owner --no-privileges "$SOURCE_DATABASE_URL"
     ```
 
-    What matters is that running this migration against an empty database leaves it with the right shape. If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
+    If the project already has Drizzle migrations, point `drizzle-kit` at `netlify/database/migrations/` and move them in instead of the schema dump. `pg_dump` 18+ emits `\restrict` / `\unrestrict` psql meta-commands that are not valid SQL — strip them: `... | grep -v -E '^\\(restrict|unrestrict)'`.
 
     > **Switching from the Netlify DB extension with Neon Auth?** The source contains a `neon_auth` schema with auth tables. Add `--schema=public` to exclude them. If you're switching auth providers too, handle that separately.
 
-3. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies your baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
+4. Push the branch. Netlify detects `@netlify/database`, provisions a preview database branch, and applies the baseline migration. The preview goes live still serving from the source database — app code hasn't changed yet.
 
-4. Confirm the baseline applied cleanly:
+5. Confirm the baseline applied cleanly:
 
     ```bash
     netlify database status --branch <preview-branch>
     ```
 
-5. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
+6. Merge the branch. Netlify provisions the production database branch and applies the baseline migration there too. Production still serves from the source.
 
 If the baseline fails on the preview, the deploy fails and production is unaffected. Iterate until a clean preview deploy confirms the schema is reproducible from nothing.
 
@@ -103,10 +109,10 @@ On a new branch:
     netlify database status --branch <preview-branch> --show-credentials
     ```
 
-6. Copy a snapshot of data from the source into the preview branch:
+6. Copy a snapshot of data from the source into the preview branch. Use `--data-only` because the schema is already in place via the baseline migration, and `--no-acl` because Netlify Database manages its own privileges:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PREVIEW_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PREVIEW_DATABASE_URL"
     ```
 
 7. Exercise the preview URL — click through reads and writes, validate the critical flows end-to-end. If something's off, iterate on the branch and push again. Each push gets a fresh preview branch, so the rehearsal can be repeated until the path is clean.
@@ -123,10 +129,10 @@ When the rehearsal is clean:
     netlify database status --show-credentials
     ```
 
-2. Export from the source and import into production Netlify Database:
+2. Export data from the source and import into production Netlify Database:
 
     ```bash
-    pg_dump -Fc "$SOURCE_DATABASE_URL" | pg_restore --no-owner --dbname="$PRODUCTION_DATABASE_URL"
+    pg_dump -Fc --data-only "$SOURCE_DATABASE_URL" | pg_restore --no-owner --no-acl --dbname="$PRODUCTION_DATABASE_URL"
     ```
 
 3. Merge the Phase 2 branch to trigger a production deploy. Once it completes, the app reads and writes through Netlify Database.

--- a/skills/netlify-database/references/migrations.md
+++ b/skills/netlify-database/references/migrations.md
@@ -8,7 +8,7 @@ Prefer Drizzle Kit for generating migrations. Manual SQL migration files are an 
 
 The platform applies migrations to every Netlify-hosted database (preview branches and production) automatically on deploy. You never run `drizzle-kit migrate` against `NETLIFY_DB_URL` from a preview or production context. For local, use `netlify database migrations apply` — it targets the local development database only.
 
-`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: the connection is read-only, and schema changes out-of-band cause drift between the migration history and the actual database.
+`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: schema changes out-of-band cause drift between the migration history and the actual database.
 
 ## Schema migration workflow
 
@@ -49,8 +49,6 @@ netlify/database/migrations/
   20260418091500_add_items_is_active/
     migration.sql
 ```
-
-The migrations directory location can be overridden by setting `db.migrations.path` in `netlify.toml`.
 
 ## Iterating on a migration you haven't shipped yet
 


### PR DESCRIPTION
Four rounds of fixes to the `netlify-database` skill, all driven by cross-checking against the live docs at https://docs.netlify.com/build/data-and-storage/netlify-database/, the published `@netlify/database` package, the actual `netlify-cli` binary, and the agent-runner-orchestrator skill where the public docs are silent.

### 1. `migration-from-extension.md` — align with the live switch guide

Two functional bugs found by comparing our reference to the live `switch-to-netlify-database` page.

**Phase 1 baseline.** The previous flow told users to overwrite the starter migration that `netlify database init` scaffolds. The live docs use a cleaner approach: decline the `init` sample-data prompt entirely, then create a dedicated baseline migration via `netlify database migrations new -d baseline` and populate that file with the schema dump. Updated to match.

**Phase 2 and Phase 3 data move — add `--data-only` and `--no-acl`.** The `pg_dump | pg_restore` pipeline was missing both flags.

- `--data-only` is required because the schema is already in place via the baseline migration the deploy applied. Without it, `pg_dump` includes schema, which would collide with existing tables when piped into `pg_restore`. Following the previous version of this guide would have produced a broken rehearsal on the preview branch.
- `--no-acl` skips source-side access privileges, which don't apply to Netlify Database (which manages its own).

Both flags now appear on Phase 2 (preview rehearsal) and Phase 3 (production cutover) data-move commands.

### 2. `SKILL.md` — drop the pre-release-only adapter-path callout

Removed the "Wrong adapter import path" entry from Common Mistakes. That callout flagged `drizzle-orm/netlify-database` (incorrect) versus `drizzle-orm/netlify-db` (correct), but the wrong path was only ever a real risk during the pre-release window when draft docs had it that way. Now that docs are live and consistent, the callout is just noise. Common Mistakes goes from 8 items to 7.

### 3. `SKILL.md` + references — drop unsupported claims, fix alias direction

A second cross-check audit (this time of every claim in `SKILL.md` against published pages — overview, getting-started, tooling, migrations, API, CLI, local-development, troubleshooting, changelog) surfaced two assertions with no source:

- **\"`netlify database connect` is read-only.\"** Repeated in four places. Not in any public doc; the CLI reference describes connect as \"an interactive SQL session\" with no restrictions, and connect targets only the local dev DB (no `--branch` flag) — local Postgres isn't going to refuse writes. Dropped the read-only framing. Kept the operational rule, reframed: schema goes through migration files; out-of-band DDL drifts the migration history from the actual schema.
- **`db.migrations.path` override in `netlify.toml`.** Claimed to override the migrations directory and be honored by both CLI and deploy. Not in any public doc. The orchestrator skill (internal source-of-truth for the agent runtime) makes zero references to it either. The migrations page actually says \"If you want to use your own migrations system, choose a different directory to avoid conflicts\" — implying custom directories aren't auto-applied. Removed the section from `SKILL.md` and the corresponding line from `references/migrations.md`.

Also corrected the alias direction in `references/legacy-extension.md`: `netlify database` is canonical, `netlify db` is the short alias (the previous wording had it reversed). Added a callout under \"Common hallucinations to avoid\" warning that `netlify db <command>` runs the GA product, not the deprecated extension — to head off agents that assume otherwise from prior knowledge.

### 4. `SKILL.md` + `migration-from-extension.md` — drop the unshipped `withNetlifyDB` helper

The live tooling page (https://docs.netlify.com/build/data-and-storage/netlify-database/tooling/) recommends:

```typescript
import { withNetlifyDB } from \"@netlify/database/drizzle\";
```

But the published `@netlify/database@0.7.0` package's `exports` field only declares `\".\"` — there is no `./drizzle` subpath. The helper was never shipped, and following the docs produces a module-not-found error at runtime. (Filed as a docs bug separately; not a fix this PR can make on the Netlify side.)

Dropped both the recommended-form and the alternative-form `drizzle.config.ts` variants in `SKILL.md` and the equivalent in `references/migration-from-extension.md`. Kept only the manual `out: \"netlify/database/migrations\"` form, which is what actually works. Tightened Common Mistake #2 to point at the manual config directly instead of mentioning the helper.

### Files touched

- `skills/netlify-database/SKILL.md`
- `skills/netlify-database/references/migration-from-extension.md`
- `skills/netlify-database/references/migrations.md`
- `skills/netlify-database/references/legacy-extension.md`

### Audit scope

Cross-checked every skill file that mentions database/storage against the live docs (index, getting-started, tooling, cli, migrations, local-development, api, switch-to-netlify-database, troubleshooting), the published `@netlify/database` npm package, and the local `netlify-cli/26.0.0` binary's `--help` output:

- `skills/CLAUDE.md`, `skills/netlify-blobs/SKILL.md`, `skills/netlify-functions/SKILL.md` — only generic references, no issues
- `skills/netlify-database/SKILL.md` — Drizzle adapter (`drizzle-orm/netlify-db`), schema example (`serial().primaryKey()`), Drizzle client, native driver (`db.sql` / `db.pool`), CLI commands and flags all match the live docs and the binary
- `skills/netlify-database/references/migrations.md`, `local-dev.md`, `legacy-extension.md` — clean after these fixes

Spot-verified directly against the binary that `netlify database migrations new -d <description>` exists (`-d, --description` is documented in `--help` output for `netlify-cli/26.0.0`). Spot-verified directly against npm that `@netlify/database/drizzle` does not exist as an export.

Beta-extension references are deliberately preserved — that's a real deprecated product some projects still have.

### Things deliberately kept as our own opinion

- **Default to `migrations: { prefix: \"timestamp\" }`.** The live CLI page uses `--scheme sequential` in its `migrations new` example, and the migrations page is neutral. The skill takes the stronger \"default to timestamp\" position because parallel-branch collisions hit even solo developers in practice.
- **Local DB persists under `.netlify/`.** Public docs don't explicitly state this for the `netlify dev` flow. Verified by local test — kept the claim.