### PR TITLE
Fix skill-validator install on Linux CI runners

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "skills/**"
+      - ".github/workflows/validate-skills.yml"
 
 jobs:
   validate:

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -12,12 +12,22 @@ jobs:
       SKILL_VALIDATOR_VERSION: 1.5.6
       SKILL_VALIDATOR_SHA256: c97faee388056023c616e312927faffd07e028bcd76d799e42da612dad7972df
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install skill-validator
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSLo "$RUNNER_TEMP/skill-validator.tar.gz" "https://github.com/agent-ecosystem/skill-validator/releases/download/v${SKILL_VALIDATOR_VERSION}/skill-validator_${SKILL_VALIDATOR_VERSION}_linux_amd64.tar.gz"
+          curl --fail --silent --show-error --location \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-connrefused \
+            --retry-all-errors \
+            --connect-timeout 10 \
+            --max-time 300 \
+            --output "$RUNNER_TEMP/skill-validator.tar.gz" \
+            "https://github.com/agent-ecosystem/skill-validator/releases/download/v${SKILL_VALIDATOR_VERSION}/skill-validator_${SKILL_VALIDATOR_VERSION}_linux_amd64.tar.gz"
           echo "${SKILL_VALIDATOR_SHA256}  $RUNNER_TEMP/skill-validator.tar.gz" | sha256sum -c -
           tar -xzf "$RUNNER_TEMP/skill-validator.tar.gz" -C "$RUNNER_TEMP" skill-validator
           install -m 0755 "$RUNNER_TEMP/skill-validator" "$HOME/.local/bin/skill-validator"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -7,12 +7,21 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      SKILL_VALIDATOR_VERSION: 1.5.6
+      SKILL_VALIDATOR_SHA256: c97faee388056023c616e312927faffd07e028bcd76d799e42da612dad7972df
     steps:
       - uses: actions/checkout@v6
 
       - name: Install skill-validator
         run: |
-          brew install agent-ecosystem/tap/skill-validator
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSLo "$RUNNER_TEMP/skill-validator.tar.gz" "https://github.com/agent-ecosystem/skill-validator/releases/download/v${SKILL_VALIDATOR_VERSION}/skill-validator_${SKILL_VALIDATOR_VERSION}_linux_amd64.tar.gz"
+          echo "${SKILL_VALIDATOR_SHA256}  $RUNNER_TEMP/skill-validator.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/skill-validator.tar.gz" -C "$RUNNER_TEMP" skill-validator
+          install -m 0755 "$RUNNER_TEMP/skill-validator" "$HOME/.local/bin/skill-validator"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/skill-validator" --version
 
       - name: Validate skills
         run: |

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -26,5 +26,23 @@ jobs:
 
       - name: Validate skills
         run: |
-          skill-validator check --strict --emit-annotations skills/
-          skill-validator check --strict -o markdown skills/ >> "$GITHUB_STEP_SUMMARY"
+          run_with_retries() {
+            local attempt
+            local max_attempts=3
+
+            for attempt in $(seq 1 "$max_attempts"); do
+              if "$@"; then
+                return 0
+              fi
+
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "Attempt $attempt failed; retrying..." >&2
+                sleep $((attempt * 5))
+              fi
+            done
+
+            return 1
+          }
+
+          run_with_retries skill-validator check --strict --emit-annotations skills/
+          run_with_retries skill-validator check --strict -o markdown skills/ >> "$GITHUB_STEP_SUMMARY"

--- a/codex/skills/netlify-deploy/SKILL.md
+++ b/codex/skills/netlify-deploy/SKILL.md
@@ -226,7 +226,7 @@ For secrets and configuration:
 ## Reference
 
 - Netlify CLI Docs: https://docs.netlify.com/cli/get-started/
-- netlify.toml Reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- netlify.toml Reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 
 ## References
 

--- a/codex/skills/netlify-deploy/references/netlify-toml.md
+++ b/codex/skills/netlify-deploy/references/netlify-toml.md
@@ -255,5 +255,5 @@ npx netlify build --dry
 
 ## Resources
 
-- Full configuration reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- Full configuration reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 - Framework-specific guides: https://docs.netlify.com/frameworks/

--- a/cursor/rules/netlify-deploy-cli-commands.mdc
+++ b/cursor/rules/netlify-deploy-cli-commands.mdc
@@ -125,12 +125,23 @@ npx netlify functions:create FUNCTION_NAME
 ## Logs
 
 ```bash
-# Stream function logs
+# View recent logs from functions and edge functions (defaults to last 10m)
 npx netlify logs
 
-# View logs for specific function
-npx netlify logs:function FUNCTION_NAME
+# Stream logs in real time
+npx netlify logs --follow
+
+# Stream logs for a specific function
+npx netlify logs --source functions --function FUNCTION_NAME --follow
+
+# View historical logs for a specific function over a longer window
+npx netlify logs --source functions --function FUNCTION_NAME --since 24h
+
+# Include deploy logs alongside function logs
+npx netlify logs --source deploy --source functions --since 1h
 ```
+
+Sources accepted by `--source`: `functions`, `edge-functions`, `deploy`. When omitted, it defaults to `functions` and `edge-functions`. Run `netlify logs --help` for the full option list.
 
 ## Troubleshooting Commands
 

--- a/cursor/rules/netlify-deploy-netlify-toml.mdc
+++ b/cursor/rules/netlify-deploy-netlify-toml.mdc
@@ -259,5 +259,5 @@ npx netlify build --dry
 
 ## Resources
 
-- Full configuration reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- Full configuration reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 - Framework-specific guides: https://docs.netlify.com/frameworks/

--- a/cursor/rules/netlify-deploy.mdc
+++ b/cursor/rules/netlify-deploy.mdc
@@ -226,7 +226,7 @@ For secrets and configuration:
 ## Reference
 
 - Netlify CLI Docs: https://docs.netlify.com/cli/get-started/
-- netlify.toml Reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- netlify.toml Reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 
 ## References
 

--- a/skills/netlify-deploy/SKILL.md
+++ b/skills/netlify-deploy/SKILL.md
@@ -226,7 +226,7 @@ For secrets and configuration:
 ## Reference
 
 - Netlify CLI Docs: https://docs.netlify.com/cli/get-started/
-- netlify.toml Reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- netlify.toml Reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 
 ## References
 

--- a/skills/netlify-deploy/references/netlify-toml.md
+++ b/skills/netlify-deploy/references/netlify-toml.md
@@ -255,5 +255,5 @@ npx netlify build --dry
 
 ## Resources
 
-- Full configuration reference: https://docs.netlify.com/configure-builds/file-based-configuration/
+- Full configuration reference: https://docs.netlify.com/build/configure-builds/file-based-configuration/
 - Framework-specific guides: https://docs.netlify.com/frameworks/


### PR DESCRIPTION
## Summary
- replace Homebrew install with direct skill-validator Linux release download
- pin the validator version and verify the release archive checksum before installing
- keep the existing strict validation commands unchanged

## Test
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/validate-skills.yml'); puts 'yaml ok'"