### PR TITLE
docs: drop migrations.prefix from drizzle.config examples

### DIFF
--- a/codex/skills/netlify-database/SKILL.md
+++ b/codex/skills/netlify-database/SKILL.md
@@ -141,11 +141,8 @@ export default defineConfig({
   dialect: "postgresql",
   schema: "./db/schema.ts",
   out: "netlify/database/migrations",
-  migrations: { prefix: "timestamp" },
 });
 ```
-
-**Default to `migrations: { prefix: "timestamp" }`.** Drizzle Kit's default sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique and order stable. If a project is already established on sequential prefixes, leave it alone, but expect collisions when working in parallel.
 
 ### Package scripts
 

--- a/codex/skills/netlify-database/references/migration-from-extension.md
+++ b/codex/skills/netlify-database/references/migration-from-extension.md
@@ -92,7 +92,6 @@ On a new branch:
       dialect: "postgresql",
       schema: "./db/schema.ts",
       out: "netlify/database/migrations",
-      migrations: { prefix: "timestamp" },
     });
     ```
 

--- a/codex/skills/netlify-database/references/migrations.md
+++ b/codex/skills/netlify-database/references/migrations.md
@@ -39,9 +39,9 @@ Migrations go in `netlify/database/migrations/`. Two layouts are supported and c
 - **Flat:** one `.sql` file per migration — `20260417143022_create_items.sql`
 - **Subdirectory:** a folder containing `migration.sql` — `20260417143022_create_items/migration.sql` (this is what `netlify database migrations new` and Drizzle Kit's default layout produce)
 
-Files apply lexicographically. **Default to timestamp prefixes** — when no precedent exists in the repo, set `migrations: { prefix: "timestamp" }` in `drizzle.config.ts` and use the `--scheme timestamp` flag for `migrations new`. Sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique.
+Files apply lexicographically. Timestamp prefixes are the default for both `drizzle-kit generate` and `netlify database migrations new`, and they keep filenames unique when two pieces of work generate migrations in parallel — common on teams and for solo developers iterating across branches.
 
-If a project is already established on sequential prefixes, leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
+If a project is already established on sequential prefixes (`0000_`, `0001_`, …), leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
 
 ```
 netlify/database/migrations/

--- a/cursor/rules/netlify-database-migration-from-extension.mdc
+++ b/cursor/rules/netlify-database-migration-from-extension.mdc
@@ -96,7 +96,6 @@ On a new branch:
       dialect: "postgresql",
       schema: "./db/schema.ts",
       out: "netlify/database/migrations",
-      migrations: { prefix: "timestamp" },
     });
     ```
 

--- a/cursor/rules/netlify-database-migrations.mdc
+++ b/cursor/rules/netlify-database-migrations.mdc
@@ -43,9 +43,9 @@ Migrations go in `netlify/database/migrations/`. Two layouts are supported and c
 - **Flat:** one `.sql` file per migration — `20260417143022_create_items.sql`
 - **Subdirectory:** a folder containing `migration.sql` — `20260417143022_create_items/migration.sql` (this is what `netlify database migrations new` and Drizzle Kit's default layout produce)
 
-Files apply lexicographically. **Default to timestamp prefixes** — when no precedent exists in the repo, set `migrations: { prefix: "timestamp" }` in `drizzle.config.ts` and use the `--scheme timestamp` flag for `migrations new`. Sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique.
+Files apply lexicographically. Timestamp prefixes are the default for both `drizzle-kit generate` and `netlify database migrations new`, and they keep filenames unique when two pieces of work generate migrations in parallel — common on teams and for solo developers iterating across branches.
 
-If a project is already established on sequential prefixes, leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
+If a project is already established on sequential prefixes (`0000_`, `0001_`, …), leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
 
 ```
 netlify/database/migrations/

--- a/cursor/rules/netlify-database.mdc
+++ b/cursor/rules/netlify-database.mdc
@@ -141,11 +141,8 @@ export default defineConfig({
   dialect: "postgresql",
   schema: "./db/schema.ts",
   out: "netlify/database/migrations",
-  migrations: { prefix: "timestamp" },
 });
 ```
-
-**Default to `migrations: { prefix: "timestamp" }`.** Drizzle Kit's default sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique and order stable. If a project is already established on sequential prefixes, leave it alone, but expect collisions when working in parallel.
 
 ### Package scripts
 

--- a/skills/netlify-database/SKILL.md
+++ b/skills/netlify-database/SKILL.md
@@ -141,11 +141,8 @@ export default defineConfig({
   dialect: "postgresql",
   schema: "./db/schema.ts",
   out: "netlify/database/migrations",
-  migrations: { prefix: "timestamp" },
 });
 ```
-
-**Default to `migrations: { prefix: "timestamp" }`.** Drizzle Kit's default sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique and order stable. If a project is already established on sequential prefixes, leave it alone, but expect collisions when working in parallel.
 
 ### Package scripts
 

--- a/skills/netlify-database/references/migration-from-extension.md
+++ b/skills/netlify-database/references/migration-from-extension.md
@@ -92,7 +92,6 @@ On a new branch:
       dialect: "postgresql",
       schema: "./db/schema.ts",
       out: "netlify/database/migrations",
-      migrations: { prefix: "timestamp" },
     });
     ```
 

--- a/skills/netlify-database/references/migrations.md
+++ b/skills/netlify-database/references/migrations.md
@@ -39,9 +39,9 @@ Migrations go in `netlify/database/migrations/`. Two layouts are supported and c
 - **Flat:** one `.sql` file per migration — `20260417143022_create_items.sql`
 - **Subdirectory:** a folder containing `migration.sql` — `20260417143022_create_items/migration.sql` (this is what `netlify database migrations new` and Drizzle Kit's default layout produce)
 
-Files apply lexicographically. **Default to timestamp prefixes** — when no precedent exists in the repo, set `migrations: { prefix: "timestamp" }` in `drizzle.config.ts` and use the `--scheme timestamp` flag for `migrations new`. Sequential indices (`0000_`, `0001_`, …) collide whenever two pieces of work generate migrations in parallel — this happens to teams and to solo developers iterating on multiple branches. Timestamp prefixes keep filenames unique.
+Files apply lexicographically. Timestamp prefixes are the default for both `drizzle-kit generate` and `netlify database migrations new`, and they keep filenames unique when two pieces of work generate migrations in parallel — common on teams and for solo developers iterating across branches.
 
-If a project is already established on sequential prefixes, leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
+If a project is already established on sequential prefixes (`0000_`, `0001_`, …), leave it alone — the CLI's `migrations new` auto-detects the scheme — but expect collisions when working in parallel and resolve them by reset + regenerate.
 
 ```
 netlify/database/migrations/


### PR DESCRIPTION
## Summary

- Removes `migrations: { prefix: "timestamp" }` from both `drizzle.config.ts` examples in `skills/netlify-database/` (`SKILL.md` and `references/migration-from-extension.md`).
- Reworks the surrounding guidance in `references/migrations.md` to note that timestamp prefixes are now the default for both `drizzle-kit generate` and `netlify database migrations new`, so no explicit config is required.
- Drops the "Default to `migrations: { prefix: "timestamp" }`" callout in `SKILL.md` since the recommendation is no longer actionable — the default already does the right thing.

## Why

The skill was telling users to set a config that's no longer needed; copy-pasting the example added a line that's now redundant. Sequential-vs-timestamp framing is preserved where it still matters (recognizing existing projects on sequential prefixes), just no longer phrased as something the user has to opt into.