### PR TITLE
WIP: feat: bundle MCP server and CLI slash commands in v2 netlify plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
   },
   "plugins": [
     {
-      "name": "netlify-skills",
-      "description": "Netlify platform skills — functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
+      "name": "netlify",
+      "description": "Netlify for Claude Code — platform skills (functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, deploy) + the Netlify MCP server (authenticated team/project/deploy introspection) + slash commands for the local-dev CLI surface (init, dev, db, logs, blobs, functions)",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,15 @@
 {
-  "name": "netlify-skills",
-  "version": "1.1.0",
-  "description": "Netlify platform skills for Claude Code",
+  "name": "netlify",
+  "version": "2.0.0",
+  "description": "Netlify for Claude Code — platform skills, the Netlify MCP server, and slash commands wrapping the local-dev CLI surface (init, dev, db, logs, blobs, functions)",
   "author": {
     "name": "Netlify"
   },
-  "repository": "https://github.com/netlify/context-and-tools"
+  "repository": "https://github.com/netlify/context-and-tools",
+  "mcpServers": {
+    "netlify": {
+      "command": "npx",
+      "args": ["-y", "@netlify/mcp"]
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -76,10 +76,24 @@ Add the marketplace and install the plugin:
 
 ```
 /plugin marketplace add netlify/context-and-tools
-/plugin install netlify-skills@netlify-context-and-tools
+/plugin install netlify@netlify-context-and-tools
 ```
 
-This installs all Netlify skills into Claude Code. The included `skills/CLAUDE.md` acts as a router — it tells the agent which skill to read based on what you're building.
+The `netlify` plugin bundles three layers so a fresh session is Netlify-aware end to end:
+
+- **Skills** — all Netlify platform references. The included `skills/CLAUDE.md` acts as a router that tells the agent which skill to read based on what you're building.
+- **MCP server** — the [`@netlify/mcp`](https://github.com/netlify/netlify-mcp) server, auto-launched via `npx`, giving the agent authenticated read access to your Netlify teams, projects, and deploys. It authenticates through the Netlify CLI's stored credentials (or set `NETLIFY_PERSONAL_ACCESS_TOKEN`).
+- **Slash commands** — wrappers for the local-dev CLI surface the MCP doesn't cover:
+  - `/netlify:init` — initialize a project and link it to a team/site
+  - `/netlify:dev` — start the local dev server with env + primitives wired
+  - `/netlify:db` — manage Netlify DB (status, create, branch)
+  - `/netlify:logs` — stream function / edge / deploy logs into context
+  - `/netlify:blobs` — read/write/list/delete the linked site's Blobs store
+  - `/netlify:functions` — scaffold and invoke functions locally
+
+**Prerequisites:** the [Netlify CLI](https://docs.netlify.com/cli/get-started/) (`npm i -g netlify-cli`) for the slash commands, and Node.js for the `npx`-launched MCP server. The slash commands are Claude Code only; the Cursor and Codex builds ship skills only.
+
+> Upgrading from the old `netlify-skills` plugin: the plugin was renamed to `netlify` in v2 (so commands namespace cleanly as `/netlify:*`). Remove the old one with `/plugin uninstall netlify-skills` before installing.
 
 ### Cursor
 

--- a/commands/blobs.md
+++ b/commands/blobs.md
@@ -1,0 +1,23 @@
+---
+description: Read/write/list/delete entries in the linked site's Netlify Blobs store
+argument-hint: "[list|get|set|delete] [store] [key] [value]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read
+---
+
+CRUD on the linked site's Netlify Blobs store via the `netlify blobs` CLI.
+
+Link status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+Requested operation + args (may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. Require a linked project (see status above); if not linked, run `/netlify:init` first.
+2. Run `netlify blobs --help` to confirm the subcommand shape for the installed CLI version, then map the request:
+   - `list [store]` → list keys in a store (or list stores)
+   - `get [store] [key]` → read a value
+   - `set [store] [key] [value]` → write a value
+   - `delete [store] [key]` → remove a key
+3. Execute the matched command and report the result. For `get` of large/binary values, summarize rather than dumping the full payload into the transcript.
+4. Treat blob contents as potentially sensitive — do not echo secrets. For the programmatic `@netlify/blobs` API (reading/writing from functions), point the user at the bundled `netlify-blobs` skill.

--- a/commands/db.md
+++ b/commands/db.md
@@ -1,0 +1,24 @@
+---
+description: Manage Netlify DB (managed Postgres) — status, create, branch
+argument-hint: "[status|create|branch|...] [args]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read, Glob
+---
+
+Drive Netlify DB (managed Postgres, powered by Neon) via the `netlify database` CLI.
+
+Link status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+Requested operation + args (may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. Require a linked project (see link status above). If not linked, run `/netlify:init` first.
+2. Map the request to the right `netlify database` subcommand:
+   - no args / `status` → show whether a database is provisioned and its connection details
+   - `create` → provision a database for the linked site (`netlify database create` / `netlify db init` per the installed CLI version — run `netlify database --help` to confirm subcommands before guessing)
+   - `branch` → create/list database branches
+3. Run `netlify database --help` first if you are unsure which subcommands the installed CLI version exposes, then execute the matched command.
+4. After provisioning, report the connection string location (usually injected as an env var on the linked site) and point to the bundled `netlify-db` skill for the Drizzle ORM + migrations workflow. Do **not** print raw secrets into the transcript.
+
+Note: the Netlify MCP server's `initialize-database` tool is currently a stub — the CLI is the real provisioning path, which is why this command wraps it.

--- a/commands/dev.md
+++ b/commands/dev.md
@@ -1,0 +1,21 @@
+---
+description: Start the Netlify dev server locally with env vars and primitives wired
+argument-hint: "[optional: extra flags, e.g. --port 8888]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read, Glob
+---
+
+Run the local Netlify dev server so functions, edge functions, redirects, and env vars behave like production.
+
+Link status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+Extra flags from the user (may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. If the status above shows the project is **not linked**, run `/netlify:init` first (or tell the user to) — `netlify dev` needs a linked site to inject the right environment variables.
+2. Detect the framework / dev command from the repo (package.json scripts, `netlify.toml` `[dev]` block, framework config). Let `netlify dev` auto-detect unless the repo clearly needs an explicit `--command` / `--targetPort`.
+3. Start the server **in the background** (it is long-running): `netlify dev $ARGUMENTS`. Capture the local URL it prints.
+4. Report the local URL, which port it bound, and that functions/edge functions/env are now wired. Note that injected env vars come from the linked site — point the user at the bundled `netlify-cli-and-deploy` skill if they need to manage them.
+
+Do not block the session waiting on the server; hand the URL back and keep it running.

--- a/commands/functions.md
+++ b/commands/functions.md
@@ -1,0 +1,21 @@
+---
+description: Scaffold, serve, and invoke Netlify Functions locally
+argument-hint: "[create|invoke] [function-name]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read, Glob, Write, Edit
+---
+
+Scaffold and exercise Netlify Functions using the `netlify functions` CLI.
+
+Link status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+Requested operation + args (may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. Map the request to the right `netlify functions` subcommand (run `netlify functions --help` to confirm for the installed CLI version):
+   - `create [name]` → scaffold a new function (`netlify functions:create`). Prefer the modern v2 function signature (`export default` + `Request`/`Response`, optional `config` export for path/schedule) — see the bundled `netlify-functions` skill. After scaffolding, show the generated file and explain the handler.
+   - `invoke [name]` → invoke a function locally (`netlify functions:invoke`). The local dev server (`/netlify:dev`) must be running for invoke to hit live code.
+   - no args → list existing functions and ask what to do.
+2. When creating a function that uses other primitives (Blobs, DB, env vars), wire them using the corresponding bundled skill rather than guessing the API.
+3. Report the function's local URL / route and how to invoke it. Remind the user that deploying it is a separate step (`netlify deploy` or a Git push to the linked site).

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,0 +1,22 @@
+---
+description: Initialize a Netlify project in this repo and link it to a team/site
+argument-hint: "[optional: team or site name]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read, Glob
+---
+
+Wire this local project to Netlify using the Netlify CLI.
+
+Current link/auth status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+User hint (team/site, may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. **Preflight.** If `netlify status` above shows the CLI is missing, tell the user to install it (`npm i -g netlify-cli`) or run via `npx netlify-cli`. If it shows the project is already linked, report the linked site/team and ask whether to re-link before proceeding.
+2. **Authenticate** if needed (`netlify login`). This opens a browser — surface that to the user rather than blocking silently.
+3. **Choose the target.** If the user named a team/site in the hint, prefer it. Otherwise list available teams (the bundled Netlify MCP `team` tools can introspect teams without leaving the session) and ask which to use.
+4. **Initialize / link.** For a new project use `netlify init`; for an existing Netlify site use `netlify link`. Pass the chosen team/site non-interactively where flags allow it, and explain any prompt the CLI raises.
+5. **Confirm.** Re-run `netlify status` and report the resulting site name, team, and admin URL.
+
+Prefer the Netlify MCP server for *reading* the user's Netlify world (teams, projects); use the CLI for the local link/scaffold that the MCP doesn't cover. See the bundled `netlify-cli-and-deploy` and `netlify-deploy` skills for command details.

--- a/commands/logs.md
+++ b/commands/logs.md
@@ -1,0 +1,23 @@
+---
+description: Stream Netlify logs (functions, edge functions, or deploys) into the session
+argument-hint: "[functions|edge|deploy] [function-name]"
+allowed-tools: Bash(netlify:*), Bash(npx netlify:*), Read
+---
+
+Tail Netlify logs for the linked site and surface them in context.
+
+Link status:
+!`netlify status 2>&1 || echo "not-linked-or-cli-missing"`
+
+What to tail (may be empty): "$ARGUMENTS"
+
+Do this:
+
+1. Require a linked project (see status above); if not linked, run `/netlify:init` first.
+2. Map the request to the right `netlify logs` subcommand:
+   - `functions` (or a function name) → `netlify logs:function [name]`
+   - `edge` → `netlify logs:edge-function`
+   - `deploy` / no args → `netlify logs:deploy` (build/deploy logs)
+   - Run `netlify logs --help` to confirm exact subcommands for the installed CLI version.
+3. Streaming log commands are long-running. Start them **in the background** and pull the captured output back into the analysis rather than blocking the session.
+4. Summarize what the logs show — errors, cold starts, status codes — instead of dumping raw lines. If the user is debugging a specific failure, correlate timestamps with the most recent deploy (the bundled Netlify MCP `deploy` tools can fetch deploy metadata).


### PR DESCRIPTION
## Summary: One Possible Route

The Claude Code plugin published from this repo currently bundles **skills only** — methodology the model loads into context. It has no runtime awareness of the user's Netlify world and cannot drive the local-development CLI commands that wire a project to Netlify's backend.

This PR is a **proof-of-concept v2** that bundles three layers so a fresh Claude Code session is Netlify-aware end to end:

- **Skills** — unchanged. Still auto-discovered from `skills/` with the `CLAUDE.md` router.
- **MCP server** — the [`@netlify/mcp`](https://github.com/netlify/netlify-mcp) server, auto-launched via `npx`, giving the agent authenticated read access to teams, projects, and deploys.
- **Slash commands** — thin wrappers over the local-dev CLI surface the MCP does not expose.

Together a fresh `claude` session in a fresh directory can go: understand the user's Netlify teams → init a project linked to one → scaffold a function → run it locally → deploy.

## What changed

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | Renamed `netlify-skills` → `netlify`, bumped to `2.0.0`, added inline `mcpServers` launching `npx -y @netlify/mcp` |
| `.claude-plugin/marketplace.json` | Updated the plugin entry name + description |
| `commands/` *(new)* | Six slash commands (see below) |
| `README.md` | Rewrote the Claude Code install section |

### Slash commands

| Command | Wraps |
|---|---|
| `/netlify:init` | Initialize a project and link it to a team/site |
| `/netlify:dev` | Start the local dev server with env + primitives wired |
| `/netlify:db` | Netlify DB operations (status, create, branch) |
| `/netlify:logs` | Stream function / edge / deploy logs into context |
| `/netlify:blobs` | Read/write/list/delete the linked site's Blobs store |
| `/netlify:functions` | Scaffold and invoke functions locally |

Each command is a **thin wrapper**, not a reimplementation: it preflights `netlify status`, runs `<cmd> --help` before assuming subcommand shapes (so it stays correct across CLI versions), defers *reads* to the MCP server and *methodology* to the bundled skills, and avoids printing secrets into the transcript.

## Design notes / open questions for review

- **Plugin rename (`netlify-skills` → `netlify`).** Done so commands namespace cleanly as `/netlify:*` rather than `/netlify-skills:*`. ⚠️ If this rename ships to the marketplace as-is it would orphan existing `netlify-skills` installs. The README adds an uninstall-old-first note, but the rename-vs-coexist tradeoff is a deliberate open question — happy to instead keep `netlify-skills` and add `netlify` as a second entry. **Scoped to the Claude Code plugin only**; the Cursor and Gemini distributions keep their existing names.
- **MCP config location.** Declared inline in `plugin.json` under `mcpServers`. A standalone `.mcp.json` at the plugin root is equivalent if preferred.
- **Auth.** The MCP server uses the Netlify CLI's stored credentials by default, or `NETLIFY_PERSONAL_ACCESS_TOKEN`.
- **Cursor / Codex builds are unaffected** — slash commands and MCP are Claude Code features. The `cursor/` and `codex/` generated outputs continue to ship skills only; no build-script changes needed.

## Prerequisites

- Netlify CLI (`npm i -g netlify-cli`) for the slash commands
- Node.js for the `npx`-launched MCP server

## Testing

No automated suite (skills/config repo). Validated:

- `plugin.json` and `marketplace.json` are well-formed JSON
- `@netlify/mcp` resolves on npm

Manual end-to-end check (recommended before un-drafting):

1. `/plugin marketplace add <local path or this branch>`
2. `/plugin install netlify@netlify-context-and-tools`
3. Confirm the six `/netlify:*` commands appear and the `netlify` MCP server connects
4. In a sample repo, run `/netlify:init` → `/netlify:dev` → `/netlify:functions create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)