### PR TITLE
docs: add GitHub Copilot CLI install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ git clone --depth 1 https://github.com/netlify/context-and-tools.git /tmp/netlif
 
 This gives you `codex/AGENTS.md` (the skill router) and `codex/skills/` with all Netlify skills. Codex discovers `AGENTS.md` automatically and activates skills by name using `$skill-name` syntax.
 
+### GitHub Copilot CLI
+
+Copy the pre-built `codex/` directory into your project root, then point Copilot CLI at it:
+
+```bash
+git clone --depth 1 https://github.com/netlify/context-and-tools.git /tmp/netlify-skills && \
+  cp -r /tmp/netlify-skills/codex . && \
+  rm -rf /tmp/netlify-skills
+```
+
+```bash
+export COPILOT_CUSTOM_INSTRUCTIONS_DIRS="$PWD/codex"
+```
+
+Copilot CLI reads `AGENTS.md` from any directory listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` and uses it as a router into the skill files under `codex/skills/`. Add the export to your shell profile to persist across sessions.
+
 ### Claude Code
 
 Add the marketplace and install the plugin:


### PR DESCRIPTION
Closes #19.

## Summary

- Adds a **GitHub Copilot CLI** section to the README, parallel to the existing **Codex CLI** section.
- Reuses the already-built `codex` directory rather than introducing a new build target — Copilot CLI also reads `AGENTS.md`, so the same artifact serves both tools.
- Install pattern: clone-and-copy (same command as Codex CLI), plus `export COPILOT_CUSTOM_INSTRUCTIONS_DIRS="$PWD/codex"` so Copilot picks up `codex/AGENTS.md` as a router.

## Caveat to verify

`codex/AGENTS.md` uses Codex-specific `$skill-name` token syntax. Codex resolves these tokens to filesystem paths; Copilot CLI doesn't have that mechanism, so it'll see them as descriptive prose. The router still tells Copilot which skills exist and what each covers — but it may need explicit prompting to load a specific `codex/skills/<name>/SKILL.md`. Worth confirming before we close the issue.
