### PR TITLE
fix: correct function logs CLI commands

### DIFF
--- a/codex/skills/netlify-deploy/references/cli-commands.md
+++ b/codex/skills/netlify-deploy/references/cli-commands.md
@@ -121,12 +121,23 @@ npx netlify functions:create FUNCTION_NAME
 ## Logs
 
 ```bash
-# Stream function logs
+# View recent logs from functions and edge functions (defaults to last 10m)
 npx netlify logs
 
-# View logs for specific function
-npx netlify logs:function FUNCTION_NAME
+# Stream logs in real time
+npx netlify logs --follow
+
+# Stream logs for a specific function
+npx netlify logs --source functions --function FUNCTION_NAME --follow
+
+# View historical logs for a specific function over a longer window
+npx netlify logs --source functions --function FUNCTION_NAME --since 24h
+
+# Include deploy logs alongside function logs
+npx netlify logs --source deploy --source functions --since 1h
 ```
+
+Sources accepted by `--source`: `functions`, `edge-functions`, `deploy`. When omitted, it defaults to `functions` and `edge-functions`. Run `netlify logs --help` for the full option list.
 
 ## Troubleshooting Commands
 

--- a/skills/netlify-deploy/references/cli-commands.md
+++ b/skills/netlify-deploy/references/cli-commands.md
@@ -121,12 +121,23 @@ npx netlify functions:create FUNCTION_NAME
 ## Logs
 
 ```bash
-# Stream function logs
+# View recent logs from functions and edge functions (defaults to last 10m)
 npx netlify logs
 
-# View logs for specific function
-npx netlify logs:function FUNCTION_NAME
+# Stream logs in real time
+npx netlify logs --follow
+
+# Stream logs for a specific function
+npx netlify logs --source functions --function FUNCTION_NAME --follow
+
+# View historical logs for a specific function over a longer window
+npx netlify logs --source functions --function FUNCTION_NAME --since 24h
+
+# Include deploy logs alongside function logs
+npx netlify logs --source deploy --source functions --since 1h
 ```
+
+Sources accepted by `--source`: `functions`, `edge-functions`, `deploy`. When omitted, it defaults to `functions` and `edge-functions`. Run `netlify logs --help` for the full option list.
 
 ## Troubleshooting Commands
 


### PR DESCRIPTION
## Summary
- `netlify logs:function FUNCTION_NAME` no longer exists in the CLI — confirmed via `netlify logs --help`.
- Plain `netlify logs` also doesn't stream by default; it shows the last 10m of historical logs unless `--follow` is passed.
- Replaces the stale snippet in `skills/netlify-deploy/references/cli-commands.md` with examples that reflect the current unified `netlify logs` command (`--source`, `--function`, `--follow`, `--since`).

The `netlify logs` mention in `skills/netlify-deploy/SKILL.md:223` is left as-is — it's still accurate since `--source` defaults to `functions` and `edge-functions`.

## Test plan
- [ ] Spot-check `npx netlify logs --help` output matches the documented flags
- [ ] Run one of the new example commands against a linked site to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)