### PR TITLE
fix(axis): reconcile over-tested judge checks with skill facts (AX-104)

### DIFF
--- a/axis-scenarios/blobs/json-helpers.ts
+++ b/axis-scenarios/blobs/json-helpers.ts
@@ -7,7 +7,7 @@ export default {
     "At the end of each build we produce a single site-configuration snapshot — one JSON object with feature flags and theme settings — and we want to stash it in Netlify Blobs and read it back as a typed object at runtime. Use Netlify Blobs' JSON convenience helpers for the write and read.",
   judge: [
     { check: "Writes the snapshot with `store.setJSON(key, obj)` rather than manually `JSON.stringify`-ing into `store.set`" },
-    { check: "Reads it back as parsed JSON via `store.get(key, { type: 'json' })` (or a `getJSON` helper) — NOT a manual `JSON.parse(await store.get(key))`" },
+    { check: "Reads it back as parsed JSON via `store.get(key, { type: 'json' })` — NOT a manual `JSON.parse(await store.get(key))`" },
     { check: "Imports a store constructor from '@netlify/blobs' — either `getStore` or `getDeployStore` (deploy-scoped is a fine choice for a per-build snapshot)" },
     { check: "Treats this as a single stored JSON asset/snapshot — does NOT model it as a queryable record store or build per-record CRUD over Blobs as if it were a database (for relational/queryable data the right tool is Netlify Database)" },
   ],

--- a/axis-scenarios/caching/vary-by-country.ts
+++ b/axis-scenarios/caching/vary-by-country.ts
@@ -4,10 +4,10 @@ import { withSkillVariants } from "../helpers/variants";
 export default {
   name: "Caching: vary cached response by country",
   prompt:
-    "Create a Netlify function at netlify/functions/pricing.ts mounted at /api/pricing that returns regional pricing based on the visitor's country (from context.geo). The response should be cached on Netlify's CDN, but visitors from different countries should never see each other's cached entry.",
+    "Create a Netlify function at netlify/functions/pricing.ts mounted at /api/pricing that returns regional pricing for a fixed set of markets — the US, Germany, and Japan (everyone else gets default pricing) — based on the visitor's country (from context.geo). The response should be cached on Netlify's CDN, with a separate cached entry per those markets so visitors in different countries don't see each other's price.",
   judge: [
     { check: "Reads the country via `context.geo.country.code` (or equivalent on context.geo) — NOT from a request header parsed by hand" },
-    { check: "Sets `Netlify-Vary: country` on the Response so the CDN keys the cache entry by country" },
+    { check: "Sets a `Netlify-Vary: country=...` header enumerating the target country codes (e.g. `country=us|de|jp`, lowercase ISO codes) so the CDN keys a separate cache entry per listed country — NOT a bare `Netlify-Vary: country`" },
     { check: "Sets a CDN cache header (`Netlify-CDN-Cache-Control` or `CDN-Cache-Control`) with a non-zero `s-maxage` so the response is actually cached at the edge" },
     { check: "Does NOT use `Vary: cookie` / a per-user cookie value to split the cache — that would fragment per-visitor and is not what was asked" },
     { check: "Does NOT rely on the function's region/location to choose pricing — uses the visitor's country as derived from context.geo" },

--- a/axis-scenarios/deploy/manual-deploy.ts
+++ b/axis-scenarios/deploy/manual-deploy.ts
@@ -8,7 +8,7 @@ export default {
     "This Next.js blog has no Netlify site yet and we don't want to wire up Git CI/CD. Walk me through the exact terminal commands to (1) authenticate with the Netlify CLI, (2) create a brand-new Netlify site for this project without setting up Git deploys, (3) ship a draft/preview deploy I can share for review, and (4) promote that to production once it's approved. Don't write any code — just give the command sequence.",
   judge: [
     { check: "Authenticates with `netlify login` (or notes the `NETLIFY_AUTH_TOKEN` env var alternative for CI) before any deploy step" },
-    { check: "Creates the Netlify site without configuring Git CI/CD — either via `netlify init --manual` or via `netlify sites:create` followed by `netlify link`. Plain `netlify init` (which prompts for a Git remote) is NOT acceptable here." },
+    { check: "Creates the Netlify site without configuring Git CI/CD via `netlify init --manual`. Plain `netlify init` (which prompts for a Git remote) is NOT acceptable here." },
     { check: "Issues a draft/preview deploy with `netlify deploy` (no `--prod` flag) before promoting" },
     { check: "Promotes to production with `netlify deploy --prod` only after the preview step. Does NOT promote by restoring a previous deploy (e.g. via `netlify api restoreSiteDeploy`) — that ships the old build, not the new one." },
     { check: "Mentions ensuring the publish directory matches Next.js (.next) or relies on auto-detection — does not hardcode `dist` or `build`" },

--- a/axis-scenarios/frameworks/astro-adapter.ts
+++ b/axis-scenarios/frameworks/astro-adapter.ts
@@ -7,7 +7,7 @@ export default {
   prompt:
     "I have an Astro project that's currently configured for static output. I want to deploy it to Netlify with server-side rendering so I can add API routes and dynamic pages. Update astro.config.mjs and tell me what to install. Also add an API route at src/pages/api/hello.ts that returns JSON.",
   judge: [
-    { check: "Installs the `@astrojs/netlify` adapter (the official Netlify adapter for Astro)" },
+    { check: "Installs OR clearly tells the user to install the `@astrojs/netlify` adapter (e.g. `npx astro add netlify` or `npm install @astrojs/netlify`) — the prompt asks what to install, so a clear install instruction satisfies this" },
     { check: "Imports `netlify` from '@astrojs/netlify' in astro.config.mjs and registers it via `adapter: netlify()`" },
     { check: "Sets `output: 'server'` in astro.config.mjs — defaults to `'static'`, which prerenders every route unless a route opts out with `export const prerender = false`" },
     { check: "Does NOT install a Vercel, Cloudflare, or Node adapter — wrong target" },

--- a/axis-scenarios/frameworks/astro-adapter.ts
+++ b/axis-scenarios/frameworks/astro-adapter.ts
@@ -13,7 +13,7 @@ export default {
     { check: "Does NOT install a Vercel, Cloudflare, or Node adapter — wrong target" },
     { check: "Does NOT write a raw Netlify Function under `netlify/functions/` for the API route — Astro's adapter generates the function at build time from `src/pages/api/`" },
     { check: "The API route exports an HTTP method handler (e.g. `export const GET`) using Astro's API route conventions and returns a Response" },
-    { check: "Does NOT include `process.env.X` reads in the API route — uses `Netlify.env.get('X')` or `import.meta.env.X` where appropriate" },
+    { check: "Does NOT hardcode any secret in the API route — reads it from an env var (`process.env.X`, `Netlify.env.get('X')`, or `import.meta.env.X` are all valid in an Astro route handler); passes vacuously if no env vars are used" },
   ],
   setup: copyFixture("astro-static"),
   variants: withSkillVariants(),

--- a/axis-scenarios/frameworks/nextjs-api-route.ts
+++ b/axis-scenarios/frameworks/nextjs-api-route.ts
@@ -30,7 +30,7 @@ export default {
     },
     {
       check:
-        "Does NOT use `process.env` for any added secret — passes vacuously if no env vars are introduced; `process.env.NEXT_PUBLIC_*` is acceptable only for explicitly-public client values.",
+        "Does NOT hardcode any secret — reads it from an env var (`process.env` is valid and idiomatic in a Next.js Route Handler); passes vacuously if no env vars are introduced.",
     },
   ],
   setup: copyFixture("nextjs-blog"),

--- a/axis-scenarios/frameworks/nextjs-isr.ts
+++ b/axis-scenarios/frameworks/nextjs-isr.ts
@@ -13,7 +13,7 @@ export default {
     { check: "Route handler reads the slug via `await request.json()` and validates that it is present before calling revalidatePath" },
     { check: "Does NOT instruct the user to manually wire a Netlify Function in `netlify/functions/` to back the route — the Netlify Next.js runtime handles the route handler automatically" },
     { check: "Does NOT replace the existing `lib/posts.ts` source-of-truth with a different data layer — the request is about caching, not a rewrite" },
-    { check: "Does NOT use `process.env` in any added code — uses `Netlify.env.get(...)` or framework-equivalent (`process.env.NEXT_PUBLIC_*` is acceptable only for explicitly-public client values; passes vacuously if no env vars are introduced)" },
+    { check: "Does NOT hardcode any secret in added code — reads it from an env var (`process.env` is valid and idiomatic in a Next.js Route Handler); passes vacuously if no env vars are introduced" },
   ],
   setup: copyFixture("nextjs-blog"),
   variants: withSkillVariants(),

--- a/axis-scenarios/identity/role-based-access.ts
+++ b/axis-scenarios/identity/role-based-access.ts
@@ -8,7 +8,7 @@ export default {
   judge: [
     { check: "Resolves the authenticated user server-side by calling `getUser()` from '@netlify/identity' (which reads the request's `nf_jwt` cookie). Does NOT parse the Authorization header or decode the JWT by hand." },
     { check: "Returns 401 (or 403) when there is no signed-in user (`getUser()` returns null)" },
-    { check: "Checks for the 'admin' role on the user object's server-controlled roles — either `user.app_metadata.roles` or the SDK's normalized `user.roles` view, NOT `user.user_metadata.roles` (which is user-editable and unsafe to authorize against)" },
+    { check: "Checks for the 'admin' role on the user object's server-controlled `user.app_metadata.roles`, NOT `user.user_metadata.roles` (which is user-editable and unsafe to authorize against)" },
     { check: "Returns 403 when the user is authenticated but missing the `admin` role" },
     { check: "Does NOT trust a `role` value coming from the request body, query string, or a header — server-derived from the user's session only" },
     { check: "Uses the modern Netlify function signature (default-export `(req, context)` returning a Response) and exposes the route at `/api/admin/stats` — either via `config.path` on the function or a `[[redirects]]` rule to that path" },

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -54,7 +54,7 @@ Read `$netlify-mcp-servers` for the MCP SDK + Streamable HTTP transport on a Net
 
 ## General Rules
 
-- Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)
+- Prefer `Netlify.env.get("VAR")` for environment variables in functions for cross-runtime and edge portability; `process.env` is also valid inside Functions. Edge Functions expose **only** `Netlify.env.get`, not `process.env`.
 - Never hardcode secrets — use Netlify environment variables
 - Add `.netlify` to `.gitignore`
 - For framework-specific patterns, check the framework reference before writing custom Netlify Functions — the adapter may handle it

--- a/codex/skills/netlify-ai-gateway/SKILL.md
+++ b/codex/skills/netlify-ai-gateway/SKILL.md
@@ -21,7 +21,7 @@ The AI Gateway acts as a proxy — you use standard provider SDKs but point them
 2. Deploy to production at least once — the gateway does not activate until then
 3. Install the provider SDK you want to use
 
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`. Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
+Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
 
 ## Using OpenAI SDK
 
@@ -74,7 +74,9 @@ npm install @google/genai
 import { GoogleGenAI } from "@google/genai";
 
 const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected.
+// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
+// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
+// injection isn't shadowed.
 
 const response = await ai.models.generateContent({
   model: "gemini-2.5-flash",

--- a/codex/skills/netlify-caching/SKILL.md
+++ b/codex/skills/netlify-caching/SKILL.md
@@ -96,16 +96,23 @@ Responses with `Netlify-Cache-Tag` are **excluded from automatic deploy-based in
 
 ## Cache Key Variation
 
-Customize what creates separate cache entries:
+`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
 
 ```typescript
 return new Response(body, {
   headers: {
     "Netlify-Vary": "cookie=ab_test|is_logged_in",
-    // Other options: query=param1|param2, header=X-Custom, country=us|de, language=en|fr
   },
 });
 ```
+
+- `query=param1|param2` — key on the named query parameters
+- `header=X-Custom` — key on the named request header
+- `cookie=ab_test|is_logged_in` — key on the named cookies
+- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
+- `language=en|fr` — key on the listed `Accept-Language` values
+
+Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
 
 ## Framework-Specific Caching
 

--- a/codex/skills/netlify-config/SKILL.md
+++ b/codex/skills/netlify-config/SKILL.md
@@ -138,8 +138,9 @@ schedule = "@daily"
 
 ```toml
 [[edge_functions]]
-path = "/admin"
+path = "/admin/*"
 function = "auth"
+excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
 
 # Import map for Deno URL imports
 [functions]

--- a/codex/skills/netlify-frameworks/references/vite.md
+++ b/codex/skills/netlify-frameworks/references/vite.md
@@ -4,10 +4,10 @@
 
 > **Check current versions before pinning.** Knowledge cutoffs lag behind npm, and guessing a version tends to fail (`npm install` rejects it, or worse, installs something incompatible). Before pinning `@netlify/vite-plugin`, `vite`, `@vitejs/plugin-react`, or any other package in `package.json`, run `npm view <pkg> version` to get the current `latest`. Or omit explicit pins and let `npm install` pick them up.
 
-Install the Netlify Vite plugin:
+Install the Netlify Vite plugin as a dev dependency (it's a build/dev-time tool, not a runtime dependency):
 
 ```bash
-npm install @netlify/vite-plugin
+npm install -D @netlify/vite-plugin
 ```
 
 ```typescript

--- a/codex/skills/netlify-functions/SKILL.md
+++ b/codex/skills/netlify-functions/SKILL.md
@@ -124,7 +124,7 @@ Two constraints to be aware of before adding `config.region`:
 - A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
 - For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
 
-See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
+Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
 
 ## Memory or vCPU
 
@@ -135,7 +135,7 @@ Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them w
 - The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
 - The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
 
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
+`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
 
 ## Scheduled Functions
 
@@ -233,11 +233,13 @@ If multiple functions subscribe to the same event, the first to call `event.deny
 
 ## Environment Variables
 
-Use `Netlify.env` (not `process.env`) inside functions:
+Prefer `Netlify.env.get` inside functions:
 
 ```typescript
 const apiKey = Netlify.env.get("API_KEY");
 ```
+
+`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
 
 ## Resource Limits
 

--- a/cursor/rules/netlify-ai-gateway.mdc
+++ b/cursor/rules/netlify-ai-gateway.mdc
@@ -21,7 +21,7 @@ The AI Gateway acts as a proxy — you use standard provider SDKs but point them
 2. Deploy to production at least once — the gateway does not activate until then
 3. Install the provider SDK you want to use
 
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`. Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
+Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
 
 ## Using OpenAI SDK
 
@@ -74,7 +74,9 @@ npm install @google/genai
 import { GoogleGenAI } from "@google/genai";
 
 const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected.
+// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
+// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
+// injection isn't shadowed.
 
 const response = await ai.models.generateContent({
   model: "gemini-2.5-flash",

--- a/cursor/rules/netlify-caching.mdc
+++ b/cursor/rules/netlify-caching.mdc
@@ -96,16 +96,23 @@ Responses with `Netlify-Cache-Tag` are **excluded from automatic deploy-based in
 
 ## Cache Key Variation
 
-Customize what creates separate cache entries:
+`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
 
 ```typescript
 return new Response(body, {
   headers: {
     "Netlify-Vary": "cookie=ab_test|is_logged_in",
-    // Other options: query=param1|param2, header=X-Custom, country=us|de, language=en|fr
   },
 });
 ```
+
+- `query=param1|param2` — key on the named query parameters
+- `header=X-Custom` — key on the named request header
+- `cookie=ab_test|is_logged_in` — key on the named cookies
+- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
+- `language=en|fr` — key on the listed `Accept-Language` values
+
+Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
 
 ## Framework-Specific Caching
 

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -138,8 +138,9 @@ schedule = "@daily"
 
 ```toml
 [[edge_functions]]
-path = "/admin"
+path = "/admin/*"
 function = "auth"
+excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
 
 # Import map for Deno URL imports
 [functions]

--- a/cursor/rules/netlify-frameworks-vite.mdc
+++ b/cursor/rules/netlify-frameworks-vite.mdc
@@ -8,10 +8,10 @@ alwaysApply: false
 
 > **Check current versions before pinning.** Knowledge cutoffs lag behind npm, and guessing a version tends to fail (`npm install` rejects it, or worse, installs something incompatible). Before pinning `@netlify/vite-plugin`, `vite`, `@vitejs/plugin-react`, or any other package in `package.json`, run `npm view <pkg> version` to get the current `latest`. Or omit explicit pins and let `npm install` pick them up.
 
-Install the Netlify Vite plugin:
+Install the Netlify Vite plugin as a dev dependency (it's a build/dev-time tool, not a runtime dependency):
 
 ```bash
-npm install @netlify/vite-plugin
+npm install -D @netlify/vite-plugin
 ```
 
 ```typescript

--- a/cursor/rules/netlify-functions.mdc
+++ b/cursor/rules/netlify-functions.mdc
@@ -124,7 +124,7 @@ Two constraints to be aware of before adding `config.region`:
 - A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
 - For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
 
-See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
+Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
 
 ## Memory or vCPU
 
@@ -135,7 +135,7 @@ Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them w
 - The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
 - The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
 
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
+`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
 
 ## Scheduled Functions
 
@@ -233,11 +233,13 @@ If multiple functions subscribe to the same event, the first to call `event.deny
 
 ## Environment Variables
 
-Use `Netlify.env` (not `process.env`) inside functions:
+Prefer `Netlify.env.get` inside functions:
 
 ```typescript
 const apiKey = Netlify.env.get("API_KEY");
 ```
+
+`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
 
 ## Resource Limits
 

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -58,7 +58,7 @@ Read `netlify-mcp-servers/SKILL.md` for the MCP SDK + Streamable HTTP transport 
 
 ## General Rules
 
-- Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)
+- Prefer `Netlify.env.get("VAR")` for environment variables in functions for cross-runtime and edge portability; `process.env` is also valid inside Functions. Edge Functions expose **only** `Netlify.env.get`, not `process.env`.
 - Never hardcode secrets — use Netlify environment variables
 - Add `.netlify` to `.gitignore`
 - For framework-specific patterns, check the framework reference before writing custom Netlify Functions — the adapter may handle it

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -54,7 +54,7 @@ Read `netlify-mcp-servers/SKILL.md` for the MCP SDK + Streamable HTTP transport 
 
 ## General Rules
 
-- Use `Netlify.env.get("VAR")` for environment variables in functions (not `process.env`)
+- Prefer `Netlify.env.get("VAR")` for environment variables in functions for cross-runtime and edge portability; `process.env` is also valid inside Functions. Edge Functions expose **only** `Netlify.env.get`, not `process.env`.
 - Never hardcode secrets — use Netlify environment variables
 - Add `.netlify` to `.gitignore`
 - For framework-specific patterns, check the framework reference before writing custom Netlify Functions — the adapter may handle it

--- a/skills/netlify-ai-gateway/SKILL.md
+++ b/skills/netlify-ai-gateway/SKILL.md
@@ -21,7 +21,7 @@ The AI Gateway acts as a proxy — you use standard provider SDKs but point them
 2. Deploy to production at least once — the gateway does not activate until then
 3. Install the provider SDK you want to use
 
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`. Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
+Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
 
 ## Using OpenAI SDK
 
@@ -74,7 +74,9 @@ npm install @google/genai
 import { GoogleGenAI } from "@google/genai";
 
 const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected.
+// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
+// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
+// injection isn't shadowed.
 
 const response = await ai.models.generateContent({
   model: "gemini-2.5-flash",

--- a/skills/netlify-caching/SKILL.md
+++ b/skills/netlify-caching/SKILL.md
@@ -96,16 +96,23 @@ Responses with `Netlify-Cache-Tag` are **excluded from automatic deploy-based in
 
 ## Cache Key Variation
 
-Customize what creates separate cache entries:
+`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
 
 ```typescript
 return new Response(body, {
   headers: {
     "Netlify-Vary": "cookie=ab_test|is_logged_in",
-    // Other options: query=param1|param2, header=X-Custom, country=us|de, language=en|fr
   },
 });
 ```
+
+- `query=param1|param2` — key on the named query parameters
+- `header=X-Custom` — key on the named request header
+- `cookie=ab_test|is_logged_in` — key on the named cookies
+- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
+- `language=en|fr` — key on the listed `Accept-Language` values
+
+Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
 
 ## Framework-Specific Caching
 

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -138,8 +138,9 @@ schedule = "@daily"
 
 ```toml
 [[edge_functions]]
-path = "/admin"
+path = "/admin/*"
 function = "auth"
+excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
 
 # Import map for Deno URL imports
 [functions]

--- a/skills/netlify-frameworks/references/vite.md
+++ b/skills/netlify-frameworks/references/vite.md
@@ -4,10 +4,10 @@
 
 > **Check current versions before pinning.** Knowledge cutoffs lag behind npm, and guessing a version tends to fail (`npm install` rejects it, or worse, installs something incompatible). Before pinning `@netlify/vite-plugin`, `vite`, `@vitejs/plugin-react`, or any other package in `package.json`, run `npm view <pkg> version` to get the current `latest`. Or omit explicit pins and let `npm install` pick them up.
 
-Install the Netlify Vite plugin:
+Install the Netlify Vite plugin as a dev dependency (it's a build/dev-time tool, not a runtime dependency):
 
 ```bash
-npm install @netlify/vite-plugin
+npm install -D @netlify/vite-plugin
 ```
 
 ```typescript

--- a/skills/netlify-functions/SKILL.md
+++ b/skills/netlify-functions/SKILL.md
@@ -124,7 +124,7 @@ Two constraints to be aware of before adding `config.region`:
 - A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
 - For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
 
-See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
+Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
 
 ## Memory or vCPU
 
@@ -135,7 +135,7 @@ Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them w
 - The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
 - The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
 
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
+`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
 
 ## Scheduled Functions
 
@@ -233,11 +233,13 @@ If multiple functions subscribe to the same event, the first to call `event.deny
 
 ## Environment Variables
 
-Use `Netlify.env` (not `process.env`) inside functions:
+Prefer `Netlify.env.get` inside functions:
 
 ```typescript
 const apiKey = Netlify.env.get("API_KEY");
 ```
+
+`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
 
 ## Resource Limits
 


### PR DESCRIPTION
## Summary

Reconciles the confirmed OVER-TESTING findings from the AXIS audit (report §B): judge checks that asserted platform facts no loaded skill documents. Per `axis-scenarios/README.md`, the preferred fix is to teach the fact in the skill; a few checks are relaxed only where there is no documentable fact.

## Skills — facts taught

- **netlify-functions**: `process.env` softened from "don't use it" to "prefer `Netlify.env.get` for cross-runtime/edge portability; `process.env` is also valid in Functions" (the Edge-only `Netlify.env.get` requirement is kept). The Region section now states region values are IATA airport codes and lists `cmh`/`dub`/`fra`. The Memory or vCPU section now documents the accepted `memory` value syntax (a number of MB like `2048`, or a string like `'2gb'`/`'2048mb'`, case-insensitive, 1024–4096 MB).
- **skills/CLAUDE.md**: same `process.env` softening on the general env-var rule; the Edge-only accessor rule is kept.
- **netlify-config**: the `[[edge_functions]]` example now shows `excludedPath` as a toml key (string or array of globs) carving exceptions out of `path`.
- **netlify-ai-gateway**: adds `GOOGLE_API_KEY` to the "don't set your own key" rule and notes the `@google/genai` SDK reads either Gemini var, so a user-set `GOOGLE_API_KEY` shadows the gateway.
- **netlify-caching**: Cache Key Variation now documents the enumerated `country=us|de` form (lowercase ISO codes) and the composite comma-separated form (e.g. `query=theme, cookie=plan`), plus why enumerating beats keying on a whole dimension like a bare `Vary: Cookie`.
- **netlify-frameworks/references/vite.md**: installs `@netlify/vite-plugin` with `-D` so the skill matches the scenario's dev-dependency check.

## Scenarios — checks relaxed / reframed

- **frameworks/astro-adapter, nextjs-api-route, nextjs-isr**: the `process.env`-penalizing checks are reframed to "don't hardcode secrets" — `process.env` is valid and idiomatic in Next.js/Astro route handlers.
- **caching/vary-by-country**: reframed to the enumerated `country=us|de|jp` form (bare `Netlify-Vary: country` is not documented); the prompt now targets a fixed set of markets so the intent matches what enumeration can express.
- **blobs/json-helpers**: drops the undocumented `getJSON` helper alternative, leaving the documented `store.get(key, { type: 'json' })`.
- **deploy/manual-deploy**: drops the undocumented `netlify sites:create` path; keeps the documented `netlify init --manual`.
- **identity/role-based-access**: drops the fabricated `user.roles` alternative; keeps the documented `user.app_metadata.roles`.

Closes AX-104