### PR TITLE
fix(ci): unblock Codex auto-rebuild from protected main

### DIFF
--- a/.github/workflows/build-codex-skills.yml
+++ b/.github/workflows/build-codex-skills.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - "skills/**"
       - "scripts/build-codex-skills.sh"
+      - ".github/workflows/build-codex-skills.yml"
   pull_request:
     paths:
       - "skills/**"
       - "scripts/build-codex-skills.sh"
+      - ".github/workflows/build-codex-skills.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/build-codex-skills.yml
+++ b/.github/workflows/build-codex-skills.yml
@@ -26,7 +26,7 @@ jobs:
         run: bash scripts/build-codex-skills.sh
 
       - name: Commit updated Codex skills
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/codex/skills/netlify-database/SKILL.md
+++ b/codex/skills/netlify-database/SKILL.md
@@ -46,7 +46,7 @@ This means:
 
 - Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
 - Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. The connection is read-only for a reason.
+- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
 - Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
 
 The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
@@ -131,24 +131,10 @@ The connection is configured automatically — no connection string needed. If y
 
 ### Drizzle Kit config
 
-Create `drizzle.config.ts` at the project root. The simplest form uses the `withNetlifyDB()` helper, which sets the `out` directory to `netlify/database/migrations` (where the deploy applies migrations from):
+Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
 
 ```typescript
 // drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-import { withNetlifyDB } from "@netlify/database/drizzle";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  ...withNetlifyDB(),
-  migrations: { prefix: "timestamp" },
-});
-```
-
-If you'd rather configure `out` manually:
-
-```typescript
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
@@ -339,7 +325,7 @@ netlify database connect --query "SELECT * FROM items LIMIT 10" --json
 netlify database connect --json
 ```
 
-The connection is read-only. **Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) or any mutating query through `netlify database connect`.** Schema changes go through migration files.
+**Never run DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) through `netlify database connect`, `psql`, or any other direct connection.** Schema changes go through migration files — out-of-band DDL drifts the migration history from the actual schema.
 
 ### `netlify database migrations new`
 
@@ -389,17 +375,6 @@ Wipes the local development database — drops all schemas and tables. Only affe
 netlify database reset
 ```
 
-### Customizing the migrations directory
-
-The default is `netlify/database/migrations`. To override, set `db.migrations.path` in `netlify.toml`:
-
-```toml
-[db.migrations]
-  path = "db/migrations"
-```
-
-The CLI commands and the deploy both honor the override.
-
 ## Iterating on migrations
 
 When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
@@ -414,9 +389,9 @@ When a migration you generated needs to change, what you do depends on whether i
 ## Common mistakes
 
 1. **Forgetting the `@beta` dist-tag.** `drizzle-orm` and `drizzle-kit` must be installed as `@beta`. The `latest` releases lack the `drizzle-orm/netlify-db` adapter.
-2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Use `withNetlifyDB()` from `@netlify/database/drizzle`, or set `out: "netlify/database/migrations"` manually.
+2. **Wrong migration output directory.** Drizzle Kit defaults to `drizzle/`. Set `out: "netlify/database/migrations"` in `drizzle.config.ts` — migrations outside that directory are not applied by the deploy.
 3. **Writing raw `CREATE TABLE` when using Drizzle.** The schema file is the source of truth. Define tables in `db/schema.ts` and generate migrations.
 4. **Running `drizzle-kit migrate` or `push` against a hosted DB.** Never. The deploy applies migrations. For local, use `netlify database migrations apply` instead.
-5. **Using `netlify database connect` to change schema.** Read-only only. Schema changes go through migrations.
+5. **Using `netlify database connect` to change schema.** Schema changes go through migration files — never DDL through `connect` or any direct connection.
 6. **Misunderstanding `netlify database migrations reset`.** It only deletes unapplied files. It cannot undo an applied migration — for that, roll forward with a new migration.
 7. **Assuming `netlify dev` applies migrations automatically.** It doesn't — only the deploy does. Run `netlify database migrations apply` locally yourself.

--- a/codex/skills/netlify-database/references/legacy-extension.md
+++ b/codex/skills/netlify-database/references/legacy-extension.md
@@ -12,7 +12,7 @@ These signals indicate the project is on the legacy extension, not the GA produc
 - `NETLIFY_DATABASE_URL` referenced in code or env files (note: different from the GA `NETLIFY_DB_URL`)
 - The Neon extension is installed under **Extensions** in the Netlify UI
 
-The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (and its `netlify database init` alias) now sets up Netlify Database (the GA product). If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
+The legacy extension was historically set up via `netlify db init` on older versions of the CLI. That command is gone in the current CLI — `netlify db init` (the short alias for `netlify database init`) now sets up Netlify Database (the GA product), not the extension. If a project shows the signals above, it was created on an older CLI version, not by anything reachable today.
 
 ## Keeping an extension project working
 
@@ -41,5 +41,6 @@ Common hallucinations to avoid:
 - Using `@netlify/neon` with `NETLIFY_DB_URL` (wrong env var)
 - Telling a user to "claim" their Netlify Database into a Neon account — that step only existed in the extension flow and is not part of Netlify Database (GA)
 - Recommending `netlify db init` to a legacy-extension user expecting it to reinstall the extension — the current CLI's `db init` sets up the GA product, not the extension
+- Assuming `netlify db <command>` still targets the extension. It's the short alias for `netlify database <command>` and runs the GA product.
 
 When in doubt, check `package.json` and the env vars actually set on the site before suggesting commands.

--- a/codex/skills/netlify-database/references/migration-from-extension.md
+++ b/codex/skills/netlify-database/references/migration-from-extension.md
@@ -82,17 +82,16 @@ On a new branch:
 
     > **Not using Drizzle?** The same flow works with any Postgres-compatible driver — see the native-driver section in `SKILL.md`.
 
-2. Update Drizzle config to point at the GA migrations directory. Use the `withNetlifyDB()` helper, or set `out` manually:
+2. Update Drizzle config to point at the GA migrations directory:
 
     ```typescript
     // drizzle.config.ts
     import { defineConfig } from "drizzle-kit";
