### PR TITLE
Add netlify-payments skill for Stripe Projects bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp/
 .DS_Store
+skills/*-workspace/

--- a/axis-scenarios/helpers/variants.ts
+++ b/axis-scenarios/helpers/variants.ts
@@ -19,6 +19,7 @@ export const ALL_NTL_SKILLS = [
   "./skills/netlify-functions",
   "./skills/netlify-identity",
   "./skills/netlify-image-cdn",
+  "./skills/netlify-payments",
 ];
 
 // Standard variant pair every scenario runs: a baseline with no extra context,

--- a/axis-scenarios/payments/ambiguous-project-slug.ts
+++ b/axis-scenarios/payments/ambiguous-project-slug.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: ambiguous project slug clarification",
   prompt:
-    "Build me a new tip jar on Netlify with Stripe. Do not run commands yet. What would you ask before bootstrapping, and what would you do after I answer?",
+    "Build me a new tip jar on Netlify with Stripe. Do not provision external services, mutate files, or run bootstrap commands yet. You may inspect local skill files/documentation before answering. What would you ask before bootstrapping, and what would you do after I answer?",
   judge: [
     { check: "Recognizes this as a new payment-taking project that should use the Netlify Payments / Stripe Projects bootstrap after clarification" },
     { check: "Asks for a project name or slug because `tip jar` does not identify a concrete project subject" },

--- a/axis-scenarios/payments/ambiguous-project-slug.ts
+++ b/axis-scenarios/payments/ambiguous-project-slug.ts
@@ -1,0 +1,17 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: ambiguous project slug clarification",
+  prompt:
+    "Build me a new tip jar on Netlify with Stripe. Do not run commands yet. What would you ask before bootstrapping, and what would you do after I answer?",
+  judge: [
+    { check: "Recognizes this as a new payment-taking project that should use the Netlify Payments / Stripe Projects bootstrap after clarification" },
+    { check: "Asks for a project name or slug because `tip jar` does not identify a concrete project subject" },
+    { check: "Asks only targeted setup questions, such as payment shape details and whether auth, database, or file storage are needed" },
+    { check: "Does NOT ask a long unrelated interview before provisioning" },
+    { check: "Says that after the user answers, it should proceed deterministically through the workflow instead of looping through repeated clarification" },
+    { check: "Does not choose a random slug or run `stripe projects init` before the user supplies enough naming context" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/browser-flow-boundaries.ts
+++ b/axis-scenarios/payments/browser-flow-boundaries.ts
@@ -1,0 +1,18 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: browser flow boundaries",
+  prompt:
+    "I'm starting a new paid Netlify project with Stripe Projects from a fresh machine. Explain how to handle authentication and first-time setup flows. Do not assume the CLIs are logged in.",
+  judge: [
+    { check: "Checks for Stripe CLI and Netlify CLI availability before using them" },
+    { check: "Uses `stripe whoami` and `netlify status` or equivalent auth checks" },
+    { check: "Tells the user to complete `stripe login` themselves if unauthenticated, because it opens a browser" },
+    { check: "Tells the user to complete `netlify login` themselves if unauthenticated, because it opens a browser" },
+    { check: "Warns that first-time `stripe projects init` may open a browser for KYC/business verification and waits for user completion" },
+    { check: "Does NOT try to script around browser login, MFA, OAuth, or KYC flows" },
+    { check: "Continues the bootstrap only after explicit user confirmation for browser-driven steps" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/draft-checkpoint-prod.ts
+++ b/axis-scenarios/payments/draft-checkpoint-prod.ts
@@ -1,0 +1,18 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: draft deploy checkpoint before production",
+  prompt:
+    "I'm at the end of a new Stripe Projects + Netlify bootstrap and the app builds locally. Give me the final deploy sequence. The app also uses Netlify Identity with Google OAuth. Do not run anything.",
+  judge: [
+    { check: "Runs the project build first if the project has a build command" },
+    { check: "Uses `netlify deploy` without `--prod` for the first deploy" },
+    { check: "Captures and surfaces the draft deploy URL for review" },
+    { check: "Inserts a user checkpoint after the draft deploy for dashboard-only setup, including enabling Netlify Identity and configuring Google OAuth if needed" },
+    { check: "Requires end-to-end verification of the Stripe checkout flow against test-mode keys before production" },
+    { check: "Does NOT run or recommend `netlify deploy --prod` until the user explicitly confirms" },
+    { check: "Promotes with `netlify deploy --prod` only after the checkpoint" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/draft-checkpoint-prod.ts
+++ b/axis-scenarios/payments/draft-checkpoint-prod.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: draft deploy checkpoint before production",
   prompt:
-    "I'm at the end of a new Stripe Projects + Netlify bootstrap and the app builds locally. Give me the final deploy sequence. The app also uses Netlify Identity with Google OAuth. Do not run anything.",
+    "I'm at the end of a new Stripe Projects + Netlify bootstrap and the app builds locally. Give me the final deploy sequence. The app also uses Netlify Identity with Google OAuth. Do not provision external services, mutate files, or run deploy commands. You may inspect local skill files/documentation before answering.",
   judge: [
     { check: "Runs the project build first if the project has a build command" },
     { check: "Uses `netlify deploy` without `--prod` for the first deploy" },

--- a/axis-scenarios/payments/existing-app-skip.ts
+++ b/axis-scenarios/payments/existing-app-skip.ts
@@ -1,0 +1,17 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: existing app skips Stripe Projects bootstrap",
+  prompt:
+    "This repo is an existing deployed Netlify app. Add Stripe Checkout to it for a new paid plan. Do not initialize any new projects or services; explain the right integration approach and commands for environment variables.",
+  judge: [
+    { check: "Does NOT run or recommend `stripe projects init`, because the prompt says the app already exists" },
+    { check: "Does NOT run or recommend `stripe projects add netlify/project` as the primary path for this existing project" },
+    { check: "Uses direct Stripe integration guidance with Netlify Functions or framework server routes for Checkout session creation and webhooks" },
+    { check: "Sets `STRIPE_SECRET_KEY` in the existing Netlify site with `netlify env:set STRIPE_SECRET_KEY <value> --secret` or equivalent" },
+    { check: "Mentions webhook signature verification and a separate webhook secret if webhooks are involved" },
+    { check: "Avoids creating a new Netlify site or changing the existing deploy topology unless the user asks" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/existing-app-skip.ts
+++ b/axis-scenarios/payments/existing-app-skip.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: existing app skips Stripe Projects bootstrap",
   prompt:
-    "This repo is an existing deployed Netlify app. Add Stripe Checkout to it for a new paid plan. Do not initialize any new projects or services; explain the right integration approach and commands for environment variables.",
+    "This repo is an existing deployed Netlify app. Add Stripe Checkout to it for a new paid plan. Do not initialize any new projects or services, provision external services, or mutate files. You may inspect local skill files/documentation before answering. Explain the right integration approach and commands for environment variables.",
   judge: [
     { check: "Does NOT run or recommend `stripe projects init`, because the prompt says the app already exists" },
     { check: "Does NOT run or recommend `stripe projects add netlify/project` as the primary path for this existing project" },

--- a/axis-scenarios/payments/netlify-account-reconciliation.ts
+++ b/axis-scenarios/payments/netlify-account-reconciliation.ts
@@ -1,0 +1,17 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: reconcile Netlify account after Stripe Projects link",
+  prompt:
+    "I'm bootstrapping a new paid Netlify app with Stripe Projects. After `stripe projects add netlify/project`, how should I verify the Netlify site is linked to the same team my local Netlify CLI can deploy to? Give commands and the halt condition.",
+  judge: [
+    { check: "Reads `NETLIFY_NETLIFY_SITE_ID` from `.env` after `stripe projects add netlify/project`" },
+    { check: "Uses `netlify api getSite --data='{\"site_id\":\"<NETLIFY_NETLIFY_SITE_ID>\"}'` or equivalent to inspect the site's owning account" },
+    { check: "Uses `netlify status` to inspect the local Netlify CLI user and team memberships" },
+    { check: "Compares the site's `account_slug` or account/team identity against the teams available to the local CLI user" },
+    { check: "Halts on team mismatch instead of continuing to deploy" },
+    { check: "Explains the two reasonable fixes: sign the local Netlify CLI into a user on that team, or re-link Stripe Projects to the intended Netlify account" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/new-subscription-bootstrap.ts
+++ b/axis-scenarios/payments/new-subscription-bootstrap.ts
@@ -1,0 +1,18 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: new subscription bootstrap with auth",
+  prompt:
+    "I'm starting a new Netlify app called Studio Pass. It will sell a $10/month subscription and require members to sign in before checkout. Do not run any commands. Walk me through the bootstrap workflow you would use from an empty local project, including the Stripe and Netlify CLI commands and the points where you would stop for my input.",
+  judge: [
+    { check: "Treats this as a new payment-taking project and uses the `netlify-payments` bootstrap flow" },
+    { check: "Starts by clarifying any missing intent before provisioning, but does NOT re-ask for the subscription payment shape, auth requirement, or project slug because the prompt already provides them" },
+    { check: "Includes Stripe CLI and Netlify CLI setup/auth checks before provisioning" },
+    { check: "Uses `stripe plugin install projects`, then `stripe projects init studio-pass`, then `stripe projects add netlify/project`; does NOT use `netlify/hosting`" },
+    { check: "Mentions first-time Stripe Projects KYC/browser verification and waits for user completion instead of scripting around it" },
+    { check: "Hands app implementation to the appropriate skills/patterns for Netlify Identity, Netlify Functions, and Stripe subscriptions rather than claiming this skill owns all app code" },
+    { check: "Uses a draft deploy with `netlify deploy`, then a user checkpoint, then `netlify deploy --prod` only after explicit confirmation" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/new-subscription-bootstrap.ts
+++ b/axis-scenarios/payments/new-subscription-bootstrap.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: new subscription bootstrap with auth",
   prompt:
-    "I'm starting a new Netlify app called Studio Pass. It will sell a $10/month subscription and require members to sign in before checkout. Do not run any commands. Walk me through the bootstrap workflow you would use from an empty local project, including the Stripe and Netlify CLI commands and the points where you would stop for my input.",
+    "I'm starting a new Netlify app called Studio Pass. It will sell a $10/month subscription and require members to sign in before checkout. Do not provision external services, mutate files, or run bootstrap commands. You may inspect local skill files/documentation before answering. Walk me through the bootstrap workflow you would use from an empty local project, including the Stripe and Netlify CLI commands and the points where you would stop for my input.",
   judge: [
     { check: "Treats this as a new payment-taking project and uses the `netlify-payments` bootstrap flow" },
     { check: "Starts by clarifying any missing intent before provisioning, but does NOT re-ask for the subscription payment shape, auth requirement, or project slug because the prompt already provides them" },

--- a/axis-scenarios/payments/non-stripe-provider-skip.ts
+++ b/axis-scenarios/payments/non-stripe-provider-skip.ts
@@ -1,0 +1,16 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: non-Stripe provider skips netlify-payments",
+  prompt:
+    "I'm starting a new Netlify app that sells paid downloads through Lemon Squeezy. Do not use Stripe. Tell me the implementation and deployment plan.",
+  judge: [
+    { check: "Does NOT use the Stripe Projects CLI or `netlify-payments` bootstrap workflow" },
+    { check: "Does NOT suggest `stripe projects init`, `stripe projects add netlify/project`, or `STRIPE_SECRET_KEY`" },
+    { check: "Treats Lemon Squeezy as the chosen provider and gives provider-agnostic Netlify guidance for functions, env vars, and webhooks" },
+    { check: "Still uses relevant Netlify skills/patterns such as Netlify Functions and deploy/env var guidance" },
+    { check: "Respects the user's explicit provider choice instead of redirecting them to Stripe" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/one-time-checkout-no-auth.ts
+++ b/axis-scenarios/payments/one-time-checkout-no-auth.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: one-time checkout without auth",
   prompt:
-    "I'm starting a new Netlify project named Print Drop. It sells one downloadable poster through a one-time Stripe Checkout payment. There is no login and no customer account area. Do not run commands; give me the exact bootstrap sequence and call out what you would skip.",
+    "I'm starting a new Netlify project named Print Drop. It sells one downloadable poster through a one-time Stripe Checkout payment. There is no login and no customer account area. Do not provision external services, mutate files, or run bootstrap commands. You may inspect local skill files/documentation before answering. Give me the exact bootstrap sequence and call out what you would skip.",
   judge: [
     { check: "Uses the new-project Stripe Projects bootstrap path because this is a new Stripe payment project" },
     { check: "Derives the project slug `print-drop` without asking for it" },

--- a/axis-scenarios/payments/one-time-checkout-no-auth.ts
+++ b/axis-scenarios/payments/one-time-checkout-no-auth.ts
@@ -1,0 +1,18 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: one-time checkout without auth",
+  prompt:
+    "I'm starting a new Netlify project named Print Drop. It sells one downloadable poster through a one-time Stripe Checkout payment. There is no login and no customer account area. Do not run commands; give me the exact bootstrap sequence and call out what you would skip.",
+  judge: [
+    { check: "Uses the new-project Stripe Projects bootstrap path because this is a new Stripe payment project" },
+    { check: "Derives the project slug `print-drop` without asking for it" },
+    { check: "Uses `stripe projects add netlify/project` and explicitly avoids the wrong `netlify/hosting` service slug" },
+    { check: "Does NOT introduce Netlify Identity, OAuth, subscriptions, Connect, or a database requirement unless framing them as unnecessary for this prompt" },
+    { check: "States that server-side Checkout can use only the secret key for this v1 flow and does not require pushing a publishable key unless Stripe.js/Elements is added" },
+    { check: "Sets `STRIPE_SECRET_KEY` in Netlify with `--secret` and says app code must explicitly read/pass it to Stripe" },
+    { check: "Uses draft deploy before production promotion" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/sandbox-test-mode.ts
+++ b/axis-scenarios/payments/sandbox-test-mode.ts
@@ -4,7 +4,7 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Payments: sandbox means Stripe test mode",
   prompt:
-    "For a new paid Netlify project, I want the Stripe sandbox set up through Stripe Projects. Explain what sandbox means here and give me the bootstrap commands. Do not run them.",
+    "For a new paid Netlify project, I want the Stripe sandbox set up through Stripe Projects. Explain what sandbox means here and give me the bootstrap commands. Do not provision external services, mutate files, or run bootstrap commands. You may inspect local skill files/documentation before answering.",
   judge: [
     { check: "Explains that Stripe Projects sandbox means test mode on the user's existing Stripe account, not a separate Stripe account" },
     { check: "Uses `stripe projects init <slug>` and `stripe projects add netlify/project` as the provisioning path" },

--- a/axis-scenarios/payments/sandbox-test-mode.ts
+++ b/axis-scenarios/payments/sandbox-test-mode.ts
@@ -1,0 +1,17 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: sandbox means Stripe test mode",
+  prompt:
+    "For a new paid Netlify project, I want the Stripe sandbox set up through Stripe Projects. Explain what sandbox means here and give me the bootstrap commands. Do not run them.",
+  judge: [
+    { check: "Explains that Stripe Projects sandbox means test mode on the user's existing Stripe account, not a separate Stripe account" },
+    { check: "Uses `stripe projects init <slug>` and `stripe projects add netlify/project` as the provisioning path" },
+    { check: "Says Stripe Projects does not auto-inject Stripe API keys into Netlify" },
+    { check: "Pulls the test-mode secret from `stripe config --list` by looking for `test_mode_api_key`" },
+    { check: "Sets the Netlify env var as `STRIPE_SECRET_KEY` with `--secret`" },
+    { check: "Does not mention live-mode or production Stripe keys as part of the v1 bootstrap" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/axis-scenarios/payments/stripe-secret-wiring.ts
+++ b/axis-scenarios/payments/stripe-secret-wiring.ts
@@ -1,0 +1,18 @@
+import type { ScenarioInput } from "@netlify/axis";
+import { withSkillVariants } from "../helpers/variants";
+
+export default {
+  name: "Payments: Stripe secret extraction and wiring",
+  prompt:
+    "A new Stripe Projects + Netlify app is created and `.env` has `NETLIFY_NETLIFY_SITE_ID`. Show the exact steps to get the Stripe test secret into Netlify and explain how Netlify Function code should pass it to the Stripe SDK.",
+  judge: [
+    { check: "Uses `stripe config --list` to find `test_mode_api_key` instead of expecting Stripe Projects to write Stripe keys to `.env`" },
+    { check: "Links the Netlify CLI to the provisioned site with `netlify link --id \"$NETLIFY_NETLIFY_SITE_ID\"` or equivalent" },
+    { check: "Sets `STRIPE_SECRET_KEY` via `netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret`" },
+    { check: "States that `STRIPE_SECRET_KEY` is the skill's convention and not an automatically read Stripe SDK default" },
+    { check: "Shows explicit SDK wiring such as `new Stripe(Netlify.env.get(\"STRIPE_SECRET_KEY\"))` in a Netlify Function or equivalent language-specific configuration" },
+    { check: "Does NOT use `process.env.STRIPE_SECRET_KEY` as the preferred Netlify Function access pattern" },
+    { check: "Does NOT commit the secret to `.env`, `netlify.toml`, or source code" },
+  ],
+  variants: withSkillVariants(),
+} satisfies ScenarioInput;

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -43,6 +43,9 @@ Read `$netlify-identity` for Netlify Identity setup, OAuth, role-based access, a
 **Deploying a site to Netlify?**
 Read `$netlify-deploy` for the full deployment workflow — authentication, site linking, preview and production deploys.
 
+**Bootstrapping a new project that takes payments?**
+Read `$netlify-payments` for provisioning a Stripe sandbox + Netlify site through the Stripe Projects CLI and wiring the test-mode secret. New projects only — for adding Stripe to an existing project, use general Stripe knowledge plus `netlify-functions` and `netlify-cli-and-deploy`.
+
 ## General Rules
 
 - Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)

--- a/codex/skills/netlify-payments/SKILL.md
+++ b/codex/skills/netlify-payments/SKILL.md
@@ -193,7 +193,7 @@ netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
 
 Two things to get right:
 
-- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
 ### 9. Build, draft deploy, then promote to prod

--- a/codex/skills/netlify-payments/SKILL.md
+++ b/codex/skills/netlify-payments/SKILL.md
@@ -30,7 +30,7 @@ The user is starting a **new** web project AND the prompt mentions a payment fea
 - No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
 - The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
 
-The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration. For existing apps, hand off to direct Stripe integration guidance; if webhooks are involved, explicitly include webhook signature verification and a separate `STRIPE_WEBHOOK_SECRET`.
 
 ## Defaults baked into this skill
 
@@ -208,7 +208,7 @@ Run the project's build (e.g. `npm run build`) if it has one.
 netlify deploy
 ```
 
-No `--prod`. Capture the draft URL from the output and surface it to the user.
+No `--prod`. Capture the draft URL from the deploy output, surface it to the user, and make that URL the thing they inspect during the checkpoint.
 
 #### 9B. User checkpoint
 
@@ -217,11 +217,11 @@ Tell the user, plainly, that this is the moment to:
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
+Then stop. Ask for explicit confirmation to promote. Do not run, print as part of a copy-paste command list, or otherwise recommend `netlify deploy --prod` until the user confirms that the draft URL, dashboard-only setup, and test-mode Stripe flow are approved.
 
 #### 9C. Promote to prod
 
-When the user confirms, run:
+Keep this as a withheld next step until the user confirms. After confirmation only, run:
 
 ```bash
 netlify deploy --prod

--- a/codex/skills/netlify-payments/SKILL.md
+++ b/codex/skills/netlify-payments/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: netlify-payments
+description: Bootstrap a new web project that takes payments by provisioning a Stripe sandbox and a Netlify site through the Stripe Projects CLI, then wiring the Stripe test-mode secret into the Netlify environment. Use when starting a new web project with any payment feature — checkout, subscriptions, credits, billing, paywall, tip jar, marketplace, monetization, "buy"/"sell" — or when the user explicitly names Stripe. Skip when the project already exists, no payment is involved, or the user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.).
+---
+
+# Netlify Payments
+
+Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
+
+- Pre-flight checks for the Stripe and Netlify CLIs
+- Initializing a Stripe project and adding the `netlify/project` service
+- Pulling the Stripe test-mode key out of the local Stripe config
+- Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
+- Triggering the first deploy
+
+It does **not** own the application itself. Stack choice (framework, language, package manager), function patterns, database, blob storage, identity, and Stripe API patterns (Checkout sessions, webhooks, signature verification) all live in other skills or general Stripe knowledge — see "Hand off to other skills" below.
+
+## Activate this skill when
+
+The user is starting a **new** web project AND the prompt mentions a payment feature. Strong signals:
+
+- Direct: payments, checkout, subscriptions, billing, paywall, tip jar
+- Commerce: "buy", "sell", "monetize", storefront, marketplace, e-commerce
+- Usage models: credits, tokens, paid generations, usage-based billing
+- Explicit Stripe mention
+
+## Skip this skill when
+
+- The project already exists ("add payments to my repo", "wire up Stripe in my app").
+- No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
+- The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
+
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+
+## Defaults baked into this skill
+
+These are decided. Don't re-ask the user.
+
+- **Stripe** is the payment provider.
+- **Stripe Projects CLI** is the provisioning entry point — not the Stripe Dashboard, not manual API key wiring.
+- **Netlify** is the host (this skill is Netlify-only).
+- **Sandbox / test mode** for v1. Production keys and the live-mode flow are out of scope here.
+
+For everything else (framework, language, package manager, database, etc.), defer to the relevant Netlify skill or follow the user's explicit choice.
+
+## UX expectations
+
+A few patterns matter throughout this workflow because the alternative is a user staring at a stalled terminal or an unexpected permission prompt:
+
+- **Announce intent before installing software or running an interactive flow.** A line like "I need the Stripe CLI for this — installing now via Homebrew" is enough. The harness may surface a permission prompt anyway, but the user shouldn't be surprised by *what* is being installed.
+- **Don't try to script around browser flows.** `stripe login`, `netlify login`, and first-time `stripe projects init` all open browsers and require user action. Surface what the user needs to do, then wait for confirmation.
+- **Narrate during multi-second commands.** `stripe projects add netlify/project`, `netlify deploy`, and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+
+## Clarify before bootstrapping
+
+This skill provisions real infrastructure (a Stripe project, a Netlify site, env vars). Before doing that, make sure you understand the project well enough to do it once. A short clarifying exchange now saves a full rewrite later — the alternative is shipping the wrong auth model or the wrong payment shape and ripping it out on the second pass.
+
+Ask only the questions whose answers aren't already in the user's prompt. Two to four targeted questions, not an interview. Cover, for payment-taking projects:
+
+- **Payment shape.** Subscription (recurring), one-time purchase, credits/usage-based, marketplace/Connect? Each implies a different Checkout / Subscription / Connect flow downstream.
+- **Other primitives.** Does this project also need auth, dynamic data, file/asset storage? Each one pulls in another skill — **netlify-identity**, **netlify-database**, **netlify-blobs** — and shifts what the agent should do after this skill ends.
+- **Framework preference**, if the user has one. If not, defer the question until step 5.
+- **Project slug.** Default to a slug derived from the prompt (lowercase, hyphenated). Only ask if the prompt is genuinely ambiguous about the project subject.
+
+If the prompt already answered any of these — "build a tip jar with Stripe and Netlify Identity" answers payment shape and auth — don't re-ask. The point is to validate intent, not to gate on a checklist.
+
+After the user answers, proceed deterministically through the workflow. Don't loop back here.
+
+## Workflow
+
+### 1. Pre-flight: tools and auth
+
+#### Stripe CLI
+
+```bash
+stripe --version
+```
+
+If missing, announce intent and install for the user's platform — see the [Stripe CLI install instructions](https://docs.stripe.com/stripe-cli). On macOS that's typically `brew install stripe/stripe-cli/stripe`. Don't blindly run `brew` on a non-macOS system.
+
+#### Stripe authentication
+
+```bash
+stripe whoami
+```
+
+If not authenticated, ask the user to run `stripe login` themselves. This opens a browser and requires interaction — don't try to script around it. Wait for the user to confirm completion before continuing. Stripe CLI keys land in `~/.config/stripe/config.toml`; step 6 reads from there.
+
+#### Netlify CLI and authentication
+
+Use the **netlify-cli-and-deploy** skill for install and auth. Verify with `netlify --version` and `netlify status`. If either fails, follow that skill's guidance — don't restate it inline.
+
+### 2. Install the Stripe Projects plugin
+
+```bash
+stripe plugin install projects
+```
+
+Idempotent — safe to run when already installed. Announce intent before running.
+
+### 3. Initialize the Stripe project
+
+Derive the project slug from the user's prompt (lowercase, hyphenated). Ask only if the prompt is genuinely ambiguous about the project subject — for example, "build me a tip jar" gives no name; "build me Pawcasso, an art store" gives `pawcasso`.
+
+**Before running, surface the first-time KYC warning.** On a fresh Stripe account, `stripe projects init` opens a browser for one-time business verification (legal name, date of birth, MFA setup). The agent can't complete this step. If the user has already KYC'd on this account, the browser flow is skipped — no harm in warning preemptively.
+
+Suggested wording:
+
+> "If this is your first time using Stripe Projects on this account, a browser will open for a one-time business verification — legal name, date of birth, MFA. I'll wait for you to finish, then continue."
+
+Then run:
+
+```bash
+stripe projects init <project-slug>
+```
+
+Wait for the user to confirm the browser flow finished.
+
+After this command, Stripe auto-installs its own skill at `.agents/skills/stripe-projects-cli/SKILL.md`. That file is the authoritative reference for the broader `stripe projects` command surface (`catalog`, `env`, `link`, `rotate`, `status`, etc.) — read it for any command this workflow doesn't cover.
+
+### 4. Add the Netlify service
+
+```bash
+stripe projects add netlify/project
+```
+
+The service slug is **`netlify/project`**, not `netlify/hosting`. An older blog draft used the wrong slug; ignore it.
+
+The CLI may prompt for a Y/n confirmation on first link — answer `Y`, or run non-interactively with `--accept-tos --yes`.
+
+After this command, the local `.env` should contain `NETLIFY_NETLIFY_SITE_ID`. This is the only Stripe/Netlify variable Stripe Projects writes — no auth tokens, no Stripe keys. Verify it landed:
+
+```bash
+grep NETLIFY_NETLIFY_SITE_ID .env
+```
+
+If missing, run `stripe projects env --pull` to fetch it. If it's still missing, stop and surface the error — the rest of this workflow depends on it.
+
+#### Reconcile the linked Netlify account
+
+`stripe projects add netlify/project` uses the Stripe Projects CLI's *own* cached Netlify auth, which can be a different Netlify user than the one the local `netlify` CLI is signed in as. If the two accounts don't share team membership, the deploy in step 9 will fail with a confusing "access denied" — and by then the fix is much more expensive. Catch the mismatch now.
+
+Read the site's owning account, substituting the value from `.env`:
+
+```bash
+netlify api getSite --data='{"site_id":"<NETLIFY_NETLIFY_SITE_ID>"}'
+```
+
+Note `account_slug` and `account_name` from the response. Then read the local CLI's user and team list:
+
+```bash
+netlify status
+```
+
+If the site's `account_slug` isn't a team the local CLI user belongs to, **halt**. Don't try to resolve it automatically — there are two valid fixes and the user has to pick. Surface it like this:
+
+> "Stripe Projects linked the new Netlify site to team **<account_name>**, but your `netlify` CLI is signed in as **<email>**, which doesn't appear to belong to that team. Continuing here will fail at deploy time. Do you want to (a) re-sign the local `netlify` CLI as a user on that team, or (b) re-link Stripe Projects to your work Netlify account?"
+
+If the accounts match, continue.
+
+### 5. Build the application
+
+This skill stops here for the app code. Hand off to the relevant Netlify skills (see below) and general Stripe knowledge for Checkout sessions, webhooks, customer/subscription handling, etc.
+
+Once the app is buildable and you're ready to deploy, return to step 6.
+
+### 6. Pull the Stripe test-mode secret
+
+Stripe Projects does **not** auto-inject Stripe API keys. They live in `~/.config/stripe/config.toml`, populated by `stripe login`. Read them via the CLI:
+
+```bash
+stripe config --list
+```
+
+Look for `test_mode_api_key` — that's the test-mode secret key.
+
+The publishable key is only required if the app uses client-side Stripe.js / Elements. For server-side Checkout sessions (the v1 default), the secret key alone is enough — skip pushing the publishable key.
+
+### 7. Link the Netlify CLI to the provisioned site
+
+Source `.env` so `NETLIFY_NETLIFY_SITE_ID` is available in the shell, then link:
+
+```bash
+set -a; source .env; set +a
+netlify link --id "$NETLIFY_NETLIFY_SITE_ID"
+```
+
+### 8. Push the Stripe secret as a Netlify env var
+
+```bash
+netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
+```
+
+Two things to get right:
+
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
+
+### 9. Build, draft deploy, then promote to prod
+
+The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+
+- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
+- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
+
+This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
+
+#### Build
+
+Run the project's build (e.g. `npm run build`) if it has one.
+
+#### First deploy: draft
+
+```bash
+netlify deploy
+```
+
+No `--prod`. Capture the draft URL from the output and surface it to the user.
+
+#### Manual checkpoint
+
+Tell the user, plainly, that this is the moment to:
+
+- Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
+- Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
+
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+
+#### Promote to prod
+
+When the user confirms, run:
+
+```bash
+netlify deploy --prod
+```
+
+Capture the live URL from the output and surface it as the final result.
+
+For preview deploys, branch deploys, environment-context vars, and the rest of deploy mechanics, see **netlify-deploy** and **netlify-cli-and-deploy**.
+
+## Hand off to other skills
+
+This skill stops once the app is wired and deployed. For everything else, the agent uses other skills or general knowledge:
+
+| Concern | Where it lives |
+|---|---|
+| Framework choice and adapter setup | **netlify-frameworks** |
+| Serverless function patterns (Checkout handlers, webhook receivers) | **netlify-functions** |
+| Persisting orders, subscriptions, customer records | **netlify-database** |
+| User auth before checkout | **netlify-identity** |
+| File/asset storage (digital downloads, generated artifacts) | **netlify-blobs** |
+| Deploy mechanics, env vars, contexts | **netlify-deploy**, **netlify-cli-and-deploy** |
+| Stripe Projects CLI surface (`catalog`, `env`, `link`, `rotate`, etc.) | `.agents/skills/stripe-projects-cli/SKILL.md` (auto-installed by `stripe projects init`) |
+| Stripe API patterns — Checkout sessions, webhook signature verification, subscription billing, credit/usage models | General Stripe knowledge or Stripe's docs |
+
+Don't re-document these inside this skill.
+
+## Things to get right
+
+- **Service slug is `netlify/project`**, not `netlify/hosting`.
+- **"Sandbox" is test mode on the user's existing Stripe account**, not a separate account. The keys are just the `test_mode_*` ones.
+- **`stripe projects add netlify/project` writes only `NETLIFY_NETLIFY_SITE_ID`** to `.env`. No tokens, no Stripe keys. The agent has to pull the Stripe key separately from `stripe config --list`.
+- **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
+- **Server-side Checkout doesn't need the publishable key** — skip it for v1.
+- **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+
+## When pre-flight or install fails
+
+- **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
+- **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.
+- **`stripe projects add netlify/project` errors because KYC isn't complete**: re-prompt the user to finish the browser verification, then retry the command.

--- a/codex/skills/netlify-payments/SKILL.md
+++ b/codex/skills/netlify-payments/SKILL.md
@@ -7,7 +7,7 @@ description: Bootstrap a new web project that takes payments by provisioning a S
 
 Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
 
-- Pre-flight checks for the Stripe and Netlify CLIs
+- Tools and authentication setup for the Stripe and Netlify CLIs
 - Initializing a Stripe project and adding the `netlify/project` service
 - Pulling the Stripe test-mode key out of the local Stripe config
 - Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
@@ -68,7 +68,7 @@ After the user answers, proceed deterministically through the workflow. Don't lo
 
 ## Workflow
 
-### 1. Pre-flight: tools and auth
+### 1. Tools and auth setup
 
 #### Stripe CLI
 
@@ -196,20 +196,13 @@ Two things to get right:
 - **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
-### 9. Build, draft deploy, then promote to prod
+### 9. Build, draft deploy, checkpoint, then promote to prod
 
-The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+The bootstrap ends with a draft deploy first, a user checkpoint, then an explicit production promotion. Keep these as separate phases; don't treat production as an automatic continuation of the draft deploy.
 
-- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
-- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
-
-This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
-
-#### Build
+#### 9A. Build and create a draft deploy
 
 Run the project's build (e.g. `npm run build`) if it has one.
-
-#### First deploy: draft
 
 ```bash
 netlify deploy
@@ -217,16 +210,16 @@ netlify deploy
 
 No `--prod`. Capture the draft URL from the output and surface it to the user.
 
-#### Manual checkpoint
+#### 9B. User checkpoint
 
 Tell the user, plainly, that this is the moment to:
 
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
 
-#### Promote to prod
+#### 9C. Promote to prod
 
 When the user confirms, run:
 
@@ -263,8 +256,9 @@ Don't re-document these inside this skill.
 - **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
 - **Server-side Checkout doesn't need the publishable key** — skip it for v1.
 - **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+- **Draft before production.** Draft and preview deploys are free; production deploys count against billable build minutes. Dashboard-only setup, such as enabling Identity or external OAuth providers, also belongs between the draft deploy and production promotion.
 
-## When pre-flight or install fails
+## When setup or install fails
 
 - **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
 - **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.

--- a/cursor/rules/netlify-payments.mdc
+++ b/cursor/rules/netlify-payments.mdc
@@ -193,7 +193,7 @@ netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
 
 Two things to get right:
 
-- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
 ### 9. Build, draft deploy, then promote to prod

--- a/cursor/rules/netlify-payments.mdc
+++ b/cursor/rules/netlify-payments.mdc
@@ -7,7 +7,7 @@ alwaysApply: false
 
 Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
 
-- Pre-flight checks for the Stripe and Netlify CLIs
+- Tools and authentication setup for the Stripe and Netlify CLIs
 - Initializing a Stripe project and adding the `netlify/project` service
 - Pulling the Stripe test-mode key out of the local Stripe config
 - Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
@@ -68,7 +68,7 @@ After the user answers, proceed deterministically through the workflow. Don't lo
 
 ## Workflow
 
-### 1. Pre-flight: tools and auth
+### 1. Tools and auth setup
 
 #### Stripe CLI
 
@@ -193,23 +193,16 @@ netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
 
 Two things to get right:
 
-- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
-### 9. Build, draft deploy, then promote to prod
+### 9. Build, draft deploy, checkpoint, then promote to prod
 
-The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+The bootstrap ends with a draft deploy first, a user checkpoint, then an explicit production promotion. Keep these as separate phases; don't treat production as an automatic continuation of the draft deploy.
 
-- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
-- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
-
-This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
-
-#### Build
+#### 9A. Build and create a draft deploy
 
 Run the project's build (e.g. `npm run build`) if it has one.
-
-#### First deploy: draft
 
 ```bash
 netlify deploy
@@ -217,16 +210,16 @@ netlify deploy
 
 No `--prod`. Capture the draft URL from the output and surface it to the user.
 
-#### Manual checkpoint
+#### 9B. User checkpoint
 
 Tell the user, plainly, that this is the moment to:
 
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
 
-#### Promote to prod
+#### 9C. Promote to prod
 
 When the user confirms, run:
 
@@ -263,8 +256,9 @@ Don't re-document these inside this skill.
 - **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
 - **Server-side Checkout doesn't need the publishable key** — skip it for v1.
 - **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+- **Draft before production.** Draft and preview deploys are free; production deploys count against billable build minutes. Dashboard-only setup, such as enabling Identity or external OAuth providers, also belongs between the draft deploy and production promotion.
 
-## When pre-flight or install fails
+## When setup or install fails
 
 - **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
 - **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.

--- a/cursor/rules/netlify-payments.mdc
+++ b/cursor/rules/netlify-payments.mdc
@@ -30,7 +30,7 @@ The user is starting a **new** web project AND the prompt mentions a payment fea
 - No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
 - The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
 
-The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration. For existing apps, hand off to direct Stripe integration guidance; if webhooks are involved, explicitly include webhook signature verification and a separate `STRIPE_WEBHOOK_SECRET`.
 
 ## Defaults baked into this skill
 
@@ -208,7 +208,7 @@ Run the project's build (e.g. `npm run build`) if it has one.
 netlify deploy
 ```
 
-No `--prod`. Capture the draft URL from the output and surface it to the user.
+No `--prod`. Capture the draft URL from the deploy output, surface it to the user, and make that URL the thing they inspect during the checkpoint.
 
 #### 9B. User checkpoint
 
@@ -217,11 +217,11 @@ Tell the user, plainly, that this is the moment to:
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
+Then stop. Ask for explicit confirmation to promote. Do not run, print as part of a copy-paste command list, or otherwise recommend `netlify deploy --prod` until the user confirms that the draft URL, dashboard-only setup, and test-mode Stripe flow are approved.
 
 #### 9C. Promote to prod
 
-When the user confirms, run:
+Keep this as a withheld next step until the user confirms. After confirmation only, run:
 
 ```bash
 netlify deploy --prod

--- a/cursor/rules/netlify-payments.mdc
+++ b/cursor/rules/netlify-payments.mdc
@@ -1,0 +1,204 @@
+---
+description: Bootstrap a new web project that takes payments by provisioning a Stripe sandbox and a Netlify site through the Stripe Projects CLI, then wiring the Stripe test-mode secret into the Netlify environment. Use when starting a new web project with any payment feature — checkout, subscriptions, credits, billing, paywall, tip jar, marketplace, monetization, "buy"/"sell" — or when the user explicitly names Stripe. Skip when the project already exists, no payment is involved, or the user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.).
+alwaysApply: false
+---
+
+# Netlify Payments
+
+Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
+
+- Pre-flight checks for the Stripe and Netlify CLIs
+- Initializing a Stripe project and adding the `netlify/project` service
+- Pulling the Stripe test-mode key out of the local Stripe config
+- Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
+- Triggering the first deploy
+
+It does **not** own the application itself. Stack choice (framework, language, package manager), function patterns, database, blob storage, identity, and Stripe API patterns (Checkout sessions, webhooks, signature verification) all live in other skills or general Stripe knowledge — see "Hand off to other skills" below.
+
+## Activate this skill when
+
+The user is starting a **new** web project AND the prompt mentions a payment feature. Strong signals:
+
+- Direct: payments, checkout, subscriptions, billing, paywall, tip jar
+- Commerce: "buy", "sell", "monetize", storefront, marketplace, e-commerce
+- Usage models: credits, tokens, paid generations, usage-based billing
+- Explicit Stripe mention
+
+## Skip this skill when
+
+- The project already exists ("add payments to my repo", "wire up Stripe in my app").
+- No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
+- The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
+
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+
+## Defaults baked into this skill
+
+These are decided. Don't re-ask the user.
+
+- **Stripe** is the payment provider.
+- **Stripe Projects CLI** is the provisioning entry point — not the Stripe Dashboard, not manual API key wiring.
+- **Netlify** is the host (this skill is Netlify-only).
+- **Sandbox / test mode** for v1. Production keys and the live-mode flow are out of scope here.
+
+For everything else (framework, language, package manager, database, etc.), defer to the relevant Netlify skill or follow the user's explicit choice.
+
+## UX expectations
+
+A few patterns matter throughout this workflow because the alternative is a user staring at a stalled terminal or an unexpected permission prompt:
+
+- **Announce intent before installing software or running an interactive flow.** A line like "I need the Stripe CLI for this — installing now via Homebrew" is enough. The harness may surface a permission prompt anyway, but the user shouldn't be surprised by *what* is being installed.
+- **Don't try to script around browser flows.** `stripe login`, `netlify login`, and first-time `stripe projects init` all open browsers and require user action. Surface what the user needs to do, then wait for confirmation.
+- **Narrate during multi-second commands.** `stripe projects add netlify/project` and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+
+## Workflow
+
+### 1. Pre-flight: tools and auth
+
+#### Stripe CLI
+
+```bash
+stripe --version
+```
+
+If missing, announce intent and install for the user's platform — see the [Stripe CLI install instructions](https://docs.stripe.com/stripe-cli). On macOS that's typically `brew install stripe/stripe-cli/stripe`. Don't blindly run `brew` on a non-macOS system.
+
+#### Stripe authentication
+
+```bash
+stripe whoami
+```
+
+If not authenticated, ask the user to run `stripe login` themselves. This opens a browser and requires interaction — don't try to script around it. Wait for the user to confirm completion before continuing. Stripe CLI keys land in `~/.config/stripe/config.toml`; step 6 reads from there.
+
+#### Netlify CLI and authentication
+
+Use the **netlify-cli-and-deploy** skill for install and auth. Verify with `netlify --version` and `netlify status`. If either fails, follow that skill's guidance — don't restate it inline.
+
+### 2. Install the Stripe Projects plugin
+
+```bash
+stripe plugin install projects
+```
+
+Idempotent — safe to run when already installed. Announce intent before running.
+
+### 3. Initialize the Stripe project
+
+Derive the project slug from the user's prompt (lowercase, hyphenated). Ask only if the prompt is genuinely ambiguous about the project subject — for example, "build me a tip jar" gives no name; "build me Pawcasso, an art store" gives `pawcasso`.
+
+**Before running, surface the first-time KYC warning.** On a fresh Stripe account, `stripe projects init` opens a browser for one-time business verification (legal name, date of birth, MFA setup). The agent can't complete this step. If the user has already KYC'd on this account, the browser flow is skipped — no harm in warning preemptively.
+
+Suggested wording:
+
+> "If this is your first time using Stripe Projects on this account, a browser will open for a one-time business verification — legal name, date of birth, MFA. I'll wait for you to finish, then continue."
+
+Then run:
+
+```bash
+stripe projects init <project-slug>
+```
+
+Wait for the user to confirm the browser flow finished.
+
+After this command, Stripe auto-installs its own skill at `.agents/skills/stripe-projects-cli/SKILL.md`. That file is the authoritative reference for the broader `stripe projects` command surface (`catalog`, `env`, `link`, `rotate`, `status`, etc.) — read it for any command this workflow doesn't cover.
+
+### 4. Add the Netlify service
+
+```bash
+stripe projects add netlify/project
+```
+
+The service slug is **`netlify/project`**, not `netlify/hosting`. An older blog draft used the wrong slug; ignore it.
+
+The CLI may prompt for a Y/n confirmation on first link — answer `Y`, or run non-interactively with `--accept-tos --yes`.
+
+After this command, the local `.env` should contain `NETLIFY_NETLIFY_SITE_ID`. This is the only Stripe/Netlify variable Stripe Projects writes — no auth tokens, no Stripe keys. Verify it landed:
+
+```bash
+grep NETLIFY_NETLIFY_SITE_ID .env
+```
+
+If missing, run `stripe projects env --pull` to fetch it. If it's still missing, stop and surface the error — the rest of this workflow depends on it.
+
+### 5. Build the application
+
+This skill stops here for the app code. Hand off to the relevant Netlify skills (see below) and general Stripe knowledge for Checkout sessions, webhooks, customer/subscription handling, etc.
+
+Once the app is buildable and you're ready to deploy, return to step 6.
+
+### 6. Pull the Stripe test-mode secret
+
+Stripe Projects does **not** auto-inject Stripe API keys. They live in `~/.config/stripe/config.toml`, populated by `stripe login`. Read them via the CLI:
+
+```bash
+stripe config --list
+```
+
+Look for `test_mode_api_key` — that's the test-mode secret key.
+
+The publishable key is only required if the app uses client-side Stripe.js / Elements. For server-side Checkout sessions (the v1 default), the secret key alone is enough — skip pushing the publishable key.
+
+### 7. Link the Netlify CLI to the provisioned site
+
+Source `.env` so `NETLIFY_NETLIFY_SITE_ID` is available in the shell, then link:
+
+```bash
+set -a; source .env; set +a
+netlify link --id "$NETLIFY_NETLIFY_SITE_ID"
+```
+
+### 8. Push the Stripe secret as a Netlify env var
+
+```bash
+netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
+```
+
+Two things to get right:
+
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
+
+### 9. Build and deploy
+
+Run the project's build (e.g. `npm run build`) if it has one, then:
+
+```bash
+netlify deploy --prod
+```
+
+Capture the live URL from the output and surface it to the user as the final result. Use `--prod` rather than a draft — there's no preview to gate on for a fresh site, and the goal of the bootstrap is a working live URL.
+
+For preview deploys, branch deploys, environment-context vars, and the rest of deploy mechanics, see **netlify-deploy** and **netlify-cli-and-deploy**.
+
+## Hand off to other skills
+
+This skill stops once the app is wired and deployed. For everything else, the agent uses other skills or general knowledge:
+
+| Concern | Where it lives |
+|---|---|
+| Framework choice and adapter setup | **netlify-frameworks** |
+| Serverless function patterns (Checkout handlers, webhook receivers) | **netlify-functions** |
+| Persisting orders, subscriptions, customer records | **netlify-database** |
+| User auth before checkout | **netlify-identity** |
+| File/asset storage (digital downloads, generated artifacts) | **netlify-blobs** |
+| Deploy mechanics, env vars, contexts | **netlify-deploy**, **netlify-cli-and-deploy** |
+| Stripe Projects CLI surface (`catalog`, `env`, `link`, `rotate`, etc.) | `.agents/skills/stripe-projects-cli/SKILL.md` (auto-installed by `stripe projects init`) |
+| Stripe API patterns — Checkout sessions, webhook signature verification, subscription billing, credit/usage models | General Stripe knowledge or Stripe's docs |
+
+Don't re-document these inside this skill.
+
+## Things to get right
+
+- **Service slug is `netlify/project`**, not `netlify/hosting`.
+- **"Sandbox" is test mode on the user's existing Stripe account**, not a separate account. The keys are just the `test_mode_*` ones.
+- **`stripe projects add netlify/project` writes only `NETLIFY_NETLIFY_SITE_ID`** to `.env`. No tokens, no Stripe keys. The agent has to pull the Stripe key separately from `stripe config --list`.
+- **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
+- **Server-side Checkout doesn't need the publishable key** — skip it for v1.
+- **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+
+## When pre-flight or install fails
+
+- **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
+- **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.
+- **`stripe projects add netlify/project` errors because KYC isn't complete**: re-prompt the user to finish the browser verification, then retry the command.

--- a/cursor/rules/netlify-payments.mdc
+++ b/cursor/rules/netlify-payments.mdc
@@ -49,7 +49,22 @@ A few patterns matter throughout this workflow because the alternative is a user
 
 - **Announce intent before installing software or running an interactive flow.** A line like "I need the Stripe CLI for this — installing now via Homebrew" is enough. The harness may surface a permission prompt anyway, but the user shouldn't be surprised by *what* is being installed.
 - **Don't try to script around browser flows.** `stripe login`, `netlify login`, and first-time `stripe projects init` all open browsers and require user action. Surface what the user needs to do, then wait for confirmation.
-- **Narrate during multi-second commands.** `stripe projects add netlify/project` and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+- **Narrate during multi-second commands.** `stripe projects add netlify/project`, `netlify deploy`, and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+
+## Clarify before bootstrapping
+
+This skill provisions real infrastructure (a Stripe project, a Netlify site, env vars). Before doing that, make sure you understand the project well enough to do it once. A short clarifying exchange now saves a full rewrite later — the alternative is shipping the wrong auth model or the wrong payment shape and ripping it out on the second pass.
+
+Ask only the questions whose answers aren't already in the user's prompt. Two to four targeted questions, not an interview. Cover, for payment-taking projects:
+
+- **Payment shape.** Subscription (recurring), one-time purchase, credits/usage-based, marketplace/Connect? Each implies a different Checkout / Subscription / Connect flow downstream.
+- **Other primitives.** Does this project also need auth, dynamic data, file/asset storage? Each one pulls in another skill — **netlify-identity**, **netlify-database**, **netlify-blobs** — and shifts what the agent should do after this skill ends.
+- **Framework preference**, if the user has one. If not, defer the question until step 5.
+- **Project slug.** Default to a slug derived from the prompt (lowercase, hyphenated). Only ask if the prompt is genuinely ambiguous about the project subject.
+
+If the prompt already answered any of these — "build a tip jar with Stripe and Netlify Identity" answers payment shape and auth — don't re-ask. The point is to validate intent, not to gate on a checklist.
+
+After the user answers, proceed deterministically through the workflow. Don't loop back here.
 
 ## Workflow
 
@@ -121,6 +136,28 @@ grep NETLIFY_NETLIFY_SITE_ID .env
 
 If missing, run `stripe projects env --pull` to fetch it. If it's still missing, stop and surface the error — the rest of this workflow depends on it.
 
+#### Reconcile the linked Netlify account
+
+`stripe projects add netlify/project` uses the Stripe Projects CLI's *own* cached Netlify auth, which can be a different Netlify user than the one the local `netlify` CLI is signed in as. If the two accounts don't share team membership, the deploy in step 9 will fail with a confusing "access denied" — and by then the fix is much more expensive. Catch the mismatch now.
+
+Read the site's owning account, substituting the value from `.env`:
+
+```bash
+netlify api getSite --data='{"site_id":"<NETLIFY_NETLIFY_SITE_ID>"}'
+```
+
+Note `account_slug` and `account_name` from the response. Then read the local CLI's user and team list:
+
+```bash
+netlify status
+```
+
+If the site's `account_slug` isn't a team the local CLI user belongs to, **halt**. Don't try to resolve it automatically — there are two valid fixes and the user has to pick. Surface it like this:
+
+> "Stripe Projects linked the new Netlify site to team **<account_name>**, but your `netlify` CLI is signed in as **<email>**, which doesn't appear to belong to that team. Continuing here will fail at deploy time. Do you want to (a) re-sign the local `netlify` CLI as a user on that team, or (b) re-link Stripe Projects to your work Netlify account?"
+
+If the accounts match, continue.
+
 ### 5. Build the application
 
 This skill stops here for the app code. Hand off to the relevant Netlify skills (see below) and general Stripe knowledge for Checkout sessions, webhooks, customer/subscription handling, etc.
@@ -159,15 +196,45 @@ Two things to get right:
 - **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
-### 9. Build and deploy
+### 9. Build, draft deploy, then promote to prod
 
-Run the project's build (e.g. `npm run build`) if it has one, then:
+The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+
+- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
+- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
+
+This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
+
+#### Build
+
+Run the project's build (e.g. `npm run build`) if it has one.
+
+#### First deploy: draft
+
+```bash
+netlify deploy
+```
+
+No `--prod`. Capture the draft URL from the output and surface it to the user.
+
+#### Manual checkpoint
+
+Tell the user, plainly, that this is the moment to:
+
+- Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
+- Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
+
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+
+#### Promote to prod
+
+When the user confirms, run:
 
 ```bash
 netlify deploy --prod
 ```
 
-Capture the live URL from the output and surface it to the user as the final result. Use `--prod` rather than a draft — there's no preview to gate on for a fresh site, and the goal of the bootstrap is a working live URL.
+Capture the live URL from the output and surface it as the final result.
 
 For preview deploys, branch deploys, environment-context vars, and the rest of deploy mechanics, see **netlify-deploy** and **netlify-cli-and-deploy**.
 

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -47,6 +47,9 @@ Read `netlify-identity/SKILL.md` for Netlify Identity setup, OAuth, role-based a
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.
 
+**Bootstrapping a new project that takes payments?**
+Read `netlify-payments/SKILL.md` for provisioning a Stripe sandbox + Netlify site through the Stripe Projects CLI and wiring the test-mode secret. New projects only — for adding Stripe to an existing project, use general Stripe knowledge plus `netlify-functions` and `netlify-cli-and-deploy`.
+
 ## General Rules
 
 - Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -43,6 +43,9 @@ Read `netlify-identity/SKILL.md` for Netlify Identity setup, OAuth, role-based a
 **Deploying a site to Netlify?**
 Read `netlify-deploy/SKILL.md` for the full deployment workflow — authentication, site linking, preview and production deploys.
 
+**Bootstrapping a new project that takes payments?**
+Read `netlify-payments/SKILL.md` for provisioning a Stripe sandbox + Netlify site through the Stripe Projects CLI and wiring the test-mode secret. New projects only — for adding Stripe to an existing project, use general Stripe knowledge plus `netlify-functions` and `netlify-cli-and-deploy`.
+
 ## General Rules
 
 - Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)

--- a/skills/netlify-payments/SKILL.md
+++ b/skills/netlify-payments/SKILL.md
@@ -193,7 +193,7 @@ netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
 
 Two things to get right:
 
-- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
 ### 9. Build, draft deploy, then promote to prod

--- a/skills/netlify-payments/SKILL.md
+++ b/skills/netlify-payments/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: netlify-payments
+description: Bootstrap a new web project that takes payments by provisioning a Stripe sandbox and a Netlify site through the Stripe Projects CLI, then wiring the Stripe test-mode secret into the Netlify environment. Use when starting a new web project with any payment feature — checkout, subscriptions, credits, billing, paywall, tip jar, marketplace, monetization, "buy"/"sell" — or when the user explicitly names Stripe. Skip when the project already exists, no payment is involved, or the user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.).
+---
+
+# Netlify Payments
+
+Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
+
+- Pre-flight checks for the Stripe and Netlify CLIs
+- Initializing a Stripe project and adding the `netlify/project` service
+- Pulling the Stripe test-mode key out of the local Stripe config
+- Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
+- Triggering the first deploy
+
+It does **not** own the application itself. Stack choice (framework, language, package manager), function patterns, database, blob storage, identity, and Stripe API patterns (Checkout sessions, webhooks, signature verification) all live in other skills or general Stripe knowledge — see "Hand off to other skills" below.
+
+## Activate this skill when
+
+The user is starting a **new** web project AND the prompt mentions a payment feature. Strong signals:
+
+- Direct: payments, checkout, subscriptions, billing, paywall, tip jar
+- Commerce: "buy", "sell", "monetize", storefront, marketplace, e-commerce
+- Usage models: credits, tokens, paid generations, usage-based billing
+- Explicit Stripe mention
+
+## Skip this skill when
+
+- The project already exists ("add payments to my repo", "wire up Stripe in my app").
+- No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
+- The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
+
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+
+## Defaults baked into this skill
+
+These are decided. Don't re-ask the user.
+
+- **Stripe** is the payment provider.
+- **Stripe Projects CLI** is the provisioning entry point — not the Stripe Dashboard, not manual API key wiring.
+- **Netlify** is the host (this skill is Netlify-only).
+- **Sandbox / test mode** for v1. Production keys and the live-mode flow are out of scope here.
+
+For everything else (framework, language, package manager, database, etc.), defer to the relevant Netlify skill or follow the user's explicit choice.
+
+## UX expectations
+
+A few patterns matter throughout this workflow because the alternative is a user staring at a stalled terminal or an unexpected permission prompt:
+
+- **Announce intent before installing software or running an interactive flow.** A line like "I need the Stripe CLI for this — installing now via Homebrew" is enough. The harness may surface a permission prompt anyway, but the user shouldn't be surprised by *what* is being installed.
+- **Don't try to script around browser flows.** `stripe login`, `netlify login`, and first-time `stripe projects init` all open browsers and require user action. Surface what the user needs to do, then wait for confirmation.
+- **Narrate during multi-second commands.** `stripe projects add netlify/project` and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+
+## Workflow
+
+### 1. Pre-flight: tools and auth
+
+#### Stripe CLI
+
+```bash
+stripe --version
+```
+
+If missing, announce intent and install for the user's platform — see the [Stripe CLI install instructions](https://docs.stripe.com/stripe-cli). On macOS that's typically `brew install stripe/stripe-cli/stripe`. Don't blindly run `brew` on a non-macOS system.
+
+#### Stripe authentication
+
+```bash
+stripe whoami
+```
+
+If not authenticated, ask the user to run `stripe login` themselves. This opens a browser and requires interaction — don't try to script around it. Wait for the user to confirm completion before continuing. Stripe CLI keys land in `~/.config/stripe/config.toml`; step 6 reads from there.
+
+#### Netlify CLI and authentication
+
+Use the **netlify-cli-and-deploy** skill for install and auth. Verify with `netlify --version` and `netlify status`. If either fails, follow that skill's guidance — don't restate it inline.
+
+### 2. Install the Stripe Projects plugin
+
+```bash
+stripe plugin install projects
+```
+
+Idempotent — safe to run when already installed. Announce intent before running.
+
+### 3. Initialize the Stripe project
+
+Derive the project slug from the user's prompt (lowercase, hyphenated). Ask only if the prompt is genuinely ambiguous about the project subject — for example, "build me a tip jar" gives no name; "build me Pawcasso, an art store" gives `pawcasso`.
+
+**Before running, surface the first-time KYC warning.** On a fresh Stripe account, `stripe projects init` opens a browser for one-time business verification (legal name, date of birth, MFA setup). The agent can't complete this step. If the user has already KYC'd on this account, the browser flow is skipped — no harm in warning preemptively.
+
+Suggested wording:
+
+> "If this is your first time using Stripe Projects on this account, a browser will open for a one-time business verification — legal name, date of birth, MFA. I'll wait for you to finish, then continue."
+
+Then run:
+
+```bash
+stripe projects init <project-slug>
+```
+
+Wait for the user to confirm the browser flow finished.
+
+After this command, Stripe auto-installs its own skill at `.agents/skills/stripe-projects-cli/SKILL.md`. That file is the authoritative reference for the broader `stripe projects` command surface (`catalog`, `env`, `link`, `rotate`, `status`, etc.) — read it for any command this workflow doesn't cover.
+
+### 4. Add the Netlify service
+
+```bash
+stripe projects add netlify/project
+```
+
+The service slug is **`netlify/project`**, not `netlify/hosting`. An older blog draft used the wrong slug; ignore it.
+
+The CLI may prompt for a Y/n confirmation on first link — answer `Y`, or run non-interactively with `--accept-tos --yes`.
+
+After this command, the local `.env` should contain `NETLIFY_NETLIFY_SITE_ID`. This is the only Stripe/Netlify variable Stripe Projects writes — no auth tokens, no Stripe keys. Verify it landed:
+
+```bash
+grep NETLIFY_NETLIFY_SITE_ID .env
+```
+
+If missing, run `stripe projects env --pull` to fetch it. If it's still missing, stop and surface the error — the rest of this workflow depends on it.
+
+### 5. Build the application
+
+This skill stops here for the app code. Hand off to the relevant Netlify skills (see below) and general Stripe knowledge for Checkout sessions, webhooks, customer/subscription handling, etc.
+
+Once the app is buildable and you're ready to deploy, return to step 6.
+
+### 6. Pull the Stripe test-mode secret
+
+Stripe Projects does **not** auto-inject Stripe API keys. They live in `~/.config/stripe/config.toml`, populated by `stripe login`. Read them via the CLI:
+
+```bash
+stripe config --list
+```
+
+Look for `test_mode_api_key` — that's the test-mode secret key.
+
+The publishable key is only required if the app uses client-side Stripe.js / Elements. For server-side Checkout sessions (the v1 default), the secret key alone is enough — skip pushing the publishable key.
+
+### 7. Link the Netlify CLI to the provisioned site
+
+Source `.env` so `NETLIFY_NETLIFY_SITE_ID` is available in the shell, then link:
+
+```bash
+set -a; source .env; set +a
+netlify link --id "$NETLIFY_NETLIFY_SITE_ID"
+```
+
+### 8. Push the Stripe secret as a Netlify env var
+
+```bash
+netlify env:set STRIPE_SECRET_KEY <test-mode-key> --secret
+```
+
+Two things to get right:
+
+- **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
+- **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
+
+### 9. Build and deploy
+
+Run the project's build (e.g. `npm run build`) if it has one, then:
+
+```bash
+netlify deploy --prod
+```
+
+Capture the live URL from the output and surface it to the user as the final result. Use `--prod` rather than a draft — there's no preview to gate on for a fresh site, and the goal of the bootstrap is a working live URL.
+
+For preview deploys, branch deploys, environment-context vars, and the rest of deploy mechanics, see **netlify-deploy** and **netlify-cli-and-deploy**.
+
+## Hand off to other skills
+
+This skill stops once the app is wired and deployed. For everything else, the agent uses other skills or general knowledge:
+
+| Concern | Where it lives |
+|---|---|
+| Framework choice and adapter setup | **netlify-frameworks** |
+| Serverless function patterns (Checkout handlers, webhook receivers) | **netlify-functions** |
+| Persisting orders, subscriptions, customer records | **netlify-database** |
+| User auth before checkout | **netlify-identity** |
+| File/asset storage (digital downloads, generated artifacts) | **netlify-blobs** |
+| Deploy mechanics, env vars, contexts | **netlify-deploy**, **netlify-cli-and-deploy** |
+| Stripe Projects CLI surface (`catalog`, `env`, `link`, `rotate`, etc.) | `.agents/skills/stripe-projects-cli/SKILL.md` (auto-installed by `stripe projects init`) |
+| Stripe API patterns — Checkout sessions, webhook signature verification, subscription billing, credit/usage models | General Stripe knowledge or Stripe's docs |
+
+Don't re-document these inside this skill.
+
+## Things to get right
+
+- **Service slug is `netlify/project`**, not `netlify/hosting`.
+- **"Sandbox" is test mode on the user's existing Stripe account**, not a separate account. The keys are just the `test_mode_*` ones.
+- **`stripe projects add netlify/project` writes only `NETLIFY_NETLIFY_SITE_ID`** to `.env`. No tokens, no Stripe keys. The agent has to pull the Stripe key separately from `stripe config --list`.
+- **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
+- **Server-side Checkout doesn't need the publishable key** — skip it for v1.
+- **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+
+## When pre-flight or install fails
+
+- **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
+- **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.
+- **`stripe projects add netlify/project` errors because KYC isn't complete**: re-prompt the user to finish the browser verification, then retry the command.

--- a/skills/netlify-payments/SKILL.md
+++ b/skills/netlify-payments/SKILL.md
@@ -30,7 +30,7 @@ The user is starting a **new** web project AND the prompt mentions a payment fea
 - No payment language anywhere in the prompt — for example, "build me a SaaS" or "build me a personal site" with no monetization signal. "SaaS" alone is not enough; a payment feature has to be named.
 - The user named a different provider (PayPal, Lemon Squeezy, Paddle, Polar, etc.). Integrate that provider directly without redirecting through this skill.
 
-The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration.
+The borderline case is "add payments to a new app I'm starting right now" — both "add" and "new" appear. The deciding factor is whether anything has been built yet. If the project is undeployed and the payment integration is still wide open, this skill applies. If services are already wired up in an opinionated way, the user is better served by a direct integration. For existing apps, hand off to direct Stripe integration guidance; if webhooks are involved, explicitly include webhook signature verification and a separate `STRIPE_WEBHOOK_SECRET`.
 
 ## Defaults baked into this skill
 
@@ -208,7 +208,7 @@ Run the project's build (e.g. `npm run build`) if it has one.
 netlify deploy
 ```
 
-No `--prod`. Capture the draft URL from the output and surface it to the user.
+No `--prod`. Capture the draft URL from the deploy output, surface it to the user, and make that URL the thing they inspect during the checkpoint.
 
 #### 9B. User checkpoint
 
@@ -217,11 +217,11 @@ Tell the user, plainly, that this is the moment to:
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
+Then stop. Ask for explicit confirmation to promote. Do not run, print as part of a copy-paste command list, or otherwise recommend `netlify deploy --prod` until the user confirms that the draft URL, dashboard-only setup, and test-mode Stripe flow are approved.
 
 #### 9C. Promote to prod
 
-When the user confirms, run:
+Keep this as a withheld next step until the user confirms. After confirmation only, run:
 
 ```bash
 netlify deploy --prod

--- a/skills/netlify-payments/SKILL.md
+++ b/skills/netlify-payments/SKILL.md
@@ -7,7 +7,7 @@ description: Bootstrap a new web project that takes payments by provisioning a S
 
 Bootstrap a payment-taking project on Netlify by going through the Stripe Projects CLI. This skill owns the connective tissue:
 
-- Pre-flight checks for the Stripe and Netlify CLIs
+- Tools and authentication setup for the Stripe and Netlify CLIs
 - Initializing a Stripe project and adding the `netlify/project` service
 - Pulling the Stripe test-mode key out of the local Stripe config
 - Pushing the Stripe secret into the Netlify site environment as `STRIPE_SECRET_KEY`
@@ -68,7 +68,7 @@ After the user answers, proceed deterministically through the workflow. Don't lo
 
 ## Workflow
 
-### 1. Pre-flight: tools and auth
+### 1. Tools and auth setup
 
 #### Stripe CLI
 
@@ -196,20 +196,13 @@ Two things to get right:
 - **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. This is the convention Stripe's own examples use, so app code should read it explicitly — e.g., `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function. The Stripe SDK does not auto-read any env var; the name only matters for consistency with the code that reads it.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
-### 9. Build, draft deploy, then promote to prod
+### 9. Build, draft deploy, checkpoint, then promote to prod
 
-The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+The bootstrap ends with a draft deploy first, a user checkpoint, then an explicit production promotion. Keep these as separate phases; don't treat production as an automatic continuation of the draft deploy.
 
-- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
-- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
-
-This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
-
-#### Build
+#### 9A. Build and create a draft deploy
 
 Run the project's build (e.g. `npm run build`) if it has one.
-
-#### First deploy: draft
 
 ```bash
 netlify deploy
@@ -217,16 +210,16 @@ netlify deploy
 
 No `--prod`. Capture the draft URL from the output and surface it to the user.
 
-#### Manual checkpoint
+#### 9B. User checkpoint
 
 Tell the user, plainly, that this is the moment to:
 
 - Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
 - Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
 
-Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so.
 
-#### Promote to prod
+#### 9C. Promote to prod
 
 When the user confirms, run:
 
@@ -263,8 +256,9 @@ Don't re-document these inside this skill.
 - **Variable name `STRIPE_SECRET_KEY` and `--secret` flag** — both required. Reasoning above in step 8.
 - **Server-side Checkout doesn't need the publishable key** — skip it for v1.
 - **Don't try to script `stripe login`, `netlify login`, or first-time `stripe projects init`** — all three open browsers and require the user.
+- **Draft before production.** Draft and preview deploys are free; production deploys count against billable build minutes. Dashboard-only setup, such as enabling Identity or external OAuth providers, also belongs between the draft deploy and production promotion.
 
-## When pre-flight or install fails
+## When setup or install fails
 
 - **Non-macOS, no `brew`**: point the user at platform-specific install instructions for Stripe CLI (https://docs.stripe.com/stripe-cli) and Netlify CLI (https://docs.netlify.com/cli/get-started/). Don't guess at a package manager.
 - **`npm install -g netlify-cli` fails (permissions, etc.)**: fall back to `npx netlify-cli` for the rest of the workflow rather than blocking on the global install. Surface the install failure to the user.

--- a/skills/netlify-payments/SKILL.md
+++ b/skills/netlify-payments/SKILL.md
@@ -49,7 +49,22 @@ A few patterns matter throughout this workflow because the alternative is a user
 
 - **Announce intent before installing software or running an interactive flow.** A line like "I need the Stripe CLI for this — installing now via Homebrew" is enough. The harness may surface a permission prompt anyway, but the user shouldn't be surprised by *what* is being installed.
 - **Don't try to script around browser flows.** `stripe login`, `netlify login`, and first-time `stripe projects init` all open browsers and require user action. Surface what the user needs to do, then wait for confirmation.
-- **Narrate during multi-second commands.** `stripe projects add netlify/project` and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+- **Narrate during multi-second commands.** `stripe projects add netlify/project`, `netlify deploy`, and `netlify deploy --prod` aren't instant. Say what's running rather than going silent.
+
+## Clarify before bootstrapping
+
+This skill provisions real infrastructure (a Stripe project, a Netlify site, env vars). Before doing that, make sure you understand the project well enough to do it once. A short clarifying exchange now saves a full rewrite later — the alternative is shipping the wrong auth model or the wrong payment shape and ripping it out on the second pass.
+
+Ask only the questions whose answers aren't already in the user's prompt. Two to four targeted questions, not an interview. Cover, for payment-taking projects:
+
+- **Payment shape.** Subscription (recurring), one-time purchase, credits/usage-based, marketplace/Connect? Each implies a different Checkout / Subscription / Connect flow downstream.
+- **Other primitives.** Does this project also need auth, dynamic data, file/asset storage? Each one pulls in another skill — **netlify-identity**, **netlify-database**, **netlify-blobs** — and shifts what the agent should do after this skill ends.
+- **Framework preference**, if the user has one. If not, defer the question until step 5.
+- **Project slug.** Default to a slug derived from the prompt (lowercase, hyphenated). Only ask if the prompt is genuinely ambiguous about the project subject.
+
+If the prompt already answered any of these — "build a tip jar with Stripe and Netlify Identity" answers payment shape and auth — don't re-ask. The point is to validate intent, not to gate on a checklist.
+
+After the user answers, proceed deterministically through the workflow. Don't loop back here.
 
 ## Workflow
 
@@ -121,6 +136,28 @@ grep NETLIFY_NETLIFY_SITE_ID .env
 
 If missing, run `stripe projects env --pull` to fetch it. If it's still missing, stop and surface the error — the rest of this workflow depends on it.
 
+#### Reconcile the linked Netlify account
+
+`stripe projects add netlify/project` uses the Stripe Projects CLI's *own* cached Netlify auth, which can be a different Netlify user than the one the local `netlify` CLI is signed in as. If the two accounts don't share team membership, the deploy in step 9 will fail with a confusing "access denied" — and by then the fix is much more expensive. Catch the mismatch now.
+
+Read the site's owning account, substituting the value from `.env`:
+
+```bash
+netlify api getSite --data='{"site_id":"<NETLIFY_NETLIFY_SITE_ID>"}'
+```
+
+Note `account_slug` and `account_name` from the response. Then read the local CLI's user and team list:
+
+```bash
+netlify status
+```
+
+If the site's `account_slug` isn't a team the local CLI user belongs to, **halt**. Don't try to resolve it automatically — there are two valid fixes and the user has to pick. Surface it like this:
+
+> "Stripe Projects linked the new Netlify site to team **<account_name>**, but your `netlify` CLI is signed in as **<email>**, which doesn't appear to belong to that team. Continuing here will fail at deploy time. Do you want to (a) re-sign the local `netlify` CLI as a user on that team, or (b) re-link Stripe Projects to your work Netlify account?"
+
+If the accounts match, continue.
+
 ### 5. Build the application
 
 This skill stops here for the app code. Hand off to the relevant Netlify skills (see below) and general Stripe knowledge for Checkout sessions, webhooks, customer/subscription handling, etc.
@@ -159,15 +196,45 @@ Two things to get right:
 - **Variable name is `STRIPE_SECRET_KEY`.** Not `STRIPE_API_KEY` or anything else. The Stripe SDK reads this name by default — picking a different name means the app can't see it without extra wiring.
 - **Pass `--secret`.** This makes the value write-only after set, so it doesn't appear in deploy logs or the dashboard. Always use it for the secret key.
 
-### 9. Build and deploy
+### 9. Build, draft deploy, then promote to prod
 
-Run the project's build (e.g. `npm run build`) if it has one, then:
+The bootstrap ends with **two** deploys — a draft first, then a deliberate promotion to prod. There are two reasons for splitting them:
+
+- **Cost.** Draft and preview deploys are free; production deploys count against the user's billable build minutes. Burning a prod deploy on something that turns out to need another iteration is real money.
+- **Dashboard-only setup.** Some Netlify primitives can't finish configuration until the site exists, and they need clicks the agent can't make — enabling the Identity instance, toggling external OAuth providers, and so on. Those steps belong between the first deploy and the prod promotion, not after the site is already live.
+
+This is a deliberate human-in-the-loop checkpoint. Don't try to poll past it.
+
+#### Build
+
+Run the project's build (e.g. `npm run build`) if it has one.
+
+#### First deploy: draft
+
+```bash
+netlify deploy
+```
+
+No `--prod`. Capture the draft URL from the output and surface it to the user.
+
+#### Manual checkpoint
+
+Tell the user, plainly, that this is the moment to:
+
+- Complete any dashboard-only setup the project needs — enabling the Identity instance, configuring external OAuth providers, etc. If Identity is involved, point them at the **netlify-identity** skill's "Dashboard configuration" section.
+- Open the draft URL and verify the app works end-to-end, including the Stripe checkout flow against test-mode keys.
+
+Then **wait for explicit user confirmation** before promoting. Don't run `netlify deploy --prod` until they say so — promotion is a separate, deliberate step, not a continuation of the first deploy.
+
+#### Promote to prod
+
+When the user confirms, run:
 
 ```bash
 netlify deploy --prod
 ```
 
-Capture the live URL from the output and surface it to the user as the final result. Use `--prod` rather than a draft — there's no preview to gate on for a fresh site, and the goal of the bootstrap is a working live URL.
+Capture the live URL from the output and surface it as the final result.
 
 For preview deploys, branch deploys, environment-context vars, and the rest of deploy mechanics, see **netlify-deploy** and **netlify-cli-and-deploy**.
 


### PR DESCRIPTION
## What ships

A new `netlify-payments` skill at `skills/netlify-payments/SKILL.md` that bootstraps a payment-taking web project on Netlify by walking the agent through the Stripe Projects CLI. The generated Codex and Cursor copies are included, plus the router entry in `skills/CLAUDE.md` and a `.gitignore` rule to keep skill-creator eval workspaces out of git.

This PR also adds AXIS coverage for the skill under `axis-scenarios/payments/`, with scenarios for:

- New subscription bootstrap with auth
- One-time Checkout without auth
- Existing-app skip behavior
- Non-Stripe provider skip behavior
- Stripe sandbox/test-mode semantics
- Netlify account reconciliation after Stripe Projects linking
- Stripe secret extraction and SDK wiring
- Draft deploy → user checkpoint → production promotion
- Browser-flow boundaries for login/KYC
- Ambiguous project slug clarification

The skill owns the connective tissue:

- A short "Clarify before bootstrapping" prelude — payment shape, primitives, framework, slug — so the agent validates intent before provisioning anything.
- Tools and auth setup for the Stripe and Netlify CLIs.
- `stripe projects init <slug>` (with a first-time KYC warning) → `stripe projects add netlify/project`, plus a reconciliation step that catches Stripe-Projects-vs-local-CLI account mismatches before they bite at deploy time.
- Pulling the test-mode key from `~/.config/stripe/config.toml` via `stripe config --list`.
- `netlify env:set STRIPE_SECRET_KEY <key> --secret`.
- A draft-first deploy, a user checkpoint for dashboard-only setup (Identity, OAuth), then explicit production promotion via `netlify deploy --prod` only after confirmation.

It does **not** own app code, framework choice, or Stripe API patterns (Checkout sessions, webhooks, signature verification, credit/usage models). Those defer to the other Netlify skills and general Stripe knowledge — the skill ships with an explicit hand-off table. For existing apps, it skips the Stripe Projects bootstrap and points agents at direct Stripe integration guidance.

## Why

Stripe Projects is the right provisioning entry point for new Netlify+payments projects, but its surface has several gotchas an agent will get wrong without guidance:

- The service slug is **`netlify/project`**, not `netlify/hosting` (an older blog draft used the wrong slug).
- `stripe projects add netlify/project` writes **only** `NETLIFY_NETLIFY_SITE_ID` — Stripe API keys are not auto-injected. The agent has to pull them separately from local Stripe config.
- "Sandbox" in Stripe Projects is **test mode on the user's existing Stripe account**, not a separate account.
- `STRIPE_SECRET_KEY` is the naming convention this skill uses for the Stripe secret, but Stripe SDKs do **not** auto-read that env var. App code must explicitly pass it to the SDK, for example `new Stripe(Netlify.env.get("STRIPE_SECRET_KEY"))` in a Netlify Function.
- The secret must be set with `--secret` so it is write-only after set.
- First-time `stripe projects init` opens a browser for KYC. The agent can't complete it; the skill surfaces a warning and waits.
- Stripe Projects has its *own* cached Netlify auth, which can be a different user than the one the local `netlify` CLI is signed in as. Without a reconciliation check, the deploy fails with a confusing "access denied" much later in the workflow.
- Prod deploys are billable; draft deploys aren't. Dashboard-only setup (Identity instance, external OAuth providers) needs to happen *between* the first deploy and the prod promotion. So the bootstrap ends with draft → user checkpoint → explicit promotion, not one automatic prod deploy.

This skill encodes those facts so an agent can one-shot a payment-taking site without learning them the hard way.

## Updates from review + AXIS

After review feedback and AXIS runs, the skill now:

1. Uses "tools and auth setup" language instead of "pre-flight".
2. Makes production promotion a withheld next step: capture the draft URL, surface it to the user, stop for dashboard/end-to-end verification, and only then run `netlify deploy --prod` after explicit confirmation.
3. Clarifies that `STRIPE_SECRET_KEY` is a convention, not a Stripe SDK default.
4. Notes that existing-app webhook handoff should include signature verification and a separate `STRIPE_WEBHOOK_SECRET` when webhooks are involved.
5. Includes AXIS scenarios that compare no-context behavior against the full Netlify skill bundle with `netlify-payments` loaded.

## AXIS validation

Codex-only AXIS runs were used to tune the skill and scenarios:

```bash
./node_modules/.bin/axis run --scenario 'payments/*' --agent codex --concurrency 2
```

A representative run completed 10 scenarios / 20 variants with 0 failures. Loading the skill improved the with-skill cases substantially, especially around Stripe Projects bootstrap, sandbox semantics, browser-flow handling, account reconciliation, secret wiring, and draft-first deploy sequencing.

The report artifact can be attached separately to the PR as a zipped `.axis/reports/<report-id>/` directory.
