### PR TITLE
feat: use Netlify's hosted HTTP MCP server instead of stdio

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,9 @@
 {
   "mcpServers": {
     "netlify": {
-      "command": "npx",
-      "args": ["-y", "@netlify/mcp"],
-      "note": "Official Netlify MCP server (stdio, requires Node 22+). Authenticates at runtime via your Netlify CLI login / OAuth; set NETLIFY_PERSONAL_ACCESS_TOKEN to override (never commit it). Lets the agent create and manage Netlify projects, deploys, and environment variables."
+      "type": "http",
+      "url": "https://netlify-mcp.netlify.app/mcp",
+      "note": "Official Netlify MCP server (hosted, streamable HTTP). Authorizes via OAuth on first connection — the agent is prompted to sign in to Netlify; no token or local install required. Lets the agent create and manage Netlify projects, deploys, and environment variables."
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This repository contains public Netlify skills — factual platform reference fo
 - `context/` — Steering guides (e.g., POWER.md for Kiro deployments)
 - `.claude-plugin/` — Plugin marketplace config for Claude Code installation
 - `.grok-plugin/` — Plugin manifest for Grok Build (same plugin format as Claude Code; hand-authored, not generated)
-- `.mcp.json` — Netlify MCP server config bundled with the Claude Code and Grok Build plugins (runs `npx @netlify/mcp`; authenticates at runtime)
+- `.mcp.json` — Netlify MCP server config bundled with the Claude Code and Grok Build plugins (hosted HTTP endpoint; OAuth at runtime)
 - `skills/` — Netlify platform skills (source of truth for all agent formats)
 - `cursor/rules/` — Auto-generated Cursor `.mdc` rule files (do NOT edit directly)
 - `codex/` — Auto-generated Codex skills and `AGENTS.md` router (do NOT edit directly)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Grok Build uses the same plugin format as Claude Code, so it installs all Netlif
 
 The Claude Code and Grok Build plugins (and the Gemini CLI extension) also register the [official Netlify MCP server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/), giving the agent tools to create and manage Netlify projects, deploys, and environment variables — not just the reference skills.
 
-It runs locally via `npx -y @netlify/mcp` (requires Node 22+) and authenticates at runtime through your Netlify CLI login / OAuth, so there's no token to configure. The rules-based integrations (Cursor, Codex, Copilot) don't bundle the MCP server — add it to those clients manually using the [Netlify MCP docs](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/).
+It connects to Netlify's hosted server over HTTP (`https://netlify-mcp.netlify.app/mcp`) and authorizes via OAuth on first use — no token or local install required. The rules-based integrations (Cursor, Codex, Copilot) don't bundle the MCP server — add it to those clients manually using the [Netlify MCP docs](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/).
 
 ### Other AI agents
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -18,8 +18,7 @@
   ],
   "mcpServers": {
     "netlify": {
-      "command": "npx",
-      "args": ["-y", "@netlify/mcp"]
+      "httpUrl": "https://netlify-mcp.netlify.app/mcp"
     }
   }
 }


### PR DESCRIPTION
Switches the bundled Netlify MCP server from the local **stdio** package (`npx @netlify/mcp`) to Netlify's **hosted, OAuth-protected streamable-HTTP** endpoint.

```json
{ "mcpServers": { "netlify": { "type": "http", "url": "https://netlify-mcp.netlify.app/mcp" } } }
```

## Why
The hosted endpoint is a real, Netlify-operated MCP server (verified: returns the MCP OAuth `401 + www-authenticate` handshake, with `/.well-known/oauth-protected-resource/mcp` advertising `read`/`write`/`offline_access`/`claudeai` scopes — it's the server behind Netlify's claude.ai connector). HTTP is the better fit for a marketplace plugin:

- **No Node 22+ requirement and no `npx` spin-up** — the stdio package needed both.
- **OAuth on first connection** — no token to configure or risk committing.
- Matches the remote-server pattern of the Vercel/Cloudflare plugins.

## Changes
- `.mcp.json` (Claude Code + Grok): `type: "http"` + hosted `url`.
- `gemini-extension.json`: `httpUrl` (Gemini's streamable-HTTP field; `url` is SSE-only and would silently fail).
- README + CLAUDE.md updated to describe the hosted HTTP server.

## Follow-up
The catalog PR ([xai-org/plugin-marketplace#17](https://github.com/xai-org/plugin-marketplace/pull/17)) will get an additive SHA bump to this commit once merged, so the regenerated `plugin-index.json` shows the `netlify` server as `http`.