### PR TITLE
ci: stop committing generated cursor/codex output into PR branches

### DIFF
--- a/.github/workflows/build-codex-skills.yml
+++ b/.github/workflows/build-codex-skills.yml
@@ -27,8 +27,12 @@ jobs:
       - name: Build Codex skills from source
         run: bash scripts/build-codex-skills.sh
 
+      # Only commit regenerated output on push to main. On PRs the build still
+      # runs above (to catch a broken script), but committing here is skipped so
+      # generated files stay out of PR diffs and the cursor/codex jobs don't race
+      # to push to the contributor's branch.
       - name: Commit updated Codex skills
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build-cursor-rules.yml
+++ b/.github/workflows/build-cursor-rules.yml
@@ -25,8 +25,12 @@ jobs:
       - name: Build Cursor rules from skills
         run: bash scripts/build-cursor-rules.sh
 
+      # Only commit regenerated output on push to main. On PRs the build still
+      # runs above (to catch a broken script), but committing here is skipped so
+      # generated files stay out of PR diffs and the cursor/codex jobs don't race
+      # to push to the contributor's branch.
       - name: Commit updated Cursor rules
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

Both `build-cursor-rules.yml` and `build-codex-skills.yml` commit regenerated output back to the branch on **`pull_request`** events:

```yaml
if: github.event_name == 'push' || github.event_name == 'pull_request'
```

On any PR that touches `skills/**`, the bots push `cursor/rules/**` and `codex/**` commits onto the contributor's branch. That:

- **bloats every skills PR diff** with generated mirrors and pulls reviewers (e.g. CodeRabbit) onto generated files instead of the source;
- makes the **two jobs race** to push to the same branch (the "rerun the loser" flakiness);
- forces contributors to **pull before every push**.

This was surfaced in review on #58, where CodeRabbit commented on generated `codex/`/`cursor/` mirrors and flagged the churn.

## Change

Gate the **commit** step to `push` (main) only. The build still runs on PRs (so a broken `build-*.sh` is still caught), it just doesn't commit. Generated output is regenerated and committed when the change lands on `main` — which matches what the root `CLAUDE.md` already documents ("rebuilds these files whenever `skills/` changes on main").

## Effect

- PR diffs for skills changes are **source-only** (`skills/**`).
- No more cross-job push races on PR branches.
- `cursor/rules/**` and `codex/**` on `main` stay current via the push-to-main build.

Net: one-line condition change per workflow (plus an explanatory comment). No change to the build scripts or generated output format.