### PR TITLE
chore(ctx-pipeline): import forms, edge-functions, image-cdn from docs

### DIFF
--- a/.ctx-gen/config.json
+++ b/.ctx-gen/config.json
@@ -8,6 +8,18 @@
     {
       "grouping": "functions",
       "skill": "netlify-functions"
+    },
+    {
+      "grouping": "forms",
+      "skill": "netlify-forms"
+    },
+    {
+      "grouping": "edge-functions",
+      "skill": "netlify-edge-functions"
+    },
+    {
+      "grouping": "image-cdn",
+      "skill": "netlify-image-cdn"
     }
   ]
 }


### PR DESCRIPTION
Per the PTO-handoff runbook ("Prove Stage 2", step 1): map the three newly-generated groupings so the receiver imports their skills. The docs smoke branch (`scd/ctx-gen-smoke-v1`) has generated, committed, and AXIS-scored context for all three (plus a regenerated functions).

Grouping → skill names follow the source mapping merged in netlify/docs#726. No script changes — config only.

After this merges we'll dispatch the receiver at the smoke branch (`workflow_dispatch`, `docs_ref=scd/ctx-gen-smoke-v1`) and review the rolling draft sync PR — that's the generated-vs-hand-written diff view, nothing merges without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration groupings for forms, edge functions, and image CDN capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->