### PR TITLE
docs(skills): rehome env-var CLI management into netlify-config (AX-108)

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -25,8 +25,8 @@ Read `$netlify-forms` for form detection, AJAX submissions, spam filtering, and 
 **Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
 Read `$netlify-config` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
-**Deploying, managing env vars, or running local dev?**
-Read `$netlify-cli-and-deploy` for CLI commands, Git vs manual deploys, and environment variable management.
+**Deploying or running local dev?**
+Read `$netlify-cli-and-deploy` for CLI commands and Git vs manual deploys.
 
 **Setting up a framework (Vite, Astro, TanStack, Next.js)?**
 Read `$netlify-frameworks` for adapter/plugin setup. Framework-specific details are in `$netlify-frameworks`.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -22,8 +22,8 @@ Read `$netlify-image-cdn` for the image transformation endpoint and clean URL pa
 **Adding HTML forms?**
 Read `$netlify-forms` for form detection, AJAX submissions, spam filtering, and file uploads.
 
-**Configuring netlify.toml (redirects, headers, build settings)?**
-Read `$netlify-config` for the complete configuration reference.
+**Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
+Read `$netlify-config` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
 **Deploying, managing env vars, or running local dev?**
 Read `$netlify-cli-and-deploy` for CLI commands, Git vs manual deploys, and environment variable management.

--- a/codex/skills/netlify-config/SKILL.md
+++ b/codex/skills/netlify-config/SKILL.md
@@ -166,7 +166,9 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
 
-For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
+When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
+
+For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 

--- a/codex/skills/netlify-config/SKILL.md
+++ b/codex/skills/netlify-config/SKILL.md
@@ -143,7 +143,7 @@ netlify env:get API_KEY
 
 # List
 netlify env:list
-netlify env:list --plain > .env                        # Export to file
+netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
 
 # Import from file
 netlify env:import .env

--- a/codex/skills/netlify-config/SKILL.md
+++ b/codex/skills/netlify-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: netlify-config
-description: Reference for netlify.toml configuration. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, environment variables, or any site-level configuration. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
+description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
 ---
 
 # Netlify Configuration (netlify.toml)
@@ -126,9 +126,47 @@ API_URL = "https://api.prod.com"
 API_URL = "https://api.staging.com"
 ```
 
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values. See the **netlify-cli-and-deploy** skill for CLI environment variable management.
+**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
 
 **Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
+
+### CLI Management
+
+```bash
+# Set
+netlify env:set API_KEY "value"
+netlify env:set API_KEY "value" --secret              # Hidden from logs
+netlify env:set API_KEY "value" --context production   # Context-specific
+
+# Get
+netlify env:get API_KEY
+
+# List
+netlify env:list
+netlify env:list --plain > .env                        # Export to file
+
+# Import from file
+netlify env:import .env
+
+# Delete
+netlify env:unset API_KEY
+```
+
+**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
+
+### Context Scoping
+
+Variables set via the CLI can also be scoped to deploy contexts:
+
+```bash
+netlify env:set API_URL "https://api.prod.com" --context production
+netlify env:set API_URL "https://api.staging.com" --context deploy-preview
+netlify env:set DEBUG "true" --context branch:feature-x
+```
+
+This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
+
+For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -1,5 +1,5 @@
 ---
-description: Reference for netlify.toml configuration. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, environment variables, or any site-level configuration. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
+description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
 alwaysApply: false
 ---
 
@@ -126,9 +126,47 @@ API_URL = "https://api.prod.com"
 API_URL = "https://api.staging.com"
 ```
 
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values. See the **netlify-cli-and-deploy** skill for CLI environment variable management.
+**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
 
 **Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
+
+### CLI Management
+
+```bash
+# Set
+netlify env:set API_KEY "value"
+netlify env:set API_KEY "value" --secret              # Hidden from logs
+netlify env:set API_KEY "value" --context production   # Context-specific
+
+# Get
+netlify env:get API_KEY
+
+# List
+netlify env:list
+netlify env:list --plain > .env                        # Export to file
+
+# Import from file
+netlify env:import .env
+
+# Delete
+netlify env:unset API_KEY
+```
+
+**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
+
+### Context Scoping
+
+Variables set via the CLI can also be scoped to deploy contexts:
+
+```bash
+netlify env:set API_URL "https://api.prod.com" --context production
+netlify env:set API_URL "https://api.staging.com" --context deploy-preview
+netlify env:set DEBUG "true" --context branch:feature-x
+```
+
+This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
+
+For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -166,7 +166,9 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
 
-For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
+When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
+
+For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -143,7 +143,7 @@ netlify env:get API_KEY
 
 # List
 netlify env:list
-netlify env:list --plain > .env                        # Export to file
+netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
 
 # Import from file
 netlify env:import .env

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -29,8 +29,8 @@ Read `netlify-forms/SKILL.md` for form detection, AJAX submissions, spam filteri
 **Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
 Read `netlify-config/SKILL.md` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
-**Deploying, managing env vars, or running local dev?**
-Read `netlify-cli-and-deploy/SKILL.md` for CLI commands, Git vs manual deploys, and environment variable management.
+**Deploying or running local dev?**
+Read `netlify-cli-and-deploy/SKILL.md` for CLI commands and Git vs manual deploys.
 
 **Setting up a framework (Vite, Astro, TanStack, Next.js)?**
 Read `netlify-frameworks/SKILL.md` for adapter/plugin setup. Framework-specific details are in `netlify-frameworks/references/`.