-    import { withNetlifyDB } from "@netlify/database/drizzle";
 
     export default defineConfig({
       dialect: "postgresql",
       schema: "./db/schema.ts",
-      ...withNetlifyDB(),
+      out: "netlify/database/migrations",
       migrations: { prefix: "timestamp" },
     });
     ```

--- a/codex/skills/netlify-database/references/migrations.md
+++ b/codex/skills/netlify-database/references/migrations.md
@@ -8,7 +8,7 @@ Prefer Drizzle Kit for generating migrations. Manual SQL migration files are an 
 
 The platform applies migrations to every Netlify-hosted database (preview branches and production) automatically on deploy. You never run `drizzle-kit migrate` against `NETLIFY_DB_URL` from a preview or production context. For local, use `netlify database migrations apply` — it targets the local development database only.
 
-`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: the connection is read-only, and schema changes out-of-band cause drift between the migration history and the actual database.
+`drizzle-kit push` is not used in this workflow at all — always generate a migration file and let the deploy apply it. And never run DDL through `netlify database connect`, `psql`, or any other direct connection: schema changes out-of-band cause drift between the migration history and the actual database.
 
 ## Schema migration workflow
 
@@ -49,8 +49,6 @@ netlify/database/migrations/
   20260418091500_add_items_is_active/
     migration.sql
 ```
-
-The migrations directory location can be overridden by setting `db.migrations.path` in `netlify.toml`.
 
 ## Iterating on a migration you haven't shipped yet
 


### PR DESCRIPTION
## Summary

- Codex workflow has been silently failing to land rebuilds on \`main\` since 2026-04-28 — the commit step only fires on \`push\` to \`main\`, but branch protection rejects direct pushes from \`github-actions[bot]\`.
- Last broken run: https://github.com/netlify/context-and-tools/actions/runs/25063270849 (\`Protected branch update failed for refs/heads/main\`).
- Fix mirrors the Cursor workflow: commit \`codex/\` updates (including \`AGENTS.md\`) on PR branches so they merge into \`main\` through the PR itself.

## Test plan

- [ ] This PR's own \`Build Codex skills\` run should commit a rebuild of \`codex/\` (including \`AGENTS.md\`) onto this branch — confirm the bot commit appears.
- [ ] After merge, the next skills-touching PR should auto-update \`codex/\` on its own branch.
- [ ] \`codex/AGENTS.md\` and \`codex/skills/\` reflect current \`skills/\` content after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)