### PR TITLE
docs(skills): duplicate cross-cutting rules into domain skills that lack them

### DIFF
--- a/codex/skills/netlify-agent-runner/SKILL.md
+++ b/codex/skills/netlify-agent-runner/SKILL.md
@@ -12,6 +12,16 @@ Run AI coding agents (Claude, Codex, Gemini) remotely on Netlify infrastructure 
 - The site must be **linked to a Netlify project** (via `netlify link` or `netlify init`), or you can specify `--project <name>` to target any Netlify site
 - The Netlify CLI must be installed and authenticated
 
+## Use only documented CLI surfaces
+
+Interact with agent tasks only through the documented `netlify agents:*` commands (plus `netlify --help` and the public CLI reference). Do **not** go around the CLI:
+
+- **Do not curl `https://api.netlify.com/...`** to fetch, create, or stop a task — the endpoint shapes are not part of the public contract.
+- **Do not run `netlify api <method>`** as a recovery hatch when a documented command fails.
+- **Do not read auth tokens** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) to authenticate side-channel calls.
+
+If a documented command fails, report the exact error and context to the user and stop — don't invent an undocumented way to reach the task.
+
 ## How Agent Tasks Run
 
 Read this before creating a task — agent tasks behave differently from running an agent locally, and the differences are easy to miss.

--- a/codex/skills/netlify-cli-and-deploy/SKILL.md
+++ b/codex/skills/netlify-cli-and-deploy/SKILL.md
@@ -137,6 +137,10 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 **Never use `VITE_` or `PUBLIC_` prefix for secrets** — these are exposed to the browser.
 
+## When a command fails, surface and stop
+
+When a `netlify` command, a deploy, or `netlify dev` fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
+
 ## Useful Commands
 
 | Command | Description |

--- a/codex/skills/netlify-deploy/SKILL.md
+++ b/codex/skills/netlify-deploy/SKILL.md
@@ -222,6 +222,7 @@ For secrets and configuration:
 - Run `netlify open` to view site in Netlify dashboard
 - Run `netlify logs` to view function logs (if using Netlify Functions)
 - Use `netlify dev` for local development with Netlify Functions
+- Add `.netlify` to `.gitignore` — linking a site or `netlify init` writes site state to `.netlify/state.json`, which shouldn't be committed
 
 ## Reference
 

--- a/codex/skills/netlify-edge-functions/SKILL.md
+++ b/codex/skills/netlify-edge-functions/SKILL.md
@@ -7,6 +7,10 @@ description: Guide for writing Netlify Edge Functions. Use when building middlew
 
 Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
 
+## Check the framework adapter first
+
+For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+
 ## Syntax
 
 ```typescript

--- a/codex/skills/netlify-forms/SKILL.md
+++ b/codex/skills/netlify-forms/SKILL.md
@@ -170,3 +170,12 @@ Key endpoints:
 | Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
 | Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
 | Delete submission | DELETE | `/api/v1/submissions/{id}` |
+
+## Use only documented surfaces
+
+To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
+
+- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
+- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
+
+If a documented path fails, report the exact error and context to the user and stop.

--- a/codex/skills/netlify-identity/SKILL.md
+++ b/codex/skills/netlify-identity/SKILL.md
@@ -80,6 +80,10 @@ Asking these *after* coding causes rework — both the auth UI shape and the das
 
 If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
 
+## Never hardcode secrets
+
+Never hardcode secrets. Identity URLs, GoTrue endpoints, admin tokens, and OAuth `client_id`/`secret` values do not belong in client or server code — read the admin token at runtime with `Netlify.env.get("VAR")`, and configure OAuth credentials in the Netlify dashboard, not the frontend. Store anything sensitive as a Netlify environment variable (mark it secret).
+
 ## Setup
 
 ```bash

--- a/cursor/rules/netlify-agent-runner.mdc
+++ b/cursor/rules/netlify-agent-runner.mdc
@@ -12,6 +12,16 @@ Run AI coding agents (Claude, Codex, Gemini) remotely on Netlify infrastructure 
 - The site must be **linked to a Netlify project** (via `netlify link` or `netlify init`), or you can specify `--project <name>` to target any Netlify site
 - The Netlify CLI must be installed and authenticated
 