--- a/cursor/rules/netlify-skills-router.mdc
+++ b/cursor/rules/netlify-skills-router.mdc
@@ -26,8 +26,8 @@ Read `netlify-image-cdn/SKILL.md` for the image transformation endpoint and clea
 **Adding HTML forms?**
 Read `netlify-forms/SKILL.md` for form detection, AJAX submissions, spam filtering, and file uploads.
 
-**Configuring netlify.toml (redirects, headers, build settings)?**
-Read `netlify-config/SKILL.md` for the complete configuration reference.
+**Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
+Read `netlify-config/SKILL.md` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
 **Deploying, managing env vars, or running local dev?**
 Read `netlify-cli-and-deploy/SKILL.md` for CLI commands, Git vs manual deploys, and environment variable management.

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -22,8 +22,8 @@ Read `netlify-image-cdn/SKILL.md` for the image transformation endpoint and clea
 **Adding HTML forms?**
 Read `netlify-forms/SKILL.md` for form detection, AJAX submissions, spam filtering, and file uploads.
 
-**Configuring netlify.toml (redirects, headers, build settings)?**
-Read `netlify-config/SKILL.md` for the complete configuration reference.
+**Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
+Read `netlify-config/SKILL.md` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
 **Deploying, managing env vars, or running local dev?**
 Read `netlify-cli-and-deploy/SKILL.md` for CLI commands, Git vs manual deploys, and environment variable management.

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -25,8 +25,8 @@ Read `netlify-forms/SKILL.md` for form detection, AJAX submissions, spam filteri
 **Configuring netlify.toml (redirects, headers, build settings) or managing environment variables?**
 Read `netlify-config/SKILL.md` for the complete configuration reference, including CLI environment variable management (`env:set`, `env:get`, `env:list`, context scoping).
 
-**Deploying, managing env vars, or running local dev?**
-Read `netlify-cli-and-deploy/SKILL.md` for CLI commands, Git vs manual deploys, and environment variable management.
+**Deploying or running local dev?**
+Read `netlify-cli-and-deploy/SKILL.md` for CLI commands and Git vs manual deploys.
 
 **Setting up a framework (Vite, Astro, TanStack, Next.js)?**
 Read `netlify-frameworks/SKILL.md` for adapter/plugin setup. Framework-specific details are in `netlify-frameworks/references/`.

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -166,7 +166,9 @@ netlify env:set DEBUG "true" --context branch:feature-x
 
 This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
 
-For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
+When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
+
+For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -143,7 +143,7 @@ netlify env:get API_KEY
 
 # List
 netlify env:list
-netlify env:list --plain > .env                        # Export to file
+netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
 
 # Import from file
 netlify env:import .env

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -152,6 +152,8 @@ netlify env:import .env
 netlify env:unset API_KEY
 ```
 
+**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
+
 ### Context Scoping
 
 Variables set via the CLI can also be scoped to deploy contexts:

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: netlify-config
-description: Reference for netlify.toml configuration. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, environment variables, or any site-level configuration. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
+description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, and edge functions config.
 ---
 
 # Netlify Configuration (netlify.toml)
@@ -126,9 +126,45 @@ API_URL = "https://api.prod.com"
 API_URL = "https://api.staging.com"
 ```
 
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values. See the **netlify-cli-and-deploy** skill for CLI environment variable management.
+**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
 
 **Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
+
+### CLI Management
+
+```bash
+# Set
+netlify env:set API_KEY "value"
+netlify env:set API_KEY "value" --secret              # Hidden from logs
+netlify env:set API_KEY "value" --context production   # Context-specific
+
+# Get
+netlify env:get API_KEY
+
+# List
+netlify env:list
+netlify env:list --plain > .env                        # Export to file
+
+# Import from file
+netlify env:import .env
+
+# Delete
+netlify env:unset API_KEY
+```
+
+### Context Scoping
+
+Variables set via the CLI can also be scoped to deploy contexts:
+
+```bash
+netlify env:set API_URL "https://api.prod.com" --context production
+netlify env:set API_URL "https://api.staging.com" --context deploy-preview
+netlify env:set DEBUG "true" --context branch:feature-x
+```
+
+This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
+
+For accessing these variables in code (`Netlify.env.get` vs `process.env`, the `VITE_`/`PUBLIC_` client-side prefixes), see the **netlify-cli-and-deploy** skill.
 
 ## Functions Configuration
 


### PR DESCRIPTION
## Summary

First of three stacked PRs reconciling the two contradictory deploy skills (AX-108). Moves environment-variable CLI management into `netlify-config` so the deploy-skill consolidation (#89) can delete `netlify-cli-and-deploy` without losing content. Additive only.

## What changed

- `netlify-config` gains CLI Management (`env:set --secret/--context`, `env:get`, `env:list`, `env:import`, `env:unset`) and Context Scoping, carried faithfully from `netlify-cli-and-deploy`
- Warning: never put secrets in client-prefixed vars (`VITE_`/`PUBLIC_`/etc.) — `--secret` doesn't protect them (audit-flagged, lost in the original move)
- States the read preference inline: prefer `Netlify.env.get` in server code (`process.env` works in Functions only) — AXIS runs showed agents echoing `process.env` and failing the judged check without this steer
- Router entry for `netlify-config` now routes env-var management questions

Merge order: this PR first, then #88, then #89.

Linear: AX-108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Netlify configuration guidance to include environment-variable setup alongside build settings, redirects/rewrites, headers, deploy contexts, functions, and edge functions.
  * Reworked environment-variable instructions to emphasize CLI-based management (set/get/list, import/export, unset) with deploy-context scoping and safer handling guidance.
  * Clarified runtime behavior: build-scoped vs runtime availability, including notes for server/Edge code and warnings about client-exposed values and secret protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->