### PR TITLE
Fix stale AXIS scenario criteria

### DIFF
--- a/axis-scenarios/ai-gateway/anthropic-chat.ts
+++ b/axis-scenarios/ai-gateway/anthropic-chat.ts
@@ -7,8 +7,8 @@ export default {
     "Create a Netlify function at netlify/functions/summarize.ts mounted at /api/summarize that accepts POST { text: string } and returns a one-paragraph summary from Claude. Use the @anthropic-ai/sdk package and route through Netlify's AI Gateway.",
   judge: [
     { check: "Installs and imports the `@anthropic-ai/sdk` package (not openai, not @google/genai, not raw fetch)" },
-    { check: "Passes `baseURL: Netlify.env.get('ANTHROPIC_BASE_URL')` to the Anthropic client constructor — the SDK does not auto-discover this env var" },
-    { check: "Does NOT read or set `ANTHROPIC_API_KEY` — the gateway injects a placeholder key automatically" },
+    { check: "Constructs the Anthropic client with NO custom `baseURL` and NO `apiKey` argument when using the official SDK — relies on the AI Gateway's auto-injected `ANTHROPIC_BASE_URL` and placeholder key" },
+    { check: "Does NOT read or set `ANTHROPIC_API_KEY` anywhere — setting it disables the gateway" },
     { check: "Uses `Netlify.env.get(...)` for any env var access, not `process.env`" },
     { check: "Calls `client.messages.create` with a Claude model from the gateway's curated list (e.g. 'claude-sonnet-4-5', 'claude-opus-4-5', 'claude-haiku-4-5')" },
     { check: "Reads the input text via `await req.json()` and includes it in the user message content" },

--- a/axis-scenarios/config/headers-and-edge.ts
+++ b/axis-scenarios/config/headers-and-edge.ts
@@ -8,7 +8,7 @@ export default {
   judge: [
     { check: "Adds a `[[headers]]` block with `for = '/assets/*'` and a `[headers.values]` table including `Cache-Control = 'public, max-age=31536000, immutable'` (or equivalent immutable long-lived header)" },
     { check: "Adds an `[[edge_functions]]` entry with `function = 'auth'` and `path = '/admin/*'`" },
-    { check: "Excludes the public subpath via `excluded_path = '/admin/public/*'` (string or array) on the same edge_functions entry" },
+    { check: "Excludes the public subpath via `excludedPath = '/admin/public/*'` (string or array) on the same edge_functions entry" },
     { check: "Does NOT try to attach the edge function via `[[redirects]]` or `[[headers]]` — edge function routing goes in `[[edge_functions]]`" },
     { check: "Does NOT add the same Cache-Control via a redirect rule with `to` — static file headers belong in `[[headers]]`" },
     { check: "Function name in the config matches the file basename ('auth' for `auth.ts`)" },


### PR DESCRIPTION
## Summary
- Update the edge-function config scenario to expect `excludedPath`, matching current Netlify docs for `[[edge_functions]]` declarations.
- Update the Anthropic AI Gateway scenario so official SDK auto-configuration passes instead of requiring a manual `baseURL` option.

## Research
- Edge Functions declarations docs list `excludedPath` as the path-exclusion property for both inline config and `netlify.toml`: https://docs.netlify.com/build/edge-functions/declarations/
- AI Gateway docs show official Anthropic SDK usage with `new Anthropic()` and note that no API key or base URL configuration is needed because the SDK picks up injected env vars: https://docs.netlify.com/build/ai-gateway/overview/#using-official-client-libraries

## Validation
- `git diff --check`