+## Use only documented CLI surfaces
+
+Interact with agent tasks only through the documented `netlify agents:*` commands (plus `netlify --help` and the public CLI reference). Do **not** go around the CLI:
+
+- **Do not curl `https://api.netlify.com/...`** to fetch, create, or stop a task — the endpoint shapes are not part of the public contract.
+- **Do not run `netlify api <method>`** as a recovery hatch when a documented command fails.
+- **Do not read auth tokens** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) to authenticate side-channel calls.
+
+If a documented command fails, report the exact error and context to the user and stop — don't invent an undocumented way to reach the task.
+
 ## How Agent Tasks Run
 
 Read this before creating a task — agent tasks behave differently from running an agent locally, and the differences are easy to miss.

--- a/cursor/rules/netlify-cli-and-deploy.mdc
+++ b/cursor/rules/netlify-cli-and-deploy.mdc
@@ -137,6 +137,10 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 **Never use `VITE_` or `PUBLIC_` prefix for secrets** — these are exposed to the browser.
 
+## When a command fails, surface and stop
+
+When a `netlify` command, a deploy, or `netlify dev` fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
+
 ## Useful Commands
 
 | Command | Description |

--- a/cursor/rules/netlify-deploy.mdc
+++ b/cursor/rules/netlify-deploy.mdc
@@ -222,6 +222,7 @@ For secrets and configuration:
 - Run `netlify open` to view site in Netlify dashboard
 - Run `netlify logs` to view function logs (if using Netlify Functions)
 - Use `netlify dev` for local development with Netlify Functions
+- Add `.netlify` to `.gitignore` — linking a site or `netlify init` writes site state to `.netlify/state.json`, which shouldn't be committed
 
 ## Reference
 

--- a/cursor/rules/netlify-edge-functions.mdc
+++ b/cursor/rules/netlify-edge-functions.mdc
@@ -7,6 +7,10 @@ alwaysApply: false
 
 Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
 
+## Check the framework adapter first
+
+For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+
 ## Syntax
 
 ```typescript

--- a/cursor/rules/netlify-forms.mdc
+++ b/cursor/rules/netlify-forms.mdc
@@ -170,3 +170,12 @@ Key endpoints:
 | Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
 | Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
 | Delete submission | DELETE | `/api/v1/submissions/{id}` |
+
+## Use only documented surfaces
+
+To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
+
+- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
+- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
+
+If a documented path fails, report the exact error and context to the user and stop.

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -80,6 +80,10 @@ Asking these *after* coding causes rework — both the auth UI shape and the das
 
 If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
 
+## Never hardcode secrets
+
+Never hardcode secrets. Identity URLs, GoTrue endpoints, admin tokens, and OAuth `client_id`/`secret` values do not belong in client or server code — read the admin token at runtime with `Netlify.env.get("VAR")`, and configure OAuth credentials in the Netlify dashboard, not the frontend. Store anything sensitive as a Netlify environment variable (mark it secret).
+
 ## Setup
 
 ```bash

--- a/skills/netlify-agent-runner/SKILL.md
+++ b/skills/netlify-agent-runner/SKILL.md
@@ -12,6 +12,16 @@ Run AI coding agents (Claude, Codex, Gemini) remotely on Netlify infrastructure 
 - The site must be **linked to a Netlify project** (via `netlify link` or `netlify init`), or you can specify `--project <name>` to target any Netlify site
 - The Netlify CLI must be installed and authenticated
 
+## Use only documented CLI surfaces
+
+Interact with agent tasks only through the documented `netlify agents:*` commands (plus `netlify --help` and the public CLI reference). Do **not** go around the CLI:
+
+- **Do not curl `https://api.netlify.com/...`** to fetch, create, or stop a task — the endpoint shapes are not part of the public contract.
+- **Do not run `netlify api <method>`** as a recovery hatch when a documented command fails.
+- **Do not read auth tokens** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) to authenticate side-channel calls.
+
+If a documented command fails, report the exact error and context to the user and stop — don't invent an undocumented way to reach the task.
+
 ## How Agent Tasks Run
 
 Read this before creating a task — agent tasks behave differently from running an agent locally, and the differences are easy to miss.

--- a/skills/netlify-cli-and-deploy/SKILL.md
+++ b/skills/netlify-cli-and-deploy/SKILL.md
@@ -137,6 +137,10 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 **Never use `VITE_` or `PUBLIC_` prefix for secrets** — these are exposed to the browser.
 
