### PR TITLE
feat: add Grok Build (xAI) plugin support

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "netlify-skills",
+  "version": "1.1.0",
+  "description": "Netlify platform skills — functions, edge functions, blobs, database, identity, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment",
+  "author": {
+    "name": "Netlify"
+  },
+  "repository": "https://github.com/netlify/context-and-tools"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This repository contains public Netlify skills — factual platform reference fo
 
 - `context/` — Steering guides (e.g., POWER.md for Kiro deployments)
 - `.claude-plugin/` — Plugin marketplace config for Claude Code installation
+- `.grok-plugin/` — Plugin manifest for Grok Build (same plugin format as Claude Code; hand-authored, not generated)
 - `skills/` — Netlify platform skills (source of truth for all agent formats)
 - `cursor/rules/` — Auto-generated Cursor `.mdc` rule files (do NOT edit directly)
 - `codex/` — Auto-generated Codex skills and `AGENTS.md` router (do NOT edit directly)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Public Netlify skills for AI coding agents. Each skill is a focused, factual ref
 | [netlify-functions](skills/netlify-functions/SKILL.md) | Serverless functions — modern syntax, routing, background/scheduled/streaming |
 | [netlify-edge-functions](skills/netlify-edge-functions/SKILL.md) | Edge compute — Deno runtime, middleware, geolocation |
 | [netlify-blobs](skills/netlify-blobs/SKILL.md) | Object storage — key-value and binary data |
-| [netlify-db](skills/netlify-db/SKILL.md) | Managed Postgres (Neon) with Drizzle ORM and migrations |
+| [netlify-database](skills/netlify-database/SKILL.md) | Managed Postgres (Neon) with Drizzle ORM and migrations |
 | [netlify-image-cdn](skills/netlify-image-cdn/SKILL.md) | Image transformation and optimization via CDN |
 | [netlify-forms](skills/netlify-forms/SKILL.md) | HTML form handling, AJAX submissions, spam filtering |
 | [netlify-config](skills/netlify-config/SKILL.md) | `netlify.toml` — redirects, headers, build settings, deploy contexts |
@@ -111,6 +111,12 @@ This copies `.mdc` rule files into `.cursor/rules/`, where Cursor automatically 
 </details>
 
 
+
+### Grok Build
+
+Netlify is listed in the [official xAI plugin marketplace](https://github.com/xai-org/plugin-marketplace). In Grok Build, open the extensions modal (`/plugins`) and use the **Marketplace** tab to find and install **netlify**.
+
+Grok Build uses the same plugin format as Claude Code, so it installs all Netlify skills directly from this repository — no separate build step or generated output. Marketplace sources live in `~/.grok/config.toml` under `[[marketplace.sources]]`; if the xAI marketplace isn't already configured, add it there. See the [xAI Skills, Plugins & Marketplaces docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) for details.
 
 ### Other AI agents
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,7 +5,7 @@
     "skills/netlify-functions",
     "skills/netlify-edge-functions",
     "skills/netlify-blobs",
-    "skills/netlify-db",
+    "skills/netlify-database",
     "skills/netlify-image-cdn",
     "skills/netlify-forms",
     "skills/netlify-frameworks",


### PR DESCRIPTION
Adds Grok Build (xAI) as a supported install target.

Grok Build uses the same plugin format as Claude Code, so this repo is installable as a Grok plugin with no new build step or generated output. Grok's index generator and installer read `.grok-plugin/plugin.json` (preferred), falling back to `.claude-plugin/`.

## Changes
- Add `.grok-plugin/plugin.json` manifest mirroring `.claude-plugin/` — having an explicit file makes future Grok-specific tweaks easy if the formats diverge.
- Document Grok Build install in the README (TUI Marketplace tab via `/plugins`).
- Note `.grok-plugin/` in CLAUDE.md repository structure.
- Fix stale `skills/netlify-db` → `skills/netlify-database` references in `gemini-extension.json` and the README skills table. The directory and the SKILL.md frontmatter `name` are both `netlify-database`; these two hand-authored references were left over from a rename.

## Follow-up
A separate PR to [`xai-org/plugin-marketplace`](https://github.com/xai-org/plugin-marketplace) will add the `netlify` catalog entry (remote `url` source), pinned to this repo's `main` HEAD once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)