### PR TITLE
feat: bundle the official Netlify MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "netlify": {
+      "command": "npx",
+      "args": ["-y", "@netlify/mcp"],
+      "note": "Official Netlify MCP server (stdio, requires Node 22+). Authenticates at runtime via your Netlify CLI login / OAuth; set NETLIFY_PERSONAL_ACCESS_TOKEN to override (never commit it). Lets the agent create and manage Netlify projects, deploys, and environment variables."
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This repository contains public Netlify skills — factual platform reference fo
 - `context/` — Steering guides (e.g., POWER.md for Kiro deployments)
 - `.claude-plugin/` — Plugin marketplace config for Claude Code installation
 - `.grok-plugin/` — Plugin manifest for Grok Build (same plugin format as Claude Code; hand-authored, not generated)
+- `.mcp.json` — Netlify MCP server config bundled with the Claude Code and Grok Build plugins (runs `npx @netlify/mcp`; authenticates at runtime)
 - `skills/` — Netlify platform skills (source of truth for all agent formats)
 - `cursor/rules/` — Auto-generated Cursor `.mdc` rule files (do NOT edit directly)
 - `codex/` — Auto-generated Codex skills and `AGENTS.md` router (do NOT edit directly)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Netlify is listed in the [official xAI plugin marketplace](https://github.com/xa
 
 Grok Build uses the same plugin format as Claude Code, so it installs all Netlify skills directly from this repository — no separate build step or generated output. Marketplace sources live in `~/.grok/config.toml` under `[[marketplace.sources]]`; if the xAI marketplace isn't already configured, add it there. See the [xAI Skills, Plugins & Marketplaces docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) for details.
 
+### Netlify MCP server
+
+The Claude Code and Grok Build plugins (and the Gemini CLI extension) also register the [official Netlify MCP server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/), giving the agent tools to create and manage Netlify projects, deploys, and environment variables — not just the reference skills.
+
+It runs locally via `npx -y @netlify/mcp` (requires Node 22+) and authenticates at runtime through your Netlify CLI login / OAuth, so there's no token to configure. The rules-based integrations (Cursor, Codex, Copilot) don't bundle the MCP server — add it to those clients manually using the [Netlify MCP docs](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/).
+
 ### Other AI agents
 
 Each `SKILL.md` file is a self-contained reference with YAML frontmatter (`name` and `description`) and markdown body. Feed them into any agent's context as needed.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -15,5 +15,11 @@
     "skills/netlify-deploy",
     "skills/netlify-ai-gateway",
     "skills/netlify-identity"
-  ]
+  ],
+  "mcpServers": {
+    "netlify": {
+      "command": "npx",
+      "args": ["-y", "@netlify/mcp"]
+    }
+  }
 }


### PR DESCRIPTION
Bundles the [official Netlify MCP server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/) with the plugin, so installs get **skills + actions** (create/manage projects, deploys, env vars) — matching the skills+MCP pattern of the Vercel and Cloudflare plugins in the xAI catalog.

## How it's wired
Every peer in the xAI marketplace declares its MCP server in a **root `.mcp.json`**, which is read by both the Claude Code and Grok Build plugin installers from a single source of truth. We follow that exactly:

```json
{
  "mcpServers": {
    "netlify": {
      "command": "npx",
      "args": ["-y", "@netlify/mcp"]
    }
  }
}
```

- **stdio** server (`npx -y @netlify/mcp`), like the chrome-devtools peer — requires Node 22+.
- **Auth at runtime** via Netlify CLI login / OAuth. No token is committed; `NETLIFY_PERSONAL_ACCESS_TOKEN` can override locally.
- Same server added to `gemini-extension.json` for parity.
- Cursor/Codex/Copilot (rules-based) are unchanged — they don't carry MCP config.

## Follow-up
The open xAI catalog PR ([xai-org/plugin-marketplace#17](https://github.com/xai-org/plugin-marketplace/pull/17)) will have its pinned SHA bumped to this commit once merged, so the regenerated `plugin-index.json` surfaces the `netlify` MCP server.