### PR TITLE
fix: drop conflicting skills array from marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,23 +7,7 @@
     {
       "name": "netlify-skills",
       "description": "Netlify platform skills — functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
-      "source": "./",
-      "strict": false,
-      "skills": [
-        "./skills/netlify-functions",
-        "./skills/netlify-edge-functions",
-        "./skills/netlify-blobs",
-        "./skills/netlify-db",
-        "./skills/netlify-image-cdn",
-        "./skills/netlify-forms",
-        "./skills/netlify-frameworks",
-        "./skills/netlify-caching",
-        "./skills/netlify-config",
-        "./skills/netlify-cli-and-deploy",
-        "./skills/netlify-deploy",
-        "./skills/netlify-ai-gateway",
-        "./skills/netlify-identity"
-      ]
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
Closes #27.

## Summary
- Removed the explicit `skills` array (and now-irrelevant `strict: false`) from the `netlify-skills` entry in `.claude-plugin/marketplace.json`, leaving `"source": "./"` to drive folder-based auto-discovery.
- Fixes the `/doctor` "conflicting manifests" warning caused by both the marketplace entry and auto-discovery declaring components.
- Eliminates the latent `./skills/netlify-db` vs. actual `skills/netlify-database` mismatch, which would have silently dropped the database skill if anyone ever set `strict: true`.
- Side benefit: future skill additions no longer require a marketplace.json edit.

## Verification
- `jq .` parses the updated `.claude-plugin/marketplace.json` cleanly (valid JSON).
- `ls skills/` confirms 13 skill folders, each with a `SKILL.md`, so auto-discovery will surface the same 13 skills the explicit array declared:
  - netlify-ai-gateway, netlify-blobs, netlify-caching, netlify-cli-and-deploy, netlify-config, netlify-database, netlify-deploy, netlify-edge-functions, netlify-forms, netlify-frameworks, netlify-functions, netlify-identity, netlify-image-cdn.
- The previously-typoed `netlify-db` path is gone; the real folder (`netlify-database`) is picked up by auto-discovery.