+## When a command fails, surface and stop
+
+When a `netlify` command, a deploy, or `netlify dev` fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
+
 ## Useful Commands
 
 | Command | Description |

--- a/skills/netlify-deploy/SKILL.md
+++ b/skills/netlify-deploy/SKILL.md
@@ -222,6 +222,7 @@ For secrets and configuration:
 - Run `netlify open` to view site in Netlify dashboard
 - Run `netlify logs` to view function logs (if using Netlify Functions)
 - Use `netlify dev` for local development with Netlify Functions
+- Add `.netlify` to `.gitignore` — linking a site or `netlify init` writes site state to `.netlify/state.json`, which shouldn't be committed
 
 ## Reference
 

--- a/skills/netlify-edge-functions/SKILL.md
+++ b/skills/netlify-edge-functions/SKILL.md
@@ -7,6 +7,10 @@ description: Guide for writing Netlify Edge Functions. Use when building middlew
 
 Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
 
+## Check the framework adapter first
+
+For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+
 ## Syntax
 
 ```typescript

--- a/skills/netlify-forms/SKILL.md
+++ b/skills/netlify-forms/SKILL.md
@@ -170,3 +170,12 @@ Key endpoints:
 | Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
 | Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
 | Delete submission | DELETE | `/api/v1/submissions/{id}` |
+
+## Use only documented surfaces
+
+To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
+
+- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
+- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
+
+If a documented path fails, report the exact error and context to the user and stop.

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -80,6 +80,10 @@ Asking these *after* coding causes rework — both the auth UI shape and the das
 
 If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
 
+## Never hardcode secrets
+
+Never hardcode secrets. Identity URLs, GoTrue endpoints, admin tokens, and OAuth `client_id`/`secret` values do not belong in client or server code — read the admin token at runtime with `Netlify.env.get("VAR")`, and configure OAuth credentials in the Netlify dashboard, not the frontend. Store anything sensitive as a Netlify environment variable (mark it secret).
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
## Summary

`skills/CLAUDE.md` is load-bearing but never loaded at test time (only the individual `skills/netlify-*/SKILL.md` dirs load), so several cross-cutting rules that scenarios judge are effectively undocumented in the skills that own those scenarios. This PR duplicates the missing rule text into each affected domain skill, mirroring the wording already carried by `netlify-database/SKILL.md` and `netlify-mcp-servers/SKILL.md`. No behavior or facts change — this is mechanical rule duplication per the repo convention of repeating cross-cutting rules per skill.

Audit source: `tmp/axis-audit-handoff/AUDIT-REPORT.md` section E1.

## What changed and why

- **`netlify-agent-runner/SKILL.md`** — added a "Use only documented CLI surfaces" section (no curling `api.netlify.com`, no `netlify api <method>` recovery hatch, no reading auth tokens off disk). Three scenarios (`check-task-status`, `list-filter-json`, `stop-task`) judge this rule but it previously lived only in the unloaded `skills/CLAUDE.md`.
- **`netlify-forms/SKILL.md`** — added a "Use only documented surfaces" section clarifying that the documented Submissions API takes an explicit PAT from an env var, and that agents must not invent endpoint shapes, use `netlify api` as a recovery hatch, or read tokens off disk. Matches what `submissions-api.ts` and `dashboard-detection-handoff.ts` grade.
- **`netlify-cli-and-deploy/SKILL.md`** — added a "When a command fails, surface and stop" section. This skill previously had zero failure-handling language despite deploy scenarios expecting surface-and-stop behavior.
- **`netlify-deploy/SKILL.md`** — added `.netlify` to `.gitignore` guidance in Tips; three of its scenarios (`manual-deploy`, `git-based-init`, `link-existing-site`) judge it.
- **`netlify-identity/SKILL.md`** — added a "Never hardcode secrets" section (Identity URLs, admin tokens, OAuth client_id/secret). Six identity scenarios judge no-hardcoded-secrets; it was previously stated verbatim only in `netlify-mcp-servers`.
- **`netlify-edge-functions/SKILL.md`** — added a "Check the framework adapter first" section, since framework adapters emit their own edge middleware and a hand-written duplicate causes conflicts.

## Testing

No scenario changes; existing judge checks are now backed by loaded skill text.

Closes AX-105