### PR TITLE
chore(context): sync skills from netlify/docs

### DIFF
--- a/.ctx-gen/state.json
+++ b/.ctx-gen/state.json
@@ -1,1 +1,189 @@
-{}
+{
+  "functions": {
+    "sourceHash": "a2c1b272355b04685b89a8b51a7bbfe0747c93d36c982c035ad01d4904c7e5b4",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "forms": {
+    "sourceHash": "e9238e4279d3cd87a88b715f87e36d4de6afbac3640e3b5ae1cbc9569374f3a9",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "edge-functions": {
+    "sourceHash": "6aefbe078cf6e2ad07f2825f043393143fd45ce202071399dc1b6e54ca555f53",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "image-cdn": {
+    "sourceHash": "d610f4e75340434db04b75990b57e1833818f6c3f33b4a2b3ffdea201cc09d23",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "caching": {
+    "sourceHash": "d66b80cad3ae85bd3b9c44eedf7b7b51968e8f976880d6ec959e91a4af52a2ee",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "configuration",
+      "workflows"
+    ]
+  },
+  "blobs": {
+    "sourceHash": "78dc00056a00c9f711ca4c8b2fcdf9af2d76070db339594c8d3b243ffecaf4d8",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "database": {
+    "sourceHash": "21eb58e3c2a11a65af5fc473c08fd724ca130cb4dc4379a692344bcdbcb29c94",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "deploy": {
+    "sourceHash": "f6973145efb21d3f6c11b37b75171005ec888b8778c57ad0a703218150f62912",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "ai-gateway": {
+    "sourceHash": "30dce37711d783b0f5d0cd0f2396f159ecc22a5ad716a2e8caa5f8d64d776f57",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "frameworks": {
+    "sourceHash": "aa1942c92161d1d0487d0173ff19302c97d60129796d56456bafc7ca155b9574",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "identity": {
+    "sourceHash": "735a828e3b87669025ac4e8cc82790defbf88ddc00591ab859d6e04194170c9b",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "access-control": {
+    "sourceHash": "1827f0ee8f9c66beb4d6b53a199d6adbda4852c110609ce2a3b3a49418a2f307",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  },
+  "config": {
+    "sourceHash": "30e8f6cc0b0482a0f4ea69506b3e7462e3fecaab4f5ef48142a06fbebae52908",
+    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "importerVersion": 1,
+    "affects": [
+      "api",
+      "authoring",
+      "compat",
+      "configuration",
+      "constraints",
+      "examples",
+      "overview",
+      "workflows"
+    ]
+  }
+}

--- a/agent-plugin/skills/netlify-access-control/SKILL.md
+++ b/agent-plugin/skills/netlify-access-control/SKILL.md
@@ -1,65 +1,165 @@
 ---
 name: netlify-access-control
-description: Use when the task involves controlling who can reach a Netlify site, or telling Netlify Identity apart from Secure Access. Trigger whenever the user wants to lock a site or deploy to their company/team, restrict access to employees only, build an internal or employees-only app, set up password protection, SSO, or SAML, asks "who can access my site", or is confused about Netlify Identity vs Secure Access vs team login vs OAuth providers. Routes the request to the right layer — app-level Identity, site-visitor Password Protection, the Auth0 extension, or Team/Org SAML SSO — and explains the two-layer (perimeter + in-app identity) pattern and its double-login tradeoff. For building the app-level auth itself, use the netlify-identity skill.
+description: Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call "auth". Use when a developer wants to password-protect a site or previews, restrict a project to their team, make a project public/private, set team visibility defaults, require SSO to view a site, or debug SSO-session symptoms like being logged out mid-session / getting 401s on an SSO-protected site / token expiry or refresh. Routes app-user login ("who is this user in my app") to the netlify-identity skill and dashboard/team SSO SSO elsewhere; this skill only chooses the perimeter layer for site/preview access.
 ---
 
-# Netlify Access Control
+# Netlify access control (picking the protection layer)
 
-"Auth" on Netlify means three different things that are easy to conflate. Picking the wrong one — or stacking two when one would do — is the main source of friction. This skill disambiguates the layers and routes you to the right one. For actually building app-level user auth, see the **netlify-identity** skill.
+This skill ROUTES. Its job is choosing the correct protection layer for loading a site, not implementing app auth. Before recommending anything, disambiguate — three unrelated layers get called "auth":
 
-## The three layers
+- **Netlify Identity** — "who is this user *inside* my app" (issues `nf_jwt`). App login, OAuth providers for your users, auth code. → Route to the **netlify-identity** skill. Not covered here.
+- **Password Protection / Project visibility** — "can this request load the site at all." Platform perimeter. **This skill.**
+- **Team/Org SAML SSO** — "can you log into the Netlify dashboard." Team member access to Netlify itself.
 
-| Layer | Answers | Who it's for | Plan | How it's configured |
-|---|---|---|---|---|
-| **Netlify Identity** | "Who is this user *inside my app*?" (signups, logins, roles; issues `nf_jwt`) | Your app's end users | All plans, free | Dashboard + `@netlify/identity` code |
-| **Password Protection** (Secure access to *sites*) | "Can this request even *load the site*?" | Basic: anyone with a shared password · Team login: Netlify team members | Basic: Pro+ · Team login: Enterprise | Dashboard-only |
-| **Team / Org SAML SSO** (Secure access to *Netlify*) | "Can you log in to the *Netlify dashboard*?" (and, with strict mode, pass the site gate) | Netlify team members, via a corporate SAML IdP | Enterprise | Dashboard-only |
+Sessions are separate. The same provider (e.g. Google) can be an Identity OAuth provider for app users AND a SAML IdP for team members — unrelated wiring.
 
-These are independent. The `nf_jwt` cookie is issued by app-level JWT auth: Netlify Identity, or a configured external JWT provider such as Auth0/Okta (the two are mutually exclusive); Password Protection and SAML SSO sessions are separate, with their own lifecycles, and do not populate `nf_jwt`.
+## Footgun: no API, CLI, or MCP for these settings
 
-> **Note on terminology:** Netlify's docs file Identity, Password Protection, role-based access, and more under an umbrella called "Secure access to your sites," while SAML SSO lives under "Secure access to Netlify." So "Secure Access" is not one feature — when a user says it, find out whether they mean *gating site visitors* (Password Protection) or *gating dashboard login* (SAML SSO).
+These settings have **no public API, no CLI command, and no MCP tool**. Do NOT curl `api.netlify.com` or read local auth tokens to inspect or change them. Hand the user the dashboard path and checklist. On failure, report what you tried and stop.
 
-## Why Google causes confusion
+## Footgun: the double login is real
 
-The same provider can show up in two unrelated places:
+A Password-Protection / team-login perimeter session and a Netlify Identity app session have **no bridge** — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire them together. For the combined Password-Protection + Identity pattern and its tradeoffs, see `references/two-layer-pattern.md`.
 
-- **Google as a Netlify Identity OAuth provider** — your app's end users click "Log in with Google." Any Google account works, it creates an Identity user, and it issues an `nf_jwt`. This is app-level auth.
-- **Google Workspace as a SAML IdP for Team/Org SSO** — your *Netlify team members* log in to the dashboard (and, with strict mode + team-login, pass the site gate) using their corporate Google account. It does **not** create an Identity user and does **not** issue an `nf_jwt`.
-
-Both are "sign in with Google," but they target different populations and produce different sessions. Don't assume one implies the other.
+For company-wide app-level SSO with a single sign-in (no double login), recommend the **Auth0 extension** (federating to the corporate IdP) BEFORE the two-layer stack.
 
 ## Pick the layer
 
-Start from what the user actually needs and walk down:
+| Goal | Use |
+|---|---|
+| Restrict site to your team, invite by email | Private project (Credit-based) or team login protection |
+| Shared password anyone can use | Basic password protection, or Password visibility (Pro only) |
+| Protect only previews, keep production open | "Non-production deploys only" / "Previews only" |
+| Require SSO to view the site | Org/Team SSO with **Only SSO allowed (strict)** + team login protection |
+| Log in users *inside* your app | → netlify-identity skill |
+| Single company-wide app SSO, no double login | → Auth0 extension |
 
-1. **Does anyone need to be blocked from loading the site at all?**
-   - **No — the site is public, but I need user accounts/roles inside the app** → **Netlify Identity** (open or invite-only registration). Use the **netlify-identity** skill. Done.
-   - **Yes — restrict who can reach it** → keep going.
+## UI naming by plan (same mechanism, different labels)
 
-2. **What kind of restriction?**
-   - **Just keep the public out — a shared secret is fine, no per-user identity needed** (staging, a soft pre-launch gate) → **Basic Password Protection** (Pro+, one shared password). Dashboard-only.
-   - **Only my employees, it's an internal tool / smaller team, and I also want to tell users apart inside the app** → **invite-only Netlify Identity** (all plans, free). Invite only company addresses; Identity itself becomes the gate because no uninvited user can sign in. **One login, full per-user identity, every plan.** This is the best default for "employees-only internal tool." Tradeoff: you manage invites manually and rely on invite links not being shared — it doesn't auto-provision from a corporate directory.
-   - **Big company, app-level company SSO with a single sign-in (no double login), where company-only is enforced inside the IdP** → the **Auth0 extension**. The extension links an Auth0 tenant to your site and exposes `AUTH0_*` env vars so your app authenticates end users through Auth0; Auth0 federates to your corporate IdP (Okta, Entra, Google Workspace) and enforces who counts as company, so users sign in once. This is **app-level**, not a CDN-edge perimeter: the site still loads and your app redirects unauthenticated visitors. Use it when invite-only Identity won't scale to a real org but you don't need a true edge perimeter; that's Option D below. Configured via the Netlify Auth0 extension (dashboard); see the Netlify docs setup guide.
-   - **I genuinely need a CDN-edge perimeter (Enterprise team login / SSO-gated site access) AND a separate app-level Identity** → the **two-layer pattern**. This works, but users sign in **twice** (once at the perimeter, once in the app) — there is no passthrough today. Read [references/two-layer-pattern.md](references/two-layer-pattern.md) before recommending it.
+The UI names differ by plan — the underlying protection is identical:
 
-If the user isn't sure, the most common real answer is **invite-only Netlify Identity** for "just my team" and the **Auth0 extension** for "my whole company with our existing IdP." Lead with those before reaching for the double-login stack.
+- **Credit-based Free / Personal / Pro:** per-project **Project visibility**; team-level **Default project visibility**.
+- **Enterprise / Open Source / legacy (non-Credit-based):** per-site **Password Protection**; team-level **Default Password Protection settings**.
 
-## The double login is real — name it early
+Legacy → Credit-based translation:
 
-When Password Protection (team login) and Netlify Identity are both on, **users authenticate twice** and there is no documented bridge between them — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire the perimeter session into the app session; it isn't supported. If single sign-on matters, that's a reason to choose the Auth0 extension (or invite-only Identity) instead of the two-layer stack. Full detail and the per-option tradeoffs are in [references/two-layer-pattern.md](references/two-layer-pattern.md).
+| Password Protection (old) | Project visibility (new) |
+|---|---|
+| No protection settings | Public |
+| Basic protection | Password |
+| Team protection | Private |
+| All deploys | Production and previews |
+| Non-production deploys only | Previews only |
 
-Also flag the hidden cost of team-login: it admits only **Netlify team members**, so every employee who passes that gate needs a paid Netlify seat. That alone usually rules it out for company-wide apps.
+## Dashboard paths
 
-## Configuration is dashboard-only — hand it off, don't probe
+**Credit-based (Project visibility):**
+- Per-project: `Project configuration > General > Visitor access > Project visibility` — `https://app.netlify.com/projects/{site_name}/configuration/general/#project-visibility`
+- Team default: `Team settings > General > Visitor access > Default project visibility` — `https://app.netlify.com/teams/{team_name}/settings/general#default-project-visibility`
 
-Password Protection, Team/Org SAML SSO, and the Auth0 extension are all configured in the Netlify dashboard or the extensions UI — **there is no public API, CLI command, or MCP tool to set or read them**, and there is no way for an agent to see this state while writing code. So:
+**Enterprise / Open Source / legacy (Password Protection):**
+- Per-site: `Project configuration > Access & security > Visitor access > Password Protection` — `https://app.netlify.com/projects/{site_name}/configuration/access#site-protection`
+- Team default: `Team settings > Access & security > Visitor access > Default Password Protection settings` — `https://app.netlify.com/teams/{team_name}/settings/access#default-site-protection-settings`
 
-- Give the user the dashboard location and an exact checklist; let them flip the setting and confirm.
-- **Do not** `curl https://api.netlify.com/...`, read tokens off disk, or probe for an undocumented endpoint to inspect or change access settings.
-- If a documented path fails, report it to the user with context (what you tried, the URL, the error) and stop — don't work around it.
+## Checklist: set a password (Credit-based, Pro)
 
-For the one piece an agent *can* read at runtime (which Identity providers are live), call `getSettings()` from `@netlify/identity` rather than hard-coding assumptions. It hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev` (which proxies to the live service). See the netlify-identity skill.
+1. Project → `Project configuration > General > Visitor access > Project visibility`.
+2. **Edit visibility**. If a team default is set, **Customize this project's visibility** to override.
+3. Select **Password**, enter the password (share it with visitors).
+4. Choose **Preview access**: **Production and previews** or **Previews only**.
+5. **Save**. Change later via **Change password**; remove by choosing **Public** or **Private**.
 
-## References
+## Checklist: Password Protection (Enterprise / OSS / legacy)
 
-- [Two-layer pattern (perimeter + in-app identity)](references/two-layer-pattern.md) — the four architecture options for "company-only access + per-user identity," the double-login reality, plan/seat costs, and the visibility gap.
+Per-site or team default via the paths above → **Configure Password Protection** → **Customize this site's protection settings** (if a default exists) → choose **Basic password protection** (single shared password) or **Team login protection** (Netlify team login, SSO-capable) → scope **All deploys** or **Non-production deploys only** → **Save**.
+
+## Checklist: require SSO to view a site
+
+1. FIRST set up Organization SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-organization-saml-sso`) or Team SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-team-saml-sso`).
+2. Configure Password Protection → **Team login protection**.
+3. To force SSO, set the SSO config to **Only SSO allowed (strict)**.
+
+## SSO session symptoms (logged out mid-session, 401s)
+
+SSO auth tokens **expire after 1 hour**. An SSO-protected site starts returning HTTP `401` once the token expires — this is the "logged out mid-session" symptom.
+
+The platform returns a `Netlify-Site-Protection-Expires-In` response header (seconds until the token expires) on requests to SSO-protected sites. Read it and re-auth before it hits zero:
+
+```js
+// SSO-protected site: refresh before the 1-hour token expires to avoid a 401.
+const res = await fetch(window.location.href, { credentials: "include" });
+const secondsLeft = Number(res.headers.get("Netlify-Site-Protection-Expires-In"));
+if (!Number.isNaN(secondsLeft) && secondsLeft < 60) {
+  window.location.reload(); // triggers re-auth via the identity provider
+}
+```
+
+The header name and semantics are documented; the JS wrapper is illustrative.
+
+## Project visibility values (Credit-based)
+
+One visibility setting — **Public**, **Password**, or **Private** — plus a separate scope (**Production and previews** or **Previews only**).
+
+- **Public** — anyone with the URL.
+- **Private** — team + invitees only, enforced with Netlify login. Recommended way to restrict to your team; lets you invite by email. No password needed.
+- **Password** — public but requires a shared password. **Pro only** among Credit-based plans.
+
+Previews stay private unless you change preview visibility (includes Deploy Previews, agent-run previews, and branch deploys). There is **no** default shared password — set a password per project.
+
+**Team defaults:** *Private for new projects* (new start behind team login; existing keep visibility), *Private for all projects* (new + all existing locked to team login; none can be made public), *Public for new projects* (new are public; existing keep visibility).
+
+## Constraints & gotchas
+
+- **Previews-only Password scope is Enterprise-only** for Password Protection settings ("Protecting only non-production deploys is only available for Enterprise plans"). Credit-based plans expose a "Previews only" scope via Project visibility separately — the docs do not fully reconcile these; state Enterprise-only for the Password Protection path.
+- **Access order:** Advanced Web Security (Firewall rules → WAF → rate limiting) runs BEFORE any password/login prompt. A blocked IP can hit an error page before ever seeing a login prompt.
+- **Team login excludes Git Contributors** — they cannot access team-login-protected deploys. It applies to Developers, Team Owners, Billing Admins; Reviewers can be invited (unlimited).
+- **Basic password protection prompts everyone**, including managing team members.
+- **Private projects can't receive third-party webhooks** (Slack, Stripe, etc.) — receiving webhooks requires the project to be **public**.
+- **Plan gating:** Basic password (whole site) available on Pro and Enterprise; all options (incl. team login) on Enterprise. Project visibility is Credit-based Free/Personal/Pro only; Free/Personal private projects are visible only to the Team Owner, Pro allows unlimited members. Enterprise/OSS/legacy have no project visibility — use team login protection.
+- **Who can change:** Password Protection — Developer (per-site), Team Owner (default). Project visibility — Org Owners (certain Enterprise plans), Team Owners, Developers with project access. Internal Builders can't publish to production, so can't make a project public.
+- **Team default by creation date:** teams created on/after July 28, 2026 default to **Private for new projects**; teams created before default to **Public**.
+- **Make public** requires at least one successful production deploy. Making public exposes production deploys; previews stay private unless changed.
+- **Invites:** Free/Personal are single-seat (upgrade to Pro to invite); Pro invites unlimited members to a single project or the whole team.
+
+## Compatibility
+
+- "Site-wide password protection" — old name, now part of **Password Protection**.
+- "Selective password protection" — old name for **Basic authentication with custom HTTP headers** (`https://docs.netlify.com/manage/security/secure-access-to-sites/basic-authentication-with-custom-http-headers`), which is code you author — out of scope here.
+
+See also: `references/two-layer-pattern.md` for the combined Password-Protection + Identity pattern.
+
+<!-- system: agent-context/access-control/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (access-control)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. This is a routing/disambiguation skill: keep it narrow — its job is
+   picking the right protection layer, not teaching each one.
+2. The combined Password-Protection + Identity pattern lives in this skill's
+   `references/two-layer-pattern.md`.
+3. "Auth" on Netlify is three unrelated layers users constantly conflate:
+   Netlify Identity ("who is this user inside my app" — issues `nf_jwt`),
+   Password Protection / project visibility ("can this request load the site
+   at all"), and Team/Org SAML SSO ("can you log in to the Netlify
+   dashboard"). Sessions are separate; the same provider (Google) can appear
+   in two unrelated places — Identity OAuth for app users, SAML IdP for team
+   members. Disambiguate before recommending anything.
+4. The double login is real: a Password-Protection/team-login perimeter
+   session and an Identity app session have no bridge — no shared cookie, no
+   header forwarding, no JWT exchange. Don't burn iterations wiring them
+   together; tradeoffs live in `references/two-layer-pattern.md`.
+5. These settings have no public API, CLI command, or MCP tool. Never curl
+   `api.netlify.com` or read local auth tokens to inspect or change them —
+   hand the user the dashboard path and checklist; on failure, report what
+   you tried and stop.
+6. Identity setup, auth code, and OAuth providers for app users belong to the
+   netlify-identity skill — route there; this skill only picks the layer.
+7. For company-wide app-level SSO with a single sign-in (no double login),
+   the Auth0 extension — federating to the corporate IdP — is the
+   recommendation before the two-layer stack.
+8. The description's triggers must include the SSO-session symptoms users
+   actually report — "logged out mid-session", 401s on an SSO-protected
+   site, token expiry/refresh — not only setup phrasing. The
+   `Netlify-Site-Protection-Expires-In` guidance is unreachable if the
+   skill never triggers on the symptom.

--- a/agent-plugin/skills/netlify-ai-gateway/SKILL.md
+++ b/agent-plugin/skills/netlify-ai-gateway/SKILL.md
@@ -1,240 +1,200 @@
 ---
 name: netlify-ai-gateway
-description: Reference for Netlify AI Gateway — the managed proxy that routes calls to OpenAI, Anthropic, and Google Gemini SDKs without provider API keys. Use this skill any time the user wants to add AI on a Netlify site (chat, completion, reasoning, image generation, image-to-image edit/stylize), choose or change a model, wire up the OpenAI / Anthropic / @google/genai SDK, decide which provider to use for an image-gen feature (it's Gemini-only on the gateway), or debug "model not found" / "API key missing" against the gateway. Required reading before pinning a model — the gateway exposes a curated subset, not every provider model.
+description: Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing provider API keys or accounts — the gateway injects credentials automatically. Reach for this when you add an AI chatbot or completion endpoint, generate images or text with Gemini/GPT/Claude, summarize form submissions with AI, build an LLM-backed API route, stream a long AI generation, or wire up any server-side AI provider call on Netlify. Covers provider SDK setup, injected env vars, model availability, rate limits, credit costs, streaming for long generations, and local dev with netlify dev or the Vite plugin.
 ---
 
 # Netlify AI Gateway
 
-> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model returns an HTTP error from the gateway.
+Call AI providers from Netlify server-side compute using each provider's **official SDK** with zero credential config — the gateway injects the API keys and base URLs the SDKs already read. Instantiate the client with no args (except OpenRouter, which needs an explicit base URL).
 
-> **First-deploy requirement:** The AI Gateway only activates after a site has had at least one production deploy. Local dev (`netlify dev`, `@netlify/vite-plugin`) will NOT have gateway access on a brand-new project until you deploy to production once.
+**Never do these** (they silently fail or cost money):
+- **Not browser-callable.** The gateway lives in Functions/Edge Functions only. Never call it from client-side React/browser code.
+- **Runtime-only credentials.** Never call the gateway from build scripts, prerender/SSG, or build plugins — those get no credentials and fail. Do AI work at request time; cache to Netlify Blobs if output must look precomputed.
+- **60s sync timeout.** A slow generation in a synchronous function is killed at 60s. Stream it (SDK streaming + `ReadableStream`), or use a background function that persists output for the client to fetch.
+- **Requires a production deploy.** The gateway does not activate until the project has at least one production deploy — even in local dev.
+- **Don't hardcode model lists.** Model availability changes; check the live providers endpoint rather than baking in IDs.
 
-> **Usage is credit-metered:** Gateway calls draw down your Netlify AI credit/inference allowance and start returning errors once it's exhausted — there's no separate provider bill behind it. Budget for this explicitly in any bulk or fan-out design (generating content for hundreds of rows/pages, retry loops), and don't retry unbounded.
+## Function example
 
-Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
+File: `netlify/functions/joke.js` (`mkdir -p netlify/functions`). Install: `npm install openai`.
 
-## How It Works
-
-The AI Gateway acts as a proxy — you use standard provider SDKs but point them at Netlify's gateway URL. Netlify auto-injects both the base URL and a placeholder API key for each provider, then authenticates upstream on your behalf.
-
-Always make the call through the provider's official SDK, constructed bare (`new OpenAI()`, `new Anthropic()`, `new GoogleGenAI()`) — the SDK reads the auto-injected base URL and key from the environment. **Don't hand-roll the gateway call with a raw `fetch()` and a manually-read `process.env.OPENAI_API_KEY`** (or a hardcoded key/URL): the injected key is only a placeholder, and rolling your own request bypasses the supported path the gateway expects.
-
-## Setup
-
-1. Enable AI on your site in the Netlify UI
-2. Deploy to production at least once — the gateway does not activate until then
-3. Install the provider SDK you want to use
-
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
-
-## Using OpenAI SDK
-
-```bash
-npm install openai
-```
-
-```typescript
+```js
+import process from "process";
 import OpenAI from "openai";
 
-const openai = new OpenAI();
-// `OPENAI_API_KEY` and `OPENAI_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+export default async () => {
+  const client = new OpenAI(); // reads OPENAI_API_KEY + OPENAI_BASE_URL
+  try {
+    const res = await client.responses.create({
+      model: "gpt-5-mini",
+      input: [{ role: "user", content: "Give me a random short dad joke" }],
+      reasoning: { effort: "minimal" },
+    });
+    return Response.json({
+      joke: res.output_text?.trim() || "Out of jokes",
+      model: res.model,
+      tokens: { input: res.usage.input_tokens, output: res.usage.output_tokens },
+    });
+  } catch (e) {
+    return Response.json({ error: `${e}` }, { status: 500 });
+  }
+};
 
-const completion = await openai.chat.completions.create({
-  model: "gpt-4o-mini",
-  messages: [{ role: "user", content: "Hello!" }],
-});
+export const config = { path: "/api/joke" }; // route, local + deployed
 ```
 
-## Using Anthropic SDK
+Client-side fetch just hits the route:
 
-```bash
-npm install @anthropic-ai/sdk
+```jsx
+const res = await fetch("/api/joke");
+const data = await res.json();
 ```
 
-```typescript
-import Anthropic from "@anthropic-ai/sdk";
+## Provider SDKs (modern — instantiate with no args)
 
-const client = new Anthropic();
-// `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+Each SDK auto-reads the injected env vars. **OpenRouter is the exception:** its base URL must be passed explicitly.
 
-const message = await client.messages.create({
-  model: "claude-sonnet-4-5-20250929",
+```js
+// Anthropic — npm i @anthropic-ai/sdk
+import Anthropic from '@anthropic-ai/sdk';
+const anthropic = new Anthropic(); // ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
+await anthropic.messages.create({
+  model: 'claude-sonnet-4-5-20250929',
   max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-## Using Google Gemini SDK
-
-Use `@google/genai` (the unified Google GenAI SDK). The older `@google/generative-ai` package does not pick up the gateway env vars.
-
-```bash
-npm install @google/genai
-```
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
-// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
-// injection isn't shadowed.
-
-const response = await ai.models.generateContent({
-  model: "gemini-2.5-flash",
-  contents: "Hello!",
-});
-
-const text = response.text;
-```
-
-## In a Netlify Function
-
-```typescript
-import type { Config, Context } from "@netlify/functions";
-import OpenAI from "openai";
-
-export default async (req: Request, context: Context) => {
-  const { prompt } = await req.json();
-  const openai = new OpenAI();
-
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  return Response.json({
-    response: completion.choices[0].message.content,
-  });
-};
-
-export const config: Config = {
-  path: "/api/ai",
-  method: "POST",
-};
-```
-
-Return the reply as JSON with `Response.json({...})`, even when the request only asks for "the reply text" back — a raw `text/plain` body breaks JSON-consuming clients and diverges from the convention used everywhere else in Netlify Functions.
-
-## Image Generation
-
-Image generation on the gateway is supported through **Gemini image models** (e.g., `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`). OpenAI's image models (`gpt-image-1`, `dall-e-*`) are **not** routed through the gateway.
-
-Both text-to-image and image-to-image use the same `generateContent` method as chat — only the model and response shape differ. The image is returned as base64 `inlineData` on a content part, not as a URL.
-
-### Text-to-image
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: "A watercolor portrait of a corgi wearing a beret",
-});
-
-const imagePart = response.candidates[0].content.parts.find(
-  (p) => p.inlineData,
-);
-const base64 = imagePart.inlineData.data;
-const mimeType = imagePart.inlineData.mimeType; // e.g. "image/png"
-const bytes = Buffer.from(base64, "base64");
-```
-
-### Image-to-image (edit / stylize an input image)
-
-Pass the source image as an additional content part with `inlineData`:
-
-```typescript
-const sourceBase64 = sourceBuffer.toString("base64");
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: [
-    { text: "Restyle this photo as a Picasso-era cubist portrait" },
-    { inlineData: { mimeType: "image/png", data: sourceBase64 } },
-  ],
+```js
+// OpenAI — npm i openai
+import OpenAI from 'openai';
+const openai = new OpenAI(); // OPENAI_API_KEY + OPENAI_BASE_URL
+await openai.chat.completions.create({
+  model: 'gpt-5',
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-The response shape is the same — pull `base64` and `mimeType` off the first part with `inlineData`. Most callers persist the bytes to Netlify Blobs (see `netlify-blobs/SKILL.md`) and serve a URL back to the client rather than returning multi-MB base64 in the function response.
+```js
+// Google Gemini — npm i @google/genai
+import { GoogleGenAI } from '@google/genai';
+const genAI = new GoogleGenAI({}); // GEMINI_API_KEY + GOOGLE_GEMINI_BASE_URL
+await genAI.models.generateContent({
+  model: 'gemini-2.5-pro',
+  contents: 'Hello!',
+});
+```
 
-## Environment Variables
+```js
+// OpenRouter — npm i @openrouter/sdk — base URL REQUIRED
+import { OpenRouter } from '@openrouter/sdk';
+const openRouter = new OpenRouter({
+  serverURL: process.env.OPENROUTER_BASE_URL, // API key auto-read from OPENROUTER_API_KEY
+});
+await openRouter.chat.send({
+  chatRequest: {
+    model: 'x-ai/grok-4.5',
+    messages: [{ role: 'user', content: 'Hello!' }],
+  },
+});
+```
 
-All of these are injected automatically by Netlify when AI is enabled. Setting your own value for any of the per-provider vars disables gateway routing.
+**OpenRouter models via the OpenAI SDK:** you can reach any OpenRouter-served model (xAI, DeepSeek, Meta, Mistral, Qwen) through the plain OpenAI SDK — just pass the model ID in OpenRouter notation, no extra config:
 
-| Variable | Provider | Purpose |
-|---|---|---|
-| `OPENAI_BASE_URL` | OpenAI | Gateway endpoint |
-| `OPENAI_API_KEY` | OpenAI | Placeholder; satisfies the SDK's "key required" check |
-| `ANTHROPIC_BASE_URL` | Anthropic | Gateway endpoint |
-| `ANTHROPIC_API_KEY` | Anthropic | Placeholder; satisfies the SDK's "key required" check |
-| `GOOGLE_GEMINI_BASE_URL` | Google Gemini | Gateway endpoint |
-| `GEMINI_API_KEY` | Google Gemini | Placeholder; satisfies the SDK's "key required" check |
-| `NETLIFY_AI_GATEWAY_BASE_URL` | (universal) | Provider-agnostic gateway endpoint |
-| `NETLIFY_AI_GATEWAY_KEY` | (universal) | Provider-agnostic gateway key |
+```js
+await openai.chat.completions.create({
+  model: 'deepseek/deepseek-v4-flash-0731',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
 
-The real upstream API keys live on Netlify's side. The per-provider `*_API_KEY` vars are placeholders so the SDKs construct successfully; the gateway authenticates server-side. You don't read these yourself — the SDK picks them up.
+## Injected environment variables
 
-When your own code needs some *other* environment value (a config flag, a model name you've parameterized), prefer `Netlify.env.get("VAR")` — it works in Netlify Functions and Edge Functions, and Edge Functions expose **only** `Netlify.env.get`. (In a framework's own server routes, use whatever that framework documents for env access — often `process.env`.)
+Set in all Netlify compute contexts at function init **only if you have not already set them** at project/team level (Netlify never overrides your keys):
 
-## Local Development
+| Provider | Vars |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
+| Anthropic | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
+| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_GEMINI_BASE_URL` |
+| OpenRouter | `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL` |
 
-With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are injected automatically into the local process — but only after the site has had at least one production deploy. A brand-new local-only project will see "API key missing" or "model not found" errors until you deploy.
+**Gemini special case:** Netlify will **not** inject `GEMINI_API_KEY` / `GOOGLE_GEMINI_BASE_URL` if either `GOOGLE_API_KEY` or `GOOGLE_VERTEX_BASE_URL` is set (use those to point at Vertex or your own Google credentials).
 
-Local injection also requires the working directory to be **linked** to the Netlify site. `netlify dev` pulls the gateway base URL and placeholder key from the linked site's environment, so an unlinked directory has no site context — nothing is injected and gateway calls fail even when the site has already been deployed to production. Run `netlify link` (or `netlify init`) in the project first, then start `netlify dev`. A bare framework dev server started outside `netlify dev` / `@netlify/vite-plugin` also gets no gateway env vars.
+**Always injected, never collide with your provider vars:**
+- `NETLIFY_AI_GATEWAY_KEY`
+- `NETLIFY_AI_GATEWAY_BASE_URL`
 
-## Usage metering and where the gateway runs
+Use the SDK path with the per-provider injected vars above as your default. Reach for `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` only when a third-party or unsupported library needs the credentials passed explicitly — that's the correct time to configure them by hand.
 
-**Gateway usage is credit-metered.** Calls draw down your Netlify AI credit/inference allowance; when that limit is reached the gateway **pauses** and returns errors until the allowance resets or is raised. There's no separate provider bill to fall back on — an unbounded loop of gateway calls burns the allowance and then starts failing, so budget for it and don't retry indefinitely.
+## Local dev
 
-**Gateway credentials are runtime-only.** Netlify injects the base URL and placeholder key only into runtime compute — deployed functions, edge functions, and server-rendered routes at request time. They are **not** present during the build: AI calls made at build time, in prerender/SSG, or in a build plugin get no gateway credentials and fail. Do AI work at request time (in a function or server route) and cache the result if you need it to look precomputed (e.g. to Netlify Blobs) — don't call the gateway from build scripts or static-generation hooks.
+Two supported paths — both still require an existing production deploy:
+- **Netlify CLI:** `netlify dev` (full support). Needs `npm install -g netlify-cli@latest` and `netlify login`.
+- **Netlify Vite plugin:** install `@netlify/vite-plugin`, add `netlify()` to `vite.config.js` plugins, run your normal `npm run dev` — gateway access without `netlify dev`.
 
-## No browser-callable gateway — proxy through server code
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import netlify from "@netlify/vite-plugin";
 
-Gateway credentials are injected only into server-side runtime compute (functions, edge functions, server-rendered routes). There is **no browser-callable gateway endpoint**: client-side JavaScript has no gateway credentials, and there is no public URL a browser can hit to reach the gateway directly. Client code (React/Vue/vanilla JS running in the browser) that constructs a provider SDK against the gateway will find no key and fail — and "fixing" it by hardcoding a real provider key in the client leaks that key to every visitor AND bypasses the gateway (a user-set key disables Netlify's auto-injection).
+export default defineConfig({
+  plugins: [react(), netlify()],
+})
+```
 
-The correct pattern is to proxy: put the gateway call in a **Netlify Function** (or edge function / server route), and have the browser `fetch()` your own endpoint (e.g. `/api/chat`). The function talks to the gateway server-side with the auto-injected credentials and returns the result to the client. Never import a provider SDK into a browser bundle to call the gateway, and never expose a provider API key to the client.
+## Enable & deploy
 
-## Long generations and the function timeout
+1. Be on a credit-based plan (Free, Personal, Pro; Enterprise via Account Manager). Legacy plans must switch to a current plan.
+2. Link a project: `netlify init`.
+3. **Deploy to production at least once** — required to activate: `netlify deploy --prod --open`.
+4. Don't disable AI Features; don't set your own provider keys unless you intend to override.
 
-A gateway call runs inside your function, so it is bound by the **60-second synchronous function timeout**. Large completions, reasoning models, and image generations can run longer than that, and a synchronous function that exceeds the ceiling is terminated before it can respond. Two mitigations:
+## Constraints & gotchas
 
-- **Stream the response.** Enable streaming on the SDK call and return a `ReadableStream` (e.g. `Content-Type: text/event-stream`), forwarding the provider's tokens/chunks as they arrive — for example `stream: true` on the OpenAI SDK, `client.messages.stream(...)` on Anthropic, or `generateContentStream(...)` on `@google/genai`. Streaming sends bytes to the client incrementally instead of buffering the whole completion inside the sync window, and is the right default for interactive chat and long text.
-- **Use a background function** for long, fire-and-forget jobs (batch generation, large image renders). Background functions run up to 15 minutes, but they return a `202` immediately and their return value is ignored — they cannot hand the result back to the caller. Persist the output (e.g. to Netlify Blobs or a database) and have the client poll or fetch it.
+- **Plan gating:** Credit-based plans only (Free/Personal/Pro; Enterprise via Account Manager).
+- **Context window:** input capped at **200k tokens**.
+- **Rate limits** (per team, across all projects, per minute, in credits): Free 90 / Personal 450 / Pro 1,800 / Enterprise 9,000. Set up [rate limiting rules](https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/) on AI functions to prevent visitor abuse driving up cost.
+- **Credit cost:** tokens → USD (provider published rates) → credits. **$1 USD of usage = 180 credits.** Enable [auto recharge](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/configure-auto-recharge/) or buy [credit packs](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/buy-credit-packs/) to meet demand.
+- **No request headers passed through** — you can't enable proprietary header-gated experimental features.
+- **Batch inference not supported.**
+- **OpenAI priority processing not supported.**
+- **Prompt caching:** Anthropic — only the default 5-minute ephemeral cache; OpenAI — a per-account `prompt_cache_key` is set; Gemini — explicit context caching not supported.
+- **Zero Data Retention only:** the gateway only routes to ZDR providers. A model listed in the OpenRouter directory is **not** served if no ZDR host offers it. Browse the ZDR-filtered catalog at https://openrouter.ai/models?zdr=true.
+- **Model list is dynamic** — served-directly models (Anthropic, OpenAI, Gemini) are enumerated from a live endpoint; OpenRouter-served models (xAI, DeepSeek, Meta, Mistral, Qwen) use OpenRouter notation. Don't hardcode; check availability at runtime.
+- **Privacy:** the gateway does not store prompts or outputs.
 
-Don't leave a slow synchronous generation unstreamed and assume it will finish — bound the model and `max_tokens`, and choose streaming or a background function based on how long the job runs.
+## Reference
 
-## Errors & Troubleshooting
+- Full docs, quickstart, and example projects (AI SEO Image Generator, form-submission summaries, TanStack Start chat app) at [AI Gateway overview](https://docs.netlify.com/build/ai-gateway/overview.md) and [quickstart](https://docs.netlify.com/build/ai-gateway/quickstart-for-ai-gateway.md).
 
-- **Unsupported model:** the gateway returns an HTTP error. Check the "Available Models" list below — the gateway exposes a curated subset, not every model the provider offers.
-- **`OPENAI_API_KEY missing` (or equivalent) at runtime:** AI Features are disabled on the site, or the project has not had a production deploy yet.
-- **Calls succeed but skip the gateway / aren't tracked:** check you haven't set your own `*_API_KEY`. Any user-set provider key shadows Netlify's auto-injection and routes directly to the provider.
-- **Limits:** 200k-token context window. Batch inference, custom request headers, and OpenAI priority processing are not supported. Anthropic prompt caching is limited to the 5-minute ephemeral cache; Gemini explicit caching is not supported.
+<!-- GAP: source does not enumerate concrete model IDs (dynamic live endpoint); model names in examples are illustrative only. -->
+<!-- GAP: SDK streaming + background-function patterns are mandated by house rules but no streaming code example exists in the source. -->
 
-## Available Models
+<!-- system: agent-context/ai-gateway/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (ai-gateway)
 
-_Verified 2026-04-30 against the live AI Gateway providers list. The user-facing reference is https://docs.netlify.com/build/ai-gateway/overview/ — re-check before pinning a new model._
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
 
-### Anthropic (chat)
-- `claude-haiku-4-5`, `claude-haiku-4-5-20251001`
-- `claude-sonnet-4-0`, `claude-sonnet-4-20250514`, `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-6`
-- `claude-opus-4-1-20250805`, `claude-opus-4-20250514`, `claude-opus-4-5`, `claude-opus-4-5-20251101`, `claude-opus-4-6`, `claude-opus-4-7`
-
-### OpenAI (chat / reasoning / Codex)
-- gpt-4 family: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
-- gpt-5: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-5-codex`; dated: `gpt-5-2025-08-07`, `gpt-5-mini-2025-08-07`
-- gpt-5.1: `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`; dated: `gpt-5.1-2025-11-13`
-- gpt-5.2: `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.2-pro`; dated: `gpt-5.2-2025-12-11`, `gpt-5.2-pro-2025-12-11`
-- gpt-5.3: `gpt-5.3-chat-latest`, `gpt-5.3-codex` (no unversioned `gpt-5.3`)
-- gpt-5.4: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`; dated: `gpt-5.4-2026-03-05`, `gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano-2026-03-17`, `gpt-5.4-pro-2026-03-05`
-- gpt-5.5: `gpt-5.5`, `gpt-5.5-pro`; dated: `gpt-5.5-2026-04-23`, `gpt-5.5-pro-2026-04-23`
-- Reasoning (o-series): `o3`, `o3-mini`, `o4-mini`
-
-### Google Gemini (chat + image)
-- Chat: `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`, `gemini-flash-latest`, `gemini-flash-lite-latest`
-- Image: `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`
-
+1. Use the provider SDK with the injected env credentials — don't hand-roll
+   a raw `fetch()` against the gateway, even though raw REST is a supported
+   surface. The body must not present raw REST or the
+   `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` pair as a
+   recommended path — but it MUST still document the pair as facts: always
+   injected, never collide with user-set provider vars, and the right choice
+   when a third-party or unsupported library needs explicit configuration.
+   Demote the recommendation; keep the knowledge.
+2. The gateway is not browser-callable: calls belong in functions or edge
+   functions, never client-side code.
+3. Model availability changes: don't hardcode model lists; check the live
+   providers endpoint.
+4. Gateway credentials are runtime-only: never call the gateway from build
+   scripts, prerender/SSG, or build plugins — those calls get no credentials
+   and fail. Do AI work at request time and cache the result (e.g. to
+   Netlify Blobs) if it must look precomputed.
+5. Gateway calls in a synchronous function are bound by the 60-second
+   timeout: stream long generations (SDK streaming + `ReadableStream`), or
+   use a background function that persists output for the client to fetch —
+   never leave a slow generation unstreamed and assume it finishes.

--- a/agent-plugin/skills/netlify-blobs/SKILL.md
+++ b/agent-plugin/skills/netlify-blobs/SKILL.md
@@ -1,171 +1,264 @@
 ---
 name: netlify-blobs
-description: Guide for using Netlify Blobs for file and asset storage — images, documents, uploads, exports, cached binary artifacts. Covers getStore(), CRUD operations, metadata, listing, deploy-scoped vs site-scoped stores, and local development. Do NOT use Blobs as a dynamic data store — use Netlify Database for that.
+description: Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/value API from Functions, Edge Functions, and Build Plugins. Use when a task involves saving user file or image uploads, persisting form or contact-form submissions, storing generated output from Background Functions (sitemaps/processed media/bulk-email results), building read-only asset stores, adding client-side blob expiration, or wiring file-based blob uploads at deploy time. Not for per-user, transactional, or relational data (counters/balances/sessions) — reach for Netlify DB there instead.
 ---
 
 # Netlify Blobs
 
-Netlify Blobs is zero-config object storage for **files and assets**: images, documents, uploads, exports, cached binary artifacts. Available from any Netlify compute (functions, edge functions, framework server routes). No provisioning required.
+Modern import — reach for this:
 
-**Not for dynamic data.** If the project needs to store records, user data, application state, or anything queryable, use Netlify Database instead — see `netlify-database/SKILL.md`. Reach for Blobs when the thing you're storing is a file or an asset blob, not a record.
-
-```bash
-npm install @netlify/blobs
+```ts
+import { getStore, getDeployStore, listStores } from "@netlify/blobs";
 ```
 
-## Before you build
+Install: `npm install @netlify/blobs`. Fetch API is required (built into Node 18+); otherwise pass a custom `fetch`.
 
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any blob storage — answers shape access patterns, scoping, and how the assets are served back to clients:
+Two ways to open a store — use the **options-object form** when you need `consistency` or a custom `fetch` (the string form cannot pass them):
 
-- **What kind of asset?** (User uploads, exported documents, cached binaries, generated images — drives the storage and serving pattern.)
-- **Who should be able to read it?** Public (anyone with a URL, or an unauthenticated endpoint that streams the blob) or private (only authenticated users, gated by your server code)? Blobs have **no built-in access control** — the serving layer is the gate. When in doubt, default to private; making something public later is easy, while pulling back data that was inadvertently exposed is not.
-- **Site-scoped or deploy-scoped?** Site-scoped (`getStore()`) persists across deploys — the right default for user data. Deploy-scoped (`getDeployStore()`) is tied to a single deploy and disappears when that deploy is replaced — use only when the lifecycle should match a deploy (e.g., per-deploy build artifacts).
-- **Roughly how big and how many?** Helps choose between a single large blob vs many small keyed blobs, and informs whether you'll need `list({ prefix: ... })` patterns.
+```ts
+const store = getStore("file-uploads");                          // string form
+const store = getStore({ name: "animals", consistency: "strong" }); // options form
+```
 
-**If you don't have preferences here, tell me what the assets are and I'll pick sensible defaults** — typically site-scoped with private access, served through an authenticated function.
+`siteID`, `token`, `deployID`, and `region` are set automatically inside Functions, Edge Functions, and Build Plugins — do not pass them manually there.
 
-## Getting a Store
+## Choosing the store type — READ THIS FIRST
 
-```typescript
+- **`getStore(name)`** — site-scoped. Persists across deploys and is **shared across ALL deploy contexts**. Code on a Deploy Preview reads, overwrites, and deletes production data. **Never seed throwaway data or run destructive tests from a preview.**
+- **`getDeployStore(name)`** — scoped to one deploy; isolated from production. Use this for throwaway/per-deploy data, or use a context-specific store name for isolation.
+
+Blobs have **no built-in access control** — the serving function is the gate. Default to private: gate reads behind an authenticated function rather than exposing blobs publicly. Never accept an arbitrary caller-supplied key against a store holding sensitive data.
+
+## Common tasks
+
+### Persist a user upload with metadata (`set`)
+
+```ts
 import { getStore } from "@netlify/blobs";
+import type { Context } from "@netlify/functions";
+import { v4 as uuid } from "uuid";
 
-const store = getStore({ name: "my-store" });
+export default async (req: Request, context: Context) => {
+  const form = await req.formData();
+  const file = form.get("file") as File;
+  const key = uuid();
 
-// Use "strong" consistency when you need immediate reads after writes
-const store = getStore({ name: "my-store", consistency: "strong" });
+  const uploads = getStore("file-uploads");
+  await uploads.set(key, file, {
+    metadata: { country: context.geo.country.name }
+  });
+
+  return new Response("Submission saved");
+};
 ```
 
-## CRUD Operations
+Edge Function form is identical but imports `Context` from `@netlify/edge-functions`.
 
-These are the **only** store methods. Do not invent others.
+### Persist JSON (`setJSON`)
 
-### Create / Update
-
-```typescript
-// String or binary data
-await store.set("key", "value");
-await store.set("key", fileBuffer);
-
-// With metadata
-await store.set("key", data, {
-  metadata: { contentType: "image/png", uploadedAt: new Date().toISOString() },
-});
-
-// JSON data
-await store.setJSON("key", { name: "Example", count: 42 });
+```ts
+const uploads = getStore("json-uploads");
+await uploads.setJSON(key, data, { metadata: { country: context.geo.country.name } });
 ```
 
-### Read
+### Read a blob (`get`) — always null-check
 
-```typescript
-// Text (default)
-const text = await store.get("key");                    // string | null
+```ts
+const uploads = getStore("file-uploads");
+const entry = await uploads.get(key);          // string by default
+if (entry === null) {
+  return new Response(`Could not find ${key}`, { status: 404 });
+}
+return new Response(entry);
+```
 
-// Typed retrieval
-const json = await store.get("key", { type: "json" });  // object | null
-const stream = await store.get("key", { type: "stream" });
-const blob = await store.get("key", { type: "blob" });
-const buffer = await store.get("key", { type: "arrayBuffer" });
+Pass `type` for other formats: `get(key, { type: "json" | "arrayBuffer" | "blob" | "stream" | "text" })`.
 
-// With metadata
-const result = await store.getWithMetadata("key");
-// { data: any, etag: string, metadata: object } | null
+### Atomic conditional write
 
-// Metadata only (no data download)
-const meta = await store.getMetadata("key");
-// { etag: string, metadata: object } | null
+Write only if the key is new:
+
+```ts
+const { modified } = await store.set("jane@netlify.com", "Jane Doe", { onlyIfNew: true });
+if (!modified) return new Response("Email already exists", { status: 400 });
+```
+
+Write only if the entry matches a known ETag (compare-and-swap):
+
+```ts
+const { modified } = await store.set(key, "New Jane", { onlyIfMatch: etag });
+if (!modified) return new Response("Cached data is stale", { status: 400 });
+```
+
+**Do not build counters, balances, or read-modify-write logic on a blob key** — even with `onlyIfMatch` retries. That is transactional data; use Netlify DB.
+
+### List blobs
+
+```ts
+const { blobs } = await store.list();          // auto-paginates all pages
+// blobs: [ { etag: "\"etag1\"", key: "..." }, ... ]
+```
+
+Manual pagination (returns an `AsyncIterator`):
+
+```ts
+for await (const entry of store.list({ paginate: true })) {
+  console.log(entry.blobs);
+}
+```
+
+Hierarchical listing — group keys with `/`, set `directories: true` to list one level, and use a **trailing slash** on `prefix` to drill in (without it, `cats` would also match `catsuit`):
+
+```ts
+const { blobs, directories } = await store.list({ directories: true });      // top level
+const catList = await store.list({ directories: true, prefix: "cats/" });    // inside cats/
+```
+
+### List stores
+
+```ts
+const { stores } = await listStores();   // does NOT include deploy-specific stores
 ```
 
 ### Delete
 
-```typescript
-await store.delete("key");
+```ts
+await store.delete(key);                       // resolves undefined
+const { deletedBlobs } = await store.deleteAll(); // deletes the whole store; 0 if it didn't exist
 ```
 
-### List
+### Build plugin — write to a deploy-specific store
 
-```typescript
-const { blobs } = await store.list();
-// blobs: [{ etag: string, key: string }, ...]
+Build plugins can **READ from any of the site's stores, but can WRITE only to deploy-specific stores** (`getDeployStore`).
 
-// Filter by prefix
-const { blobs } = await store.list({ prefix: "uploads/" });
+```js
+import { readFile } from "node:fs/promises";
+import { getDeployStore } from "@netlify/blobs";
+import { v4 as uuid } from "uuid";
+
+export const onPostBuild = async () => {
+  const file = await readFile("some-file.txt", "utf8");
+  const uploads = getDeployStore("file-uploads");
+  await uploads.set(uuid(), file);
+};
 ```
 
-`store.list()` **auto-paginates**: a plain `await store.list()` transparently fetches every page and returns the complete `blobs` array — you do NOT hand-roll page cursors or offsets. For a very large store, pass `{ paginate: true }` to get an async iterator and stream results a page at a time instead of buffering every key in memory:
+### Client-side expiration (no server-side TTL)
 
-```typescript
-for await (const page of store.list({ paginate: true })) {
-  for (const { key } of page.blobs) {
-    // handle each key
-  }
+Blobs have no TTL. Store a timestamp in metadata, check it on read, and `delete` when expired:
+
+```ts
+await uploads.set(key, await req.text(), {
+  metadata: { expiration: new Date("2024-01-01").getTime() }
+});
+const entry = await uploads.getWithMetadata(key);
+const { expiration } = entry.metadata;
+if (expiration && expiration < Date.now()) {
+  await uploads.delete(key);
 }
 ```
 
-Pass `{ directories: true }` to group keys by the `/` delimiter (folder-style): the result's `blobs` holds keys at the current level and `directories` holds the common prefixes, which you drill into with `prefix`. Keys are a flat namespace — `/` is only a naming convention that `prefix` and `directories` let you navigate.
+### Conditional read with ETag (`getWithMetadata`)
 
-## Store Types
-
-- **Site-scoped** (`getStore()`): Persist across all deploys. Use for most cases.
-- **Deploy-scoped** (`getDeployStore()`): Tied to a specific deploy lifecycle.
-
-**A site-scoped store is shared across ALL deploy contexts.** Production, deploy previews, and branch deploys all read and write the *same* `getStore()` store — unlike Netlify Database, which forks a separate branch per preview, Blobs does not isolate previews. Code running on a deploy preview reads, overwrites, and deletes the same production data. Don't run destructive tests or seed throwaway data against a `getStore()` store from a preview — it hits production. When you need per-context isolation, use `getDeployStore()`, or partition by deploy context with a context-specific store `name` or key prefix.
-
-## Consistency and concurrency
-
-Blobs are **eventually consistent by default**: an immediate read right after a write may return the previous value or `null`. Opt into **strong** consistency when you need read-your-writes. You can set it once on the store, or request it per read:
-
-```typescript
-import { getStore } from "@netlify/blobs";
-
-const store = getStore({ name: "my-store", consistency: "strong" });
-
-// or just for a single read that must see the latest write:
-const fresh = await store.get("key", { consistency: "strong" });
+```ts
+const { data, etag } = await uploads.getWithMetadata("my-key", { etag: cachedETag });
+if (etag === cachedETag) {
+  // data is null — cached copy still fresh
+}
 ```
 
-Strong reads are **slower** than eventual reads, so don't make everything strong "to be safe" — reserve it for the reads that genuinely need the latest write (typically a read right after a write in the same request). For read-heavy access to data that rarely changes, the default eventual consistency is faster and is the right choice.
+`getWithMetadata` returns `{ data, etag, metadata }`, or `null` if the key is absent. `getMetadata(key)` returns `{ metadata, etag }` (no blob body) — use it to check existence cheaply.
 
-Blobs has **no concurrency control**: there is no locking and there are no transactions, and concurrent writes to the same key are **last-write-wins** — one silently overwrites the other. Do NOT build counters, balances, or any read-modify-write logic over a single blob key and expect it to be correct under concurrent traffic (two requests can both read the old value and both write back, losing an update). When you need atomic or transactional updates, use Netlify Database (see `netlify-database/SKILL.md`), which provides real transactions — not Blobs.
+## API surface
 
-## Limits
+Store instance methods:
+- `set(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`. `value` is `ArrayBuffer | Blob | string`.
+- `setJSON(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`.
+- `get(key, { consistency, type })` → blob in requested format, or `null`.
+- `getWithMetadata(key, { consistency, etag, type })` → `{ data, etag, metadata }` or `null`.
+- `getMetadata(key, { consistency, etag })` → `{ metadata, etag }` or `null`.
+- `list({ directories, paginate, prefix })` → `{ blobs, directories }` (auto-paginates unless `paginate: true`).
+- `delete(key)` → `undefined`.
+- `deleteAll()` → `{ deletedBlobs }`.
 
-| Limit | Value |
-|---|---|
-| Max object size | 5 GB |
-| Metadata per object | 2 KB |
-| Store name max length | 64 bytes |
-| Key max length | 600 bytes |
+Module functions:
+- `listStores({ paginate })` → `{ stores }`. Excludes deploy-specific stores.
 
-Object metadata is capped at **2 KB per object** — it's for small descriptors (content type, size, timestamps, a status flag), not a place to stash large JSON. Anything bigger belongs in the blob value itself, not in `metadata`.
+## Configuration
 
-## Local Development
+### Consistency
+Default is **eventual**: writes are globally readable immediately; updates and deletes propagate within **60 seconds**. Opt into **strong** consistency per store or per read:
 
-Local dev uses a sandboxed store (separate from production). For Vite-based projects, install `@netlify/vite-plugin` to enable local Blobs access. Otherwise, use `netlify dev`.
-
-**Common error**: "The environment has not been configured to use Netlify Blobs" — install `@netlify/vite-plugin` or run via `netlify dev`.
-
-## Inspecting blobs from the CLI
-
-The Netlify CLI can read and write blobs directly — useful for debugging, seeding, or a one-off fix without writing and deploying a function:
-
-```bash
-netlify blobs:list <store-name>
-netlify blobs:get <store-name> <key>
-netlify blobs:set <store-name> <key> <value>
-netlify blobs:delete <store-name> <key>
+```ts
+const store = getStore({ name: "animals", consistency: "strong" }); // whole store
+await store.get("dog", { consistency: "strong" });                  // single read
 ```
 
-These act on the linked site's store, so link the project first (`netlify link`). Reach for these documented subcommands for manual inspection or repair rather than the raw API.
+The CLI always uses strong consistency.
 
-## Uploading blobs at build time
+### Regions (deploy-specific stores)
+Deploy-specific stores default to the function's region. Override with `region`:
 
-You don't have to write blobs from runtime code — you can seed a store during the build by writing files into a special directory. Files placed in `.netlify/blobs/deploy/` during the build are uploaded to a **deploy-scoped** store and are then readable at runtime via `getDeployStore()`. The path under that directory becomes the blob key (so `.netlify/blobs/deploy/products/1.json` is stored under the key `products/1.json`). This avoids a runtime function looping over `store.set` on a cold start.
+```ts
+const uploads = getDeployStore({ name: "file-uploads", region: "ap-southeast-2" });
+```
 
-To attach metadata to a build-time blob, add a JSON sidecar whose name is the blob's filename prefixed with `$` and suffixed with `.json` — metadata for `logo.png` goes in `$logo.png.json`. Read these blobs back with `getDeployStore()`, not `getStore()`: they live in the deploy-scoped store and are replaced when the deploy is replaced.
+Available regions: https://docs.netlify.com/build/functions/configuration#region
 
-## When a store operation fails
+### File-based uploads (no build plugin)
+Place blob files under `.netlify/blobs/deploy/` in the site's base directory; Netlify uploads them to deploy-specific stores (preserving directory structure) after build, before deploy.
 
-If a `get`/`set` call throws in a deployed function, don't guess at a fix or route around it — the exact error is in the **function logs**, and it almost always names the cause. Read it first. Common causes: the store isn't reachable from the calling context, a missing or mismatched store `name`, or a read-after-write timing gap (an immediate read of a just-written key — use `consistency: "strong"` when you need read-your-writes).
+- Attach metadata with a sibling JSON file prefixed with `$`: `$mouse.jpg.json` for `mouse.jpg`, `dogs/$good-boy.jpg.json` for `dogs/good-boy.jpg`.
+- Metadata files must be valid JSON or **the deploy fails**.
+- `.netlify/blobs/deploy` is **wiped before each build** — files must be created DURING the build (build command or plugin). Files committed to the repo beforehand are NOT uploaded.
+- Requires continuous deployment or CLI deploys.
 
-The store exposes only the documented methods above; there is no lower-level REST endpoint to fall back on. If the logs don't resolve it, report the exact error plus the affected site/deploy to the user and stop. Reaching around a failing store — direct `https://api.netlify.com/...` calls, reading auth tokens off disk, or inventing endpoints — can't work (those aren't supported surfaces) and risks corrupting or losing the very data you're trying to save.
+## Constraints & gotchas
+
+- **Store names:** no `/`, no `:`, max 64 bytes.
+- **Keys:** non-empty, cannot start with `/`, max 600 bytes, any Unicode. (UTF-8: most chars 1 byte, some more, e.g. `à` = 2 bytes.)
+- **Sizes:** object ≤ 5 GB; metadata ≤ 2 KB.
+- **Pagination pages:** `list` and `listStores` cap pages at 1,000 entries/stores.
+- **Last write wins** — no concurrency control beyond `onlyIfMatch` / `onlyIfNew`.
+- **Go Functions cannot access Blobs.**
+- **Local dev (Netlify Dev)** uses a sandboxed local store: no file-based uploads, and you cannot read production data.
+- **Not supported** under Netlify's HIPAA-compliant hosting.
+- Deploy deletion cleans up deploy-specific stores only; other stores need manual deletion or your own expiration logic.
+- Downloading a deploy does NOT include deploy-specific blobs; locking a published deploy does NOT prevent writes to its deploy-specific stores.
+- Encrypted at rest and in transit; blobs are reachable only through your own site.
+
+## When something fails
+Surface the error and read the function logs. Do not invent REST endpoints or side-channel APIs to retry a failed store operation.
+
+## CLI & migration
+Inspect blobs with `netlify blobs:list` / `:get` / `:set` / `:delete` — reference: https://cli.netlify.com/commands/blobs/
+
+If you wrote to site-wide stores with `@netlify/blobs` ≤ 6.5.0, data becomes inaccessible after upgrading (namespacing change). Migrate with the latest CLI, which makes the store accessible on 7.0.0+:
+
+```sh
+netlify recipes blobs-migrate YOUR_STORE_NAME
+```
+
+<!-- system: agent-context/blobs/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (blobs)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Blobs is not a database. For dynamic, per-user, or transactional data,
+   use Netlify DB — Blobs is for objects, files, and cache-like state.
+2. When a store operation fails, surface the error and read the function
+   logs — do not invent REST endpoints or side-channel APIs to retry.
+3. `netlify blobs:list/get/set/delete` exist for inspection; the CLI
+   reference is their source of truth — link, don't restate.
+4. Blobs have no built-in access control — the serving function is the gate.
+   When in doubt, default to private: gate reads behind an authenticated
+   function rather than exposing blobs publicly.
+5. Site-scoped stores are shared across ALL deploy contexts — code on a
+   deploy preview reads, overwrites, and deletes production data. Never run
+   destructive tests or seed throwaway data from previews; use
+   `getDeployStore()` or a context-specific store name for isolation.
+6. Don't build counters, balances, or read-modify-write logic on a blob key —
+   even with `onlyIfMatch` retries. That's transactional data; use Netlify DB.
+7. Build plugins: state BOTH halves — they can read from any of the site's
+   stores, but write only to deploy-specific stores (`getDeployStore`).

--- a/agent-plugin/skills/netlify-caching/SKILL.md
+++ b/agent-plugin/skills/netlify-caching/SKILL.md
@@ -1,186 +1,311 @@
 ---
 name: netlify-caching
-description: Guide for controlling caching on Netlify's CDN. Use when configuring cache headers, setting up stale-while-revalidate, implementing on-demand cache purge, or understanding Netlify's CDN caching behavior. Covers Cache-Control, Netlify-CDN-Cache-Control, cache tags, durable cache, and framework-specific caching patterns.
+description: Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add caching or cache-control headers to a function response, tune cache TTL or stale-while-revalidate, set up the durable cache, vary a cache key by query/header/cookie/country/language, purge or invalidate the cache by site or cache tag, use the programmatic Cache API (caches.open/match/put) or @netlify/cache helpers (fetchWithCache/cacheHeaders/getCacheStatus), speed up an expensive API call, add ISR or on-demand revalidation, or debug why a response is or isn't cached via the Cache-Status header.
 ---
 
-# Caching on Netlify
+# Netlify caching
 
-## Default Behavior
+## Cache-control header to reach for
 
-**Static assets** are cached automatically:
-- CDN: cached for 1 year, invalidated on every deploy
-- Browser: always revalidates (`max-age=0, must-revalidate`)
-- No configuration needed
+Dynamic responses (Functions, Edge Functions, proxies) are **NOT cached by default** — you must opt in. Set `Netlify-CDN-Cache-Control` on the response:
 
-**Dynamic responses** (functions, edge functions, proxied) are **not cached by default**. Add cache headers explicitly.
+```ts
+import type { Context } from "@netlify/functions";
 
-**Only `GET` requests are cached.** Netlify's CDN caches responses to `GET` requests only. Responses to `POST`, `PUT`, `PATCH`, `DELETE`, and other non-`GET` methods are never cached, no matter what cache headers you set on them. If a response needs to be CDN-cacheable, expose it on a `GET` route (put the inputs in the URL/query string) — you cannot make the CDN cache a mutating `POST` endpoint by adding cache headers.
-
-## Cache-Control Headers
-
-Three headers control caching, from most to least specific:
-
-| Header | Who sees it | Use case |
-|---|---|---|
-| `Netlify-CDN-Cache-Control` | Netlify CDN only (stripped before browser) | CDN-only caching |
-| `CDN-Cache-Control` | All CDN caches (stripped before browser) | Multi-CDN setups |
-| `Cache-Control` | Browser and all caches | General caching |
-
-### Common Patterns
-
-```typescript
-// Cache at CDN for 1 hour, browser always revalidates
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, s-maxage=3600, must-revalidate",
-    "Cache-Control": "public, max-age=0, must-revalidate",
-  },
-});
-
-// Stale-while-revalidate (serve stale for 2 min while refreshing)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=120",
-  },
-});
-
-// Durable cache (shared across edge nodes, serverless functions only)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, durable, max-age=60, stale-while-revalidate=120",
-  },
-});
-```
-
-### Immutable Assets
-
-For fingerprinted files (hash in filename):
-
-```toml
-# netlify.toml
-[[headers]]
-for = "/assets/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-```
-
-## Cache Tags and On-Demand Purge
-
-Tag responses for selective cache invalidation:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-Tag": "product,listing",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
-```
-
-Purge by tag:
-
-```typescript
-import { purgeCache } from "@netlify/functions";
-
-export default async () => {
-  await purgeCache({ tags: ["product"] });
-  return new Response("Purged", { status: 202 });
+export default async (req: Request, context: Context) => {
+  return new Response("Hello world", {
+    headers: {
+      'Netlify-CDN-Cache-Control': 'public, durable, max-age=60, stale-while-revalidate=120'
+    }
+  });
 };
 ```
 
-Purge entire site:
+Header choice (most specific wins; `CDN-Cache-Control`/`Cache-Control` always pass downstream):
+- `Netlify-CDN-Cache-Control` — Netlify CDN only. **Reach for this.**
+- `CDN-Cache-Control` — all CDNs that support it.
+- `Cache-Control` — any CDN or the browser.
 
-```typescript
-await purgeCache();
+**Legacy path to avoid:** On-demand Builders do **not** support these headers or `Netlify-Vary` — they use a TTL pattern and key on URL path only. Don't reach for ODBs in new code.
+
+## Footguns (read first)
+
+- **Only `GET` is cached.** POST/PUT/etc. are never cached regardless of headers — expose cacheable data on a GET route (inputs in the URL or query string).
+- **`netlify dev` does not emulate the CDN cache.** A local cache miss every time is expected. Verify caching on a deployed URL (Deploy Preview or production) via its `Cache-Status` header.
+- **Without `Netlify-Vary: query=...`, the full query string is the cache key** — every distinct query string (`utm_*`, `fbclid`, …) is a separate cache entry. Enumerate only the params that change the response.
+- **Static assets are fresh for up to a year** — a shorter `max-age` is ignored. They change only on a new deploy or manual purge.
+- **basic-auth on ANY page disables caching for the ENTIRE site.**
+- **`durable` is serverless-only** — it has no effect on Edge Function responses.
+- Never opt sensitive content out of automatic invalidation — it can stay publicly cached after deploys/firewall changes.
+
+## Directives
+
+- `public` cache it / `private` browser-only, not Netlify's shared cache / `no-store` don't cache.
+- `s-maxage=N` seconds in Netlify's shared cache (overrides `max-age` there).
+- `max-age=N` seconds in any cache.
+- `stale-while-revalidate=N` serve stale for N seconds after expiry while revalidating in background.
+- `durable` (serverless only) store in Netlify's durable cache so other edge nodes reuse it instead of re-invoking the function.
+
+Defaults when no header is set — static: `Netlify-CDN-Cache-Control: public, s-maxage=31536000, must-revalidate`; dynamic: `Cache-Control: public, max-age=0, must-revalidate`.
+
+## Cache key variation — `Netlify-Vary`
+
+Comma-delimited instructions on the response; pipe-delimited value lists:
+
+```
+Netlify-Vary: query=item_id|page, country=es+de|us, cookie=ab_test|is_logged_in
 ```
 
-`purgeCache()` picks up the site ID and credentials automatically **only when it runs inside a deployed Netlify Function**. Called from anywhere else — a local script, a CI job, a build step, or any code outside the Netlify Functions runtime — it has no ambient credentials, and you must pass a Netlify personal access token (and the site ID). Read the token from an environment variable; never hardcode it:
+- `query=a|b` subset, or bare `query` for all params. Keys case-sensitive; param order irrelevant.
+- `header=Device-Type|App-Version` — custom + most standard headers.
+- `language=en|es+pt` — `+` groups; checked against `Accept-Language` with quality weighting.
+- `country=us|es+pt` — GeoIP, ISO 3166-1 two-letter codes; `+` groups.
+- `cookie=ab_test|is_logged_in` — target specific keys, not the whole `Cookie` header.
 
-```typescript
-await purgeCache({
-  token: process.env.NETLIFY_PURGE_TOKEN, // a Netlify personal access token, from env
-  siteID: process.env.NETLIFY_SITE_ID,
-  tags: ["product"],
-});
+**Cannot vary by header on:** `Accept*`, `Cache-Control`, `Connection`, `Content-Length`, `Cookie`, `Host`, `If-*`, `Range`, `Referer`, `Upgrade`, `User-Agent`. For language/cookie/format use `Vary: Accept-Language`/`Vary: Cookie` or the specific `Netlify-Vary` instruction.
+
+**Consistency rule:** a URL must return the same `Netlify-Vary` on every response — the first cached response's instructions win and later ones are ignored. `Netlify-Vary` + standard `Vary` are both respected (use `Vary` for format/encoding, and to pass instructions to an upstream CDN like Cloudflare).
+
+## Cache tags & opt-out
+
+Tag responses for taggable purging:
+
+```
+Netlify-Cache-Tag: tag1,tag2,tag3
 ```
 
-`Netlify-Cache-Tag` is **purge-only**: tagged responses are still cleared by automatic deploy-based invalidation like everything else. The tag only lets you purge them on demand between deploys.
+- `Netlify-Cache-Tag` (Netlify CDN) wins over `Cache-Tag` (passed downstream). Some providers strip `Cache-Tag` — set both when proxying through them.
+- Constraints: case-insensitive, UTF-8 only, ≤1024 chars/tag, ≤500 tags/response.
 
-### Surviving deploys with `Netlify-Cache-ID`
+Opt a response out of automatic atomic-deploy invalidation with `Netlify-Cache-ID` (comma-separated; auto-registered as cache tags for purging; separate 500-ID limit):
 
-To keep a cached response *across* deploys, set a `Netlify-Cache-ID` header. A response carrying it is **excluded from automatic deploy-based invalidation** — it persists across deploys and clears only on explicit purge. The `Netlify-Cache-ID` value also auto-registers as a purge tag, so you purge it by that same id:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-ID": "catalog",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
+```
+Netlify-Cache-ID: cms-proxy,product,image
 ```
 
-```typescript
+After opting out, purge on-demand after relevant changes (e.g. redirect/proxy or function changes behind a `Netlify-Cache-ID`).
+
+## On-demand invalidation (purge)
+
+Purge from a **deployed function** with `purgeCache` (site ID is passed automatically):
+
+```ts
 import { purgeCache } from "@netlify/functions";
 
-// Purge by the same id — it doubles as a purge tag.
-await purgeCache({ tags: ["catalog"] });
+export default async () => {
+  await purgeCache(); // no args = purge everything for the site
+  return new Response("Purged!", { status: 202 });
+};
 ```
 
-## Cache Key Variation
+Purge by tag, optionally targeting a deploy/subdomain:
 
-`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
+```ts
+import { purgeCache } from "@netlify/functions";
 
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Vary": "cookie=ab_test|is_logged_in",
-  },
+export default async (req: Request) => {
+  const cacheTag = new URL(req.url).searchParams.get("tag");
+  if (!cacheTag) return;
+  await purgeCache({
+    tags: [cacheTag],
+    deployAlias: "deploy-preview-11",
+    domain: "early-access.company.com",
+  });
+  return new Response("Purged!", { status: 202 });
+};
+```
+
+**Ambient credentials only work inside a deployed function.** From CI, local scripts, or the build, pass `token` (a personal access token read from an env var — never hardcoded) and `siteID`.
+
+**Lambda-compatible functions** use the legacy `module.exports.handler = async (event, context) => {…}` signature and must pass `context.clientContext.custom.purge_api_token`:
+
+```ts
+import { purgeCache } from "@netlify/functions";
+
+module.exports.handler = async (event, context) => {
+  const token = context.clientContext.custom.purge_api_token;
+  await purgeCache({ tags: ["tag1", "tag2"], token });
+  return { body: "Purged!", statusCode: 202 };
+};
+```
+
+Direct API (from outside a function) — `POST https://api.netlify.com/api/v1/purge` with `Authorization: Bearer <personal_access_token>` and `Content-Type: application/json`:
+
+```sh
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <personal_access_token>" \
+  --data '{"site_slug": "mysitename", "cache_tags": ["news"], "deploy_alias": "deploy-preview-11", "domain": "early-access.company.com"}' \
+  'https://api.netlify.com/api/v1/purge'
+```
+
+- Purge by site: `site_id` or `site_slug`. By tag: `cache_tags` + site. Omitting `cache_tags` purges the whole site; an **empty** `cache_tags` list purges NOTHING.
+- Identifier mapping: in the UI (Project configuration > General > Project details), **Project ID** = `site_id`, **Project name** = `site_slug`. See https://docs.netlify.com/api-and-cli-guides/api-guides/get-started-with-api#get-site.
+- **Rate limit:** each tag or site can be purged only twice per 5s — exceeding returns `429`.
+
+## Cache API (`caches` global)
+
+Programmatic read/write of HTTP responses from Functions/Edge Functions. Use for caching individual components of a route or arbitrary fetches, alongside header-based route caching.
+
+**Scope rule:** `caches.open()` anywhere, but `match`/`put`/`delete` **only inside the request handler** — doing them at module/global scope throws.
+
+```ts
+import type { Config, Context } from "@netlify/functions";
+
+const cache = await caches.open("my-cache"); // ok in global scope
+
+export default async (req: Request, context: Context) => {
+  const request = new Request("https://example.com/expensive-api");
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const fresh = await fetch(request);
+  if (fresh.ok) {
+    cache.put(request, fresh.clone()).catch((error) => {
+      console.error("Failed to add to the cache:", error);
+    });
+  }
+  return fresh;
+};
+
+export const config: Config = { path: "/cache-api-example" };
+```
+
+`CacheStorage` subset:
+- `caches.match(request)` → `Response` from any cache, or `undefined`.
+- `caches.open(name)` → `Cache`. Distinct names fragment the cache and lower hit ratio — use few, meaningful names.
+
+`Cache` methods (all require `caches.open()`):
+- `cache.match(request)` → `Response` | `undefined`.
+- `cache.put(request, response)` → adds a response.
+- `cache.add(request)` / `cache.addAll(requests)` → fetch + store.
+- `cache.delete(request)` → `true`.
+- `keys()` is **not implemented** — no way to list contents.
+
+Consistency: reads/writes strongly consistent; **deletes eventually consistent** (a deleted entry may still return briefly).
+
+**Cannot cache:** partial responses (206), `Vary: *`, or non-`GET` methods. Responses need a cache-control header with `max-age`/`s-maxage` ≥ 1s, `public` (not `private`/`no-cache`/`no-store`), and a 2xx status — otherwise storage errors. For responses you don't control, rewrite headers with `fetchWithCache`.
+
+**Limits per invocation:** 100 lookups, 20 insertions/deletions. Exceeding: further lookups return nothing; writes/deletes no-op. Limits are shared across edge functions in a request but separate between serverless and edge functions. Cache data is per-region (not replicated), auto-invalidated on redeploy and on `max-age`/`s-maxage` expiry.
+
+## `@netlify/cache` module
+
+Install to get helpers, time constants (`MINUTE`/`HOUR`/`DAY`), and a `caches` export for local dev:
+
+```
+npm install @netlify/cache
+```
+
+**Local-dev workaround:** the `caches` global isn't part of Node.js. Netlify provides it in its Functions/Edge runtimes (live and under `netlify dev`), but if you run your framework's own dev server the global is undefined and throws — import it instead:
+
+```ts
+import { caches } from "@netlify/cache";
+const cache = await caches.open("my-cache");
+```
+
+Requires Netlify CLI 20.0.3+; nothing persists locally (lookups return nothing, writes/deletes don't mutate). No functional change from the global.
+
+### `cacheHeaders(settings)` → header object
+
+```ts
+import { cacheHeaders, DAY } from "@netlify/cache";
+
+const headers = {
+  "x-custom-header": "some value",
+  ...cacheHeaders({
+    ttl: 2 * DAY,          // s-maxage
+    swr: HOUR,             // stale-while-revalidate
+    durable: true,
+    tags: ["product", "sale"],
+    overrideDeployRevalidation: ["tag"], // opt out of atomic-deploy invalidation
+    vary: {
+      cookie: ["ab_test_name", "ab_test_bucket"],
+      query: ["item_id", "page"], // or true for all
+      country: ["us", ["es", "pt"]], // nested = OR
+      language: ["en"],
+      header: ["Device-Type"],
+    },
+  }),
+};
+```
+
+For only generic (non-Netlify) headers, use the `cdn-cache-control` npm module instead.
+
+### `fetchWithCache(resource, options?, cacheSettings?)`
+
+Drop-in `fetch` that returns a cached response or fetches, stores, and returns. `cacheSettings` override conflicting response headers; with `swr`, background revalidation is handled automatically.
+
+```ts
+import { fetchWithCache, DAY } from "@netlify/cache";
+
+const response = await fetchWithCache("https://example.com/expensive-api", {
+  ttl: 2 * DAY,
+  tags: ["product", "sale"],
+  vary: { cookie: ["ab_test_name"], query: ["item_id", "page"] },
 });
 ```
 
-- `query=param1|param2` — key on the named query parameters
-- `header=X-Custom` — key on the named request header
-- `cookie=ab_test|is_logged_in` — key on the named cookies
-- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
-- `language=en|fr` — key on the listed `Accept-Language` values
+### `getCacheStatus(response | headers | headerString)`
 
-Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
+Returns `{ hit, caches: { durable: { hit, stale, stored, ttl }, edge: { hit, stale } } }`.
 
-## Framework-Specific Caching
-
-### Next.js
-ISR uses Netlify's durable cache automatically (runtime 5.5.0+). `revalidatePath` and `revalidateTag` trigger cache purge.
-
-### Astro / Remix
-Full control over cache headers in server routes. Set `Netlify-CDN-Cache-Control` in responses for CDN caching.
-
-### Nuxt
-Default Nitro preset handles caching. ISR-style patterns use `routeRules` with `swr` or `isr` options.
-
-### Vite SPA
-Static assets are cached by default. API responses from Netlify Functions need explicit cache headers.
-
-**The full query string is part of the cache key by default.** With no `Netlify-Vary: query=` directive, every distinct query string is cached as a separate entry — so appending tracking or marketing params (`?utm_source=…`, `fbclid`, and the like) silently fragments the cache into many near-duplicate entries and lowers the hit rate, even when those params don't change the response. Add `Netlify-Vary: query=<names>` listing only the parameters that actually affect the output; the CDN then keys on just those and ignores all other query params, collapsing the variants onto one cache entry.
-
-## Local Development
-
-`netlify dev` does not emulate the CDN cache. Header-based CDN caching is only observable on a deployed site: locally, cache headers pass through untouched, nothing is stored in or served from the CDN cache, Cache-API reads return no persisted entries, and the `Cache-Status` response header is absent. A "cache miss every time" on `localhost` is expected, not a bug — you cannot validate `Netlify-Vary` keying, cache tags, durable cache, or purge behavior locally. Verify caching on a deployed URL instead (a Deploy Preview or production) and read its `Cache-Status` header.
-
-## Debugging
-
-Check the `Cache-Status` response header. Netlify emits it in the RFC 9211 format — one entry per named cache layer the request passed through, not a bare `HIT`/`MISS`:
-
-```
-Cache-Status: "Netlify Edge"; fwd=miss, "Netlify Durable"; hit; ttl=3600
+```ts
+const { hit, edge, durable } = getCacheStatus(response);
 ```
 
-- A named layer (`"Netlify Edge"`, `"Netlify Durable"`) with `hit` — served from that cache
-- `fwd=miss` — the entry was not in that layer, so the request was forwarded onward
-- `ttl=…` — remaining freshness (seconds) for a hit
+### `needsRevalidation(response)` → boolean
 
-## Constraints
+Only needed when calling `cache.match`/`cache.put` directly (not with `fetchWithCache`+`swr`). True when a Cache-API response is stale within its SWR window — return it, then revalidate in `context.waitUntil` and `cache.put` the fresh copy:
 
-- Basic auth disables caching for the entire site
-- Durable cache is serverless functions only (not edge functions)
-- Same URL must return identical `Netlify-Vary` headers across responses
-- Deploy invalidation is scoped to deploy context (production vs preview)
+```ts
+if (cached) {
+  if (needsRevalidation(cached)) {
+    context.waitUntil(
+      fetch(request).then((fresh) => {
+        const response = new Response(fresh.body, {
+          headers: { ...Object.fromEntries(fresh.headers), ...cacheHeaders({ ttl: MINUTE, swr: HOUR }) },
+        });
+        return cache.put(request, response);
+      })
+    );
+  }
+  return cached;
+}
+```
+
+## Durable cache
+
+Add `durable` (serverless only) so edge nodes lacking a local copy check the shared durable cache before invoking the function — fewer invocations, better cache-miss latency. Eventually consistent, so multiple regions may still invoke the function a few times per version. Co-located with the site's functions region. Works with `Netlify-Vary`, SWR, and on-demand invalidation. **Next.js:** Next Runtime 5.5.0+ uses the durable cache automatically.
+
+## Debugging with `Cache-Status`
+
+Netlify sets `Cache-Status` (RFC 9211) on all responses. Check it on a **deployed** URL. Look for values starting `"Netlify Edge"` or `"Netlify Durable"`:
+
+- `"Netlify Edge"; fwd=miss` — nothing cached.
+- `"Netlify Edge"; hit` — served from cache.
+- `"Netlify Edge"; hit; fwd=stale` — stale served while revalidating (SWR).
+- Durable stored on miss: `"Netlify Durable"; fwd=uri-miss; stored=true; ttl=3600`.
+- Durable hit: `"Netlify Durable"; hit; ttl=1234`.
+
+`ttl` negative = seconds since expiry. Each request may hit a different cache instance — without production traffic or `durable`, expect several empty caches before a hit; repeat requests to warm one.
+
+<!-- Gaps: package/method inconsistency in @netlify/cache local-dev docs (caches import shown with cache.set, not the documented cache.put) resolved to cache.put per Cache API surface. -->
+
+<!-- system: agent-context/caching/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (caching)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Only `GET` responses are cached by the CDN. `POST`/`PUT`/etc. are never
+   cached regardless of headers — expose cacheable data on a `GET` route
+   (put the inputs in the URL or query string).
+2. Without `Netlify-Vary: query=...`, the full query string is the cache key —
+   every distinct query string (`utm_*`, `fbclid`, ...) is a separate cache
+   entry. Enumerate only the params that actually change the response.
+3. `netlify dev` does not emulate the CDN cache — a cache miss every time
+   locally is expected, not a bug. Verify caching behavior on a deployed URL
+   (Deploy Preview or production) via its `Cache-Status` header.
+4. `purgeCache()` has ambient credentials only inside a deployed function.
+   From CI, local scripts, or the build, pass `token` (a personal access
+   token read from an env var, never hardcoded) and `siteID`.

--- a/agent-plugin/skills/netlify-config/SKILL.md
+++ b/agent-plugin/skills/netlify-config/SKILL.md
@@ -1,228 +1,302 @@
 ---
 name: netlify-config
-description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, the `[dev]` block that controls `netlify dev` (command, port, targetPort, framework), or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, edge functions config, and the `[dev]` block (including when `framework` must be `"#custom"` — required when both a custom `command` and `targetPort` are set).
+description: Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy contexts alongside environment variables/scopes and the Secrets Controller plus redirect/rewrite/proxy and custom-header rules. Use when setting a build command or publish directory, adding redirect or rewrite or proxy rules, configuring custom headers or basic auth, setting or scoping environment variables and secrets, wiring up a monorepo or SPA fallback, or skipping unnecessary builds. Reach for this whenever you touch netlify.toml or ask "why is my env var undefined in a function" or "how do I redirect this path".
 ---
 
-# Netlify Configuration (netlify.toml)
+# Netlify configuration
 
-Place `netlify.toml` at the repository root. In a monorepo, Netlify searches for the config and uses the **first** one it finds: the package directory (the subdirectory containing the site), then the base directory, then the repository root — so put a site-specific `netlify.toml` in the package directory to take precedence over root-level config (see the **netlify-deploy** skill's monorepo notes).
+`netlify.toml` lives at the repo root (or set `base`/package directory for monorepos). Settings in `netlify.toml` **override** the Netlify UI on conflict. `_headers` and `_redirects` are extensionless plain-text files in the **publish directory**, processed **before** `netlify.toml` rules.
 
-**`netlify.toml` takes precedence over the Netlify UI.** When the same property (build command, publish directory, an environment variable, a redirect, a header) is configured in both places, the value in `netlify.toml` wins and silently overrides the corresponding Netlify UI setting — the dashboard field still shows its old value but is inert. Once a `netlify.toml` is present, treat it as the source of truth and change settings there, not in the UI.
+## Footguns (read first)
 
-## Build Settings
+- **Env vars in `netlify.toml` are NOT available to functions or edge functions at runtime** — reading them there returns `undefined`. Vars declared in `netlify.toml` only get the **Builds** and **Post processing** scopes. Set runtime vars in the UI or with `netlify env:set`.
+- **Never put secrets in client-prefixed vars** (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, …) — they are inlined into the client bundle. `--secret` does not protect them.
+- **`.env` is not read by the Netlify build system** — import variables into Netlify first (`netlify env:import`). The CLI reads `.env` only for local builds.
+- **Direct env injection into `netlify.toml` (`key = "$VAR"`) is unsupported** — except signed proxy redirects. Use a build plugin or `sed` in the build command.
+- **`[[redirects]]` and `[[headers]]` are global** — NOT context-aware, cannot be scoped to branches/contexts. Workaround: per-context build command copies a custom file into the publish directory.
+- **Proxy rewrites time out at 26 seconds.** HTTP `307` is unsupported — use `302`.
+
+## `netlify.toml` — core structure
 
 ```toml
 [build]
-  base = "project/"          # Base directory (default: root)
-  command = "npm run build"  # Build command
-  publish = "dist/"          # Output directory
+  base = "project/"          # base directory
+  publish = "build-output/"  # relative to base, default /
+  command = "npm run build"  # runs in Bash shell
+  [build.environment]
+    NODE_VERSION = "18"
+
+[context.production]         # production branch deploy
+  command = "make publish"
+  environment = { NODE_VERSION = "14.15.3" }
+[context.deploy-preview]     # PR/MR previews
+  publish = "dist/"
+[context.branch-deploy]      # non-production branches
+  command = "echo branch"
+[context.dev.environment]    # local dev env vars ONLY
+  NODE_ENV = "development"
+[context.staging]            # a specific branch name
+  command = "echo staging"
+[context."feat/branch"]      # quote branches with special chars
+  command = "echo special"
 ```
 
-## Redirects
+Context precedence (least → most specific): UI settings < base context-aware key < `[context.production|deploy-preview|branch-deploy|dev]` < `[context.branchname]`. Only `[build]` and `[[plugins]]` are context-aware. All paths are absolute relative to the base directory (root `/` default).
 
-```toml
-# Basic redirect
-[[redirects]]
-from = "/old"
-to = "/new"
-status = 301              # 301 (default), 302, 200 (rewrite), 404
+Config file search order: package directory → base directory → root.
 
-# SPA catch-all
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
-
-# Splat (wildcard)
-[[redirects]]
-from = "/blog/*"
-to = "/news/:splat"
-
-# Path parameters
-[[redirects]]
-from = "/users/:id"
-to = "/api/users/:id"
-status = 200
-
-# Force (override existing files)
-[[redirects]]
-from = "/app/*"
-to = "/index.html"
-status = 200
-force = true
-
-# Proxy to external service
-[[redirects]]
-from = "/api/*"
-to = "https://api.example.com/:splat"
-status = 200
-[redirects.headers]
-  X-Custom = "value"
-
-# Country/language conditions
-[[redirects]]
-from = "/*"
-to = "/fr/:splat"
-status = 200
-conditions = { Country = ["FR"], Language = ["fr"] }
-```
-
-**Rule order matters** — Netlify processes the first matching rule. Place specific rules before general ones.
-
-Redirect rules can also live in a plain-text `_redirects` file in the publish directory. If both a `_redirects` file and `[[redirects]]` in `netlify.toml` exist, the `_redirects` file rules are processed **first**, then the `netlify.toml` rules, reading top to bottom — and the first matching rule wins. The same ordering applies to a `_headers` file versus `[[headers]]`. Because a `_redirects` rule can silently shadow a `netlify.toml` rule for the same path, keep overlapping rules in a single source.
-
-## Headers
-
-```toml
-[[headers]]
-for = "/*"
-[headers.values]
-  X-Frame-Options = "DENY"
-  X-Content-Type-Options = "nosniff"
-
-[[headers]]
-for = "/assets/*"
-[headers.values]
-  Cache-Control = "public, max-age=31536000, immutable"
-```
-
-Headers apply only to files served from Netlify's CDN (not to function or edge function responses — set those in code).
-
-## Deploy Contexts
-
-Override settings per deploy context:
-
-```toml
-[context.production]
-command = "npm run build"
-environment = { NODE_ENV = "production" }
-
-[context.deploy-preview]
-command = "npm run build:preview"
-
-[context.branch-deploy]
-command = "npm run build:staging"
-
-[context.dev]
-environment = { NODE_ENV = "development" }
-
-# Specific branch
-[context."staging"]
-command = "npm run build:staging"
-```
-
-**`[[redirects]]` and `[[headers]]` are global — they cannot be scoped to a deploy context.** Context tables like `[context.production]` work for keys such as `[build]`, `[build.environment]`, and `[[plugins]]`, but redirect and header rules apply to every context no matter where you place them in the file; there is no `[context.production.redirects]` or context-nested `[[redirects]]`. For context-specific redirects or headers, use the per-deploy escape hatch: generate a `_redirects` or `_headers` file during that context's build (those files ship per deploy), or gate the behavior on a runtime signal in an edge function.
-
-## Environment Variables
-
-```toml
-[build.environment]
-NODE_VERSION = "20"
-
-[context.production.environment]
-API_URL = "https://api.prod.com"
-
-[context.deploy-preview.environment]
-API_URL = "https://api.staging.com"
-```
-
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
-
-**Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
-
-### CLI Management
-
-```bash
-# Set
-netlify env:set API_KEY "value"
-netlify env:set API_KEY "value" --secret              # Hidden from logs
-netlify env:set API_KEY "value" --context production   # Context-specific
-
-# Get
-netlify env:get API_KEY
-
-# List
-netlify env:list
-netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
-
-# Import from file
-netlify env:import .env
-
-# Delete
-netlify env:unset API_KEY
-```
-
-**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
-
-### Context Scoping
-
-Variables set via the CLI can also be scoped to deploy contexts:
-
-```bash
-netlify env:set API_URL "https://api.prod.com" --context production
-netlify env:set API_URL "https://api.staging.com" --context deploy-preview
-netlify env:set DEBUG "true" --context branch:feature-x
-```
-
-This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
-
-When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
-
-For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-frameworks** skill; for function-side details, see **netlify-functions**.
-
-## Functions Configuration
+## Functions config
 
 ```toml
 [functions]
-directory = "netlify/functions"   # Default
-node_bundler = "esbuild"
+  directory = "functions/"           # default: YOUR_BASE_DIR/netlify/functions
+  node_bundler = "esbuild"           # prefer esbuild; zisi is the JS default
+  external_node_modules = ["package-1"]
+  included_files = ["files/*.md", "!files/skip.md"]
 
-# Scheduled function
-[functions."cleanup"]
-schedule = "@daily"
+[functions."api_*"]                  # glob filter; values CONCATENATE across matches
+  external_node_modules = ["package-2"]
 ```
 
-Use the single-table `[functions]` form for global settings and `[functions."name-or-glob"]` for per-function overrides. There is **no** `[[functions]]` array-of-tables and no path-based function routing table in `netlify.toml` — functions are routed by file (served at `/.netlify/functions/{name}`) or by an in-code `path`/`config` export, not by config.
+- `esbuild` = smaller/faster artifacts; TypeScript functions **always** use `esbuild`.
+- `external_node_modules` applies only with `esbuild`. `included_files`: `*` wildcard, `!` excludes; paths absolute to base.
 
-## Edge Functions Configuration
+## Environment variables
+
+Set runtime/scoped vars via CLI/UI/API (not `netlify.toml`):
+
+```sh
+netlify env:set MY_KEY value --secret     # --secret marks an env var secret
+netlify env:import .env                    # site-level, all scopes, all contexts
+netlify env:list --plain --context production > .env
+netlify env:unset MY_KEY
+```
+
+**Keep any `.env` snapshot gitignored — never commit it.**
+
+**Types:** site vars (one site) vs shared vars (whole team; Pro/Enterprise; Team Owners only).
+
+**Scopes** (Pro/Enterprise; default = all): **Builds**, **Functions** (also Edge Functions + On-demand Builders), **Runtime** (forms, signed proxy redirects), **Post processing** (snippet injection). Vars from `netlify.toml` are locked to **Builds** + **Post processing**.
+
+**Scope precedence is independent per scope:** a site variable scoped only to Builds does NOT shadow a shared variable for the Functions scope — the shared value still applies there. Site beats shared only within the scopes the site variable actually carries.
+
+**Deploy-context values:** `Production`, `Deploy Previews`, `Branch deploys` (override per-branch with a `Branch` value, wildcard suffix `release/*`), `Preview server`, `Local development`.
+
+**Overrides:** `netlify.toml` vars override same-key UI/CLI/API vars. Site var beats shared var per its scopes/contexts.
+
+**Limits:** keys ≤ 255 chars, alphanumeric + underscore, first char a letter (`KEY1` ok; `1KEY`/`_KEY1` invalid). Values ≤ 5,000 chars (functions within AWS limits). Reserved read-only names can't be overridden.
+
+### Build variables
+
+Settable in `netlify.toml` `[build.environment]`: `NODE_VERSION`, `NODE_ENV`, `NPM_VERSION`, `NPM_FLAGS`, `NPM_TOKEN`, `YARN_VERSION`, `PNPM_FLAGS`, `BUN_VERSION`, `RUBY_VERSION`, `PHP_VERSION`, `PYTHON_VERSION`, `GO_VERSION`, `HUGO_VERSION`, `NETLIFY_USE_YARN`, `CI`, etc.
+
+**Set in UI/CLI only (NOT `netlify.toml`, which is read after clone):** `AWS_LAMBDA_JS_RUNTIME`, `GIT_LFS_ENABLED`, `GIT_LFS_FETCH_INCLUDE`, `NETLIFY_BUILD_DEBUG`.
+
+Read-only build metadata (examples): `NETLIFY`, `BUILD_ID`, `CONTEXT` (`production`/`deploy-preview`/`branch-deploy`/`dev`), `BRANCH`, `HEAD`, `COMMIT_REF`, `CACHED_COMMIT_REF`, `PULL_REQUEST`, `REVIEW_ID`, `URL`, `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `DEPLOY_ID`, `SITE_NAME`, `SITE_ID`, `ACCOUNT_ID`.
+
+Access: Bash `$VAR_NAME` in build/ignore commands; `process.env.VAR_NAME` in Node scripts and plugins. Scope must include **Builds**.
+
+### Inject env values into headers/redirects
 
 ```toml
-[[edge_functions]]
-path = "/admin/*"
-function = "auth"
-excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
-
-# Import map for Deno URL imports
-[functions]
-deno_import_map = "./import_map.json"
+[build]
+  command = "sed -i \"s|HEADER_PLACEHOLDER|${PROD_API_LOCATION}|g\" netlify.toml && yarn build"
 ```
 
-## Dev Server
+Substitution only reaches `[[headers]]`/`[[redirects]]` (read after build); NOT available to build plugins. Alternatively mutate `netlifyConfig` in a local build plugin.
+
+## Redirects & rewrites
+
+`_redirects` (one rule per line) or `[[redirects]]`. Rules process top-down; first match wins. `_redirects`/file rules run before `netlify.toml`.
+
+```
+/home            /                301
+/my-redirect     /                302
+/store id=:id    /blog/:id        301
+/news/*          /blog/:splat
+/*               /index.html      200          # SPA fallback
+```
 
 ```toml
-[dev]
-command = "npm start"       # Dev server command
-port = 8888                 # Netlify Dev port
-targetPort = 3000           # Your app's dev server port
-framework = "#auto"         # "#auto", "#static", "#custom"
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 302              # default 301
+  force = true             # default false; shadow an existing URL
+  query = { id = ":id" }
+  conditions = { Language = ["en"], Country = ["US"], Role = ["admin"] }
+  [redirects.headers]
+    X-From = "Netlify"
 ```
 
-**If you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`.** With `framework = "#auto"` (the default) Netlify Dev runs its own detector and ignores your custom `command`; `"#custom"` tells it to run your `command` as the app server and connect to `targetPort`. Setting `command` + `targetPort` while leaving `framework` at `#auto` (or omitting it) is a silent misconfiguration.
+- **Force/shadow:** you can't shadow an existing URL by default — append `!` in `_redirects` or `force = true` in toml.
+- **Splats** (`*`) only at the end of a path segment (`/jobs/*.html` won't work). Can't exclude a path from a splat — order a more specific rule first.
+- **Query:** `id=:id` matches URLs with *only* `id` and no other params. List optional-param variants most-general-last.
+- **Trailing slash:** URLs are normalized before rules run; you cannot add/remove a trailing slash via a redirect (infinite loop). Pretty URLs (on by default) handle standardization.
+- **Country/Language conditions:** no spaces (`Country=au,nz`). `Country` = ISO 3166-1 alpha-2; `Language` = browser/locale codes, matches the FIRST `Accept-Language` entry. `nf_country`/`nf_lang` cookies override.
+- **Domain redirects:** HTTP and HTTPS need separate rules unless forcing SSL; the domain must be assigned to the site.
+- Role-based redirects with external auth: Enterprise only. HTTP `307` unsupported → use `302`.
+- **10,000+ redirects:** favor wildcards/placeholders; serialization across `_redirects` + `netlify.toml` can fail the deploy if too large — consider Edge Functions.
 
-## Plugins
+### Rewrites & proxies (status 200)
+
+```
+/api/*            https://api.example.com/:splat        200
+/netlify-site/*   https://my-other-site.netlify.app/:splat  200
+```
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  headers = { X-From = "Netlify" }
+```
+
+- No cross-team rewrites between Netlify sites. Infinite-loop rules (from == to) are ignored.
+- Internal rewrites limited to one hop. Proxy timeout **26s** — use async for longer. Rewrites break relative-path assets — use absolute paths or `<base>`.
+- Proxy to another Netlify site: use its `.netlify.app` subdomain. Rewrites into a separate password-protected site are not allowed.
+
+### Signed proxy redirects (`netlify.toml` only)
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  signed = "API_SIGNATURE_TOKEN_PLACEHOLDER"
+```
+
+Must be in `netlify.toml`; env var scope must include **Runtime**; not supported proxying Netlify→Netlify. Netlify sends the JWS as HMAC HS256 in the `x-nf-sign` header. (This is the one place `$VAR`-style env injection is allowed.)
+
+## Custom headers
+
+```
+/*
+  X-Frame-Options: DENY
+  cache-control: max-age=0
+  cache-control: no-cache          # multi-value collapses comma-joined
+```
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Basic-Auth = "someuser:somepassword anotheruser:anotherpassword"
+    cache-control = '''
+    max-age=0,
+    no-cache,
+    no-store'''
+```
+
+- **Headers apply only to files Netlify serves from its own store** — proxied content, functions, and edge/SSR pages must return their own headers.
+- Reserved header names Netlify controls (ignored if you set them): `Content-Length`, `Content-Encoding`, `Location` (use redirects), `Set-Cookie` (may be overridden), `Server`, `Date`, `Age`, `Connection`, `Transfer-Encoding`, etc.
+- Basic-Auth headers: Pro/Enterprise. Cross-subdomain cookies impossible on `*.netlify.app` (Public Suffix List) — needs a custom domain.
+- Global only; per-branch via the build-command copy workaround.
+
+## Secrets Controller
+
+Mark a var secret via `--secret` (CLI), `is_secret: true` (API), or the UI. Enforced, non-customizable policy:
+
+- Values are **write-only** — no readable version after setting; the flag can't be removed to reveal a value.
+- Must be set to explicit deploy contexts and scopes; **cannot** have the `post processing` scope.
+- Only code on Netlify reads unmasked values; outside code gets masked. The `dev` context value is unmasked and exempt.
+- Secret scanning (smart detection: Personal/Pro/Enterprise) runs on the next build after marking a var secret. Resolve a detection by removing the value at the location in the deploy log, then redeploy. Safelist false positives via `SECRETS_SCAN_SMART_DETECTION_OMIT_VALUES` (comma-separated), then redeploy.
+
+**Sensitive variable policy (public repos only):** untrusted deploys (unrecognized authors) default to **Require approval**; alternatives are **Deploy without sensitive variables** or **Deploy without restrictions**. Not available for GitHub Enterprise Server / GitLab self-managed (treated as private).
+
+## Ignore builds
+
+```toml
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/blog"
+```
+
+- Exit `0` = no changes, **build stops**; exit `1` = changed, build continues.
+- Runs from base directory; uses fixed **Node.js 18** (not customizable); site `package.json` deps unavailable. Referenced file paths must start with `./`.
+- Won't cancel a build triggered by a build hook, regardless of exit code.
+
+Node.js variant:
+```js
+// ignore_build.js — build only non-debug branches
+process.exitCode = process.env.BRANCH.includes("debug") ? 0 : 1
+```
+
+## JavaScript SPAs
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"        # varies by framework
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200            # required for pushState routing to avoid 404s
+```
+
+Hashed/code-split filenames + atomic deploys can break asset refs (`Uncaught SyntaxError: Unexpected token`) — disable hashed filenames, use permalinks, or a service worker.
+
+## Monorepos
+
+Recommended: set the site's subdirectory as the **package directory** (keep `netlify.toml` there), leave base directory at repo root `/`, declare deps at the subdirectory level.
+
+- **Package directory is UI-only** (Build settings > Configure) — it cannot be set in `netlify.toml`. Base directory can be set in root-level `netlify.toml` (`[build] base`) and overrides the UI.
+- Use absolute paths relative to base: base `/frontend` + plugin at `/frontend/packages/my-app/plugins` → specify `/packages/my-app/plugins/...`.
+- Build only on subdirectory changes with an `ignore` command. CLI: `--filter <site>`. Netlify caches all `node_modules` regardless of where deps are declared.
+
+## Plugins, extensions, dev, templates
 
 ```toml
 [[plugins]]
-package = "@netlify/plugin-lighthouse"
-[plugins.inputs]
-  audits = ["performance", "accessibility"]
+  package = "@netlify/plugin-lighthouse"
+  [plugins.inputs]
+    breeds = ["pomeranian"]
+
+[[integrations]]           # extensions; install on team first
+  name = "abc-performance-extension"
+  [integrations.config]
+    output_path = "reports/perf.html"
+
+[dev]                      # Netlify Dev — NOT run in Bash; no `environment` key here
+  command = "yarn start"
+  targetPort = 3000        # if command + targetPort both set, framework must be "#custom"
+  port = 8888
+  publish = "dist"
+  [dev.https]
+    certFile = "cert.pem"
+    keyFile = "key.pem"
 ```
 
-## Image CDN
+`[dev]` has **no `environment` property** — set local env vars in `[context.dev.environment]` instead. `framework` values: `#auto` (default), `#static`, `#custom`.
 
+For Deploy-to-Netlify buttons use `[template]` / `[template.environment]`.
+
+Post-processing pretty URLs:
 ```toml
-[images]
-remote_images = ["https://example\\.com/.*"]
+[build.processing.html]
+  pretty_urls = true
 ```
 
-See the **netlify-image-cdn** skill for full Image CDN usage.
+<!-- TOML syntax reference: https://toml.io/en/ · Netlify config docs: https://docs.netlify.com/build/configure-builds/file-based-configuration.md -->
+
+<!-- system: agent-context/config/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (config)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Env vars set in `netlify.toml` are NOT available to functions or edge
+   functions at runtime — reading them there returns `undefined`. Set
+   runtime vars in the UI or with `netlify env:set`, not `netlify.toml`.
+2. Never put secrets in client-prefixed env vars (`VITE_`, `NEXT_PUBLIC_`,
+   `PUBLIC_`, ...) — they are inlined into the client bundle; `--secret`
+   does not protect them.
+3. When snapshotting env vars locally (`netlify env:list --plain > .env`),
+   keep `.env` gitignored — never commit it.
+4. State env-var scope interaction explicitly: a site variable scoped to
+   Builds does not shadow the shared variable for other scopes — precedence
+   resolves independently per scope (site beats shared only within the
+   scopes the site variable actually carries).

--- a/agent-plugin/skills/netlify-database/SKILL.md
+++ b/agent-plugin/skills/netlify-database/SKILL.md
@@ -1,286 +1,78 @@
 ---
 name: netlify-database
-description: Guide for using Netlify Database — the GA managed Postgres product built into Netlify. Use when a project needs any kind of dynamic, structured, or relational data. Covers provisioning via @netlify/database, Drizzle ORM (@beta) setup, migrations, preview branching, and safe production data handling. Blobs is only for file/asset storage — any dynamic data belongs in the database.
+description: Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing schema migrations, setting up Drizzle ORM, local dev with netlify dev, database branches for deploy previews, and migrating an existing Postgres project onto Netlify. Use when adding a database, building a contact form or CRUD API, writing SQL migrations, wiring up Drizzle, running netlify database commands, testing with a local Postgres, or switching from Neon/Supabase/RDS to Netlify Database.
 ---
 
 # Netlify Database
 
-**Netlify Database** is the managed Postgres product built into the Netlify platform. It is **GA** and is the default choice for any dynamic data in a Netlify project.
+Zero-config managed Postgres. Install `@netlify/database`, write migrations under `netlify/database/migrations/`, deploy — Netlify provisions the DB and applies migrations automatically. Queryable from Functions, Edge Functions, Builds, and Agent Runners.
 
-Install `@netlify/database` and Netlify auto-provisions a Postgres database for the site at deploy time. Each deploy preview gets its own isolated branch forked from production data. No Neon account, connection-string wiring, or claim flow — the database is a first-class Netlify primitive.
+## Modern client (reach for this)
 
-## Database vs Blobs
-
-Use **Netlify Database** for anything dynamic:
-
-- Any user-generated or app-generated records (posts, comments, orders, sessions, audit logs)
-- Structured data that will grow, be queried, or be joined
-- Key-value-style data read or written by application code at runtime
-
-Use **Netlify Blobs** only for **file and asset storage**: images, documents, exports, uploads, cached binary artifacts. Do not use Blobs as a dynamic data store — reach for Database instead. See `netlify-blobs/SKILL.md`.
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any database code — answers shape the schema, the seed data, and the query layer:
-
-- **What entities does the app need?** (Users, posts, orders, sessions — drives the schema in `db/schema.ts`.)
-- **Any seed data for the prototype?** (Test rows, default roles, sample content — these become a DML migration, not ad-hoc `INSERT`s against production.)
-- **Drizzle (recommended) or native driver?** (Drizzle for type-safe queries and generated migrations; native for raw SQL or a different query builder like Kysely.)
-
-**If you don't have preferences here, tell me roughly what the app does and I'll pick sensible defaults** — typically Drizzle with timestamp-prefix migrations and a starter schema for the entities the prompt implies.
-
-## CRITICAL: Install Drizzle from the `@beta` dist-tag
-
-The Netlify Database adapter for Drizzle ORM currently only exists on the `beta` release line of `drizzle-orm`. Install **both** `drizzle-orm` and `drizzle-kit` from the `@beta` dist-tag:
-
-```bash
-npm install drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-The default `latest` versions do not include the `drizzle-orm/netlify-db` adapter and will fail. If `drizzle-kit generate` errors about being outdated, or the `drizzle-orm/netlify-db` import fails to resolve, the install is missing `@beta`.
-
-The `@beta` tag only affects the installed version — imports are written as `drizzle-orm`, `drizzle-orm/pg-core`, and `drizzle-orm/netlify-db` without modification.
-
-## CRITICAL: Use the Netlify CLI for database operations
-
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`) that replaces hand-rolled scripts and direct API/UI work. Reach for these commands first before writing custom tooling. **Requires Netlify CLI 26.0.0+** — if a `netlify database` subcommand isn't recognized, run `npm install -g netlify-cli@latest`.
-
-The corollary: **never go around the CLI**, even for read-only work. Don't run `psql`/`pg_dump` or any raw Postgres client (use `netlify database connect --query "..."`), don't curl `https://api.netlify.com/...`, don't read auth tokens off disk for side-channel calls, and don't use `netlify api <method>` as a recovery hatch when provisioning fails — the supported recovery is under [If the first deploy fails to provision the database](#if-the-first-deploy-fails-to-provision-the-database).
-
-If the documented happy path doesn't work, [surface the failure and stop](#when-something-fails-surface-and-stop) — don't escalate to lower-level tools. Full command reference is in [Netlify CLI commands](#netlify-cli-commands-for-netlify-database) below.
-
-## When something fails, surface and stop
-
-When a `netlify` command fails, a deploy fails to provision the database, or any documented happy path errors out, the right action is to **report the failure to the user** with the deploy log URL, the exact error, and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools.
-
-Specific failure modes (like the first-deploy 401) get their own playbooks below. The general rule applies everywhere: a stuck agent surfacing context is far safer than one that wanders off.
-
-## CRITICAL: Never apply migrations to a Netlify-hosted database
-
-The only database you ever apply migrations to yourself is the **local development DB**. For any Netlify-hosted database — production or a deploy preview branch — **Netlify applies migrations automatically during the deploy**. Your job is to create migration files and commit them. The deploy does the rest.
-
-This means:
-
-- Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
-- Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
-- Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
-
-The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
-
-## Not the legacy "Netlify DB" extension
-
-The older **Netlify DB** extension (Beta) is **deprecated**. It is a separate product and must not be confused with Netlify Database. Do not recommend or install it for new projects.
-
-| | Netlify Database (GA, recommended) | Netlify DB extension (deprecated Beta) |
-|---|---|---|
-| Package | `@netlify/database` | `@netlify/neon` |
-| Env var | `NETLIFY_DB_URL` | `NETLIFY_DATABASE_URL` |
-| Setup | `netlify database init` or install the package — auto-provisioned at deploy | Historically `netlify db init` on older CLI versions, with a claim into the user's Neon account; that flow is no longer reachable from the current CLI |
-| Status | GA | Deprecated; new creation blocked as of April 2026 |
-
-If an existing project is already using the `@netlify/neon` extension, keep it working and encourage the user to switch. See `references/legacy-extension.md` for recognition and coexistence, and `references/migration-from-extension.md` for the full switching process (also covers switching from other external Postgres providers).
-
-## Provisioning
-
-The fastest path is `netlify database init` — an interactive setup that installs `@netlify/database`, lets the user pick Drizzle or raw SQL, writes `drizzle.config.ts` if needed, scaffolds a starter migration, applies it locally, and runs a sample query end-to-end:
-
-```bash
-netlify database init           # interactive
-netlify database init --yes     # accept defaults — for CI/agents
-```
-
-If you'd rather wire things up by hand, install the package directly:
-
-```bash
-npm install @netlify/database
-```
-
-Either way, the presence of `@netlify/database` in the dependency tree triggers provisioning on the next deploy. A database can also be created manually from the Netlify UI before first deploy, but the package + deploy path is the supported automation flow.
-
-### Provisioning workflow: preview-first
-
-The supported inner loop is **preview-first**, not `--prod`-first:
-
-1. **First deploy: `netlify deploy`** (no `--prod`). This provisions the database if needed, applies any pending migrations to the production branch, and produces a draft URL. Verify the deploy log shows `Netlify Database setup completed in <n>s` (and, if migrations exist, `Loading migrations from netlify/database/migrations directory`) before continuing.
-2. **User verifies on the draft URL** — and completes any dashboard-only setup along the way (e.g., enabling Identity if the project also uses it; see `netlify-identity/SKILL.md`).
-3. **Promote: `netlify deploy --prod`**.
-
-Why preview-first matters: the preview deploy provisions the database and applies migrations exactly the way the production deploy will, so a failure during preview is recoverable without prod ever entering a half-configured state. `--prod`-first works in the happy case but is harder to recover from when something goes wrong.
-
-### If the first deploy fails to provision the database
-
-**Symptom:** the build (or the Netlify Database setup extension inside the build) fails with a `401 Access Denied` on `createSiteDatabase`, typically on the very first deploy of a brand-new site. The deploy log shows the failure inside the extension's setup step.
-
-**If the failure happened on `netlify deploy --prod` as the very first deploy**, the first thing to try is the supported preview-first flow — run `netlify deploy` (no `--prod`). The failure has only been observed on `--prod`-first attempts on brand-new sites.
-
-**If a preview deploy also fails — or the original failure was already on a preview — report the failure to the user and stop.** Do not work around it. Specifically, do not:
-
-- Curl `https://api.netlify.com/...` directly
-- Run `netlify api createSiteDatabase` (or any other `netlify api` call to manually create what the platform was supposed to provision)
-- Pull auth tokens out of `~/Library/Preferences/netlify/config.json`
-- Connect via `psql` to "check on things"
-
-The recovery is to give the user the deploy log URL, the site URL, and the exact error, and let them decide what to do next (file a support issue, recreate the site, switch teams).
-
-## Drizzle ORM (recommended path)
-
-Drizzle is the recommended way to work with Netlify Database. Prefer Drizzle over writing raw SQL or hand-editing migration files — manual migrations are an edge case (see `references/migrations.md`).
-
-### Install
-
-```bash
-npm install @netlify/database drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-### Schema file
-
-Create `db/schema.ts`. Define all tables here using Drizzle's schema builder.
-
-```typescript
-// db/schema.ts
-import { boolean, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
-
-export const items = pgTable("items", {
-  id: serial().primaryKey(),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  isActive: boolean("is_active").notNull().default(true),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
-
-export type Item = typeof items.$inferSelect;
-export type NewItem = typeof items.$inferInsert;
-```
-
-Use snake_case strings for column names (`"is_active"`, `"created_at"`) to match Postgres conventions. Drizzle variable names can be camelCase.
-
-### Drizzle client
-
-Create `db/index.ts`. The adapter on `drizzle-orm/netlify-db` picks the right driver for the runtime automatically.
-
-```typescript
-// db/index.ts
-import { drizzle } from "drizzle-orm/netlify-db";
-import * as schema from "./schema";
-
-export const db = drizzle({ schema });
-```
-
-The connection is configured automatically — no connection string needed. If your project uses native ESM with `.js` extensions on relative imports (`from "./schema.js"`), keep that style consistent here.
-
-### Drizzle Kit config
-
-Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
-
-```typescript
-// drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  out: "netlify/database/migrations",
-});
-```
-
-No `migrations` block is needed: `drizzle-kit generate` (the `@beta` line this skill pins) already defaults to timestamp prefixes, which keep filenames unique when branches generate migrations in parallel. Setting `migrations: { prefix: "timestamp" }` explicitly is harmless but redundant — and forcing a sequential `prefix: "index"` is what causes the parallel-branch collisions, so don't.
-
-### Package scripts
-
-```json
-{
-  "scripts": {
-    "db:generate": "drizzle-kit generate",
-    "db:migrate": "netlify database migrations apply"
-  }
-}
-```
-
-- `db:generate` writes a new migration file under `netlify/database/migrations/` from the current schema.
-- `db:migrate` applies pending migrations to the **local development database only**, via the CLI. Hosted migrations (preview branches, production) are applied by the deploy — never by this script.
-
-### Schema-change workflow
-
-1. Edit `db/schema.ts`.
-2. `npm run db:generate` — writes a new file into `netlify/database/migrations/`.
-3. Review the SQL.
-4. `npm run db:migrate` — applies it to the local development DB for testing.
-5. Commit the schema change and migration file together and push. The deploy applies the migration to the preview branch, then to production on publish.
-
-### Query patterns
-
-```typescript
-import { db } from "./db";
-import { items } from "./db/schema";
-import { eq, desc } from "drizzle-orm";
-
-// Select all
-const all = await db.select().from(items);
-
-// Select with condition
-const [one] = await db.select().from(items).where(eq(items.id, id)).limit(1);
-
-// Ordering and limit
-const recent = await db.select().from(items).orderBy(desc(items.createdAt)).limit(10);
-
-// Insert
-const [created] = await db.insert(items).values({ title: "New" }).returning();
-
-// Update
-const [updated] = await db.update(items).set({ title: "Updated" }).where(eq(items.id, id)).returning();
-
-// Delete
-await db.delete(items).where(eq(items.id, id));
-```
-
-Full migration workflow, expand-and-contract for breaking schema changes, and production DML migrations are in `references/migrations.md`.
-
-## Native driver (when Drizzle isn't a fit)
-
-When a project wants raw SQL, uses a different query builder (Kysely, etc.), or has a library that needs a `pg.Pool`, use the native driver exposed by `@netlify/database`.
-
-```bash
-npm install @netlify/database
-```
-
-```typescript
+```ts
 import { getDatabase } from "@netlify/database";
 
-const db = getDatabase();
-
-// Tagged template — parameters are safely bound, not interpolated
-const users = await db.sql`SELECT * FROM users WHERE active = ${true}`;
-
-// Insert with RETURNING
-const [user] = await db.sql`
-  INSERT INTO users (name, email)
-  VALUES (${name}, ${email})
-  RETURNING *
-`;
-
-// Bulk insert
-const rows = db.sql.values([
-  ["Ada", "ada@example.com"],
-  ["Bob", "bob@example.com"],
-]);
-await db.sql`INSERT INTO users (name, email) VALUES ${rows}`;
+const db = getDatabase();               // auto-selects connection for the runtime
+const userId = 42;
+const users = await db.sql`SELECT * FROM users WHERE id = ${userId}`;  // auto-parameterized
 ```
 
-Transactions go through `db.pool` so `BEGIN`, the queries, and `COMMIT`/`ROLLBACK` all run on the same connection:
+Own driver / ORM instead:
+```ts
+import { getConnectionString } from "@netlify/database";
+const connectionString = getConnectionString();  // correct branch for this env
+```
 
-```typescript
-import { getDatabase } from "@netlify/database";
+**Legacy — do NOT use for new code:** `import { neon } from "@netlify/neon"`. Superseded by `@netlify/database`. Replace `neon()` calls with the Drizzle `netlify-db` adapter or a Postgres driver via `getConnectionString()`. The legacy env var `NETLIFY_DATABASE_URL` is replaced by `NETLIFY_DB_URL`.
 
+## Where things go
+
+| What | Location |
+|------|----------|
+| Migrations | `netlify/database/migrations/` (SQL files or subdirs with `migration.sql`) |
+| Query code | Functions (`netlify/functions/`), Edge Functions |
+| Drizzle schema | `db/schema.ts` (convention) |
+| Drizzle client | `db/index.ts` (convention) |
+| Connection string | `NETLIFY_DB_URL` env var, or `getConnectionString()` |
+
+## Querying
+
+`getDatabase(options?)` returns a client with `sql` and `pool`. `options.connectionString` overrides the auto-provisioned one; `options.debug` enables logging.
+
+```ts
 const db = getDatabase();
+const active = await db.sql`SELECT * FROM users WHERE active = ${true}`;
+await db.sql`INSERT INTO users (name, email) VALUES (${"Ada"}, ${"ada@example.com"})`;
+await db.sql`UPDATE users SET name = ${"Ada Lovelace"} WHERE id = ${1}`;
+await db.sql`DELETE FROM users WHERE id = ${1}`;
+
+// Type the rows
+interface User { id: number; name: string; email: string; }
+const typed = await db.sql<User>`SELECT * FROM users`;
+
+// Stream
+for await (const row of db.sql`SELECT * FROM users`.stream()) { /* ... */ }
+for await (const chunk of db.sql`SELECT * FROM users`.chunked(100)) { /* ... */ }
+```
+
+`SQLTemplate` methods: `execute()` → `Promise<T[]>`, `stream()` → `AsyncGenerator<T>`, `chunked(n)` → `AsyncGenerator<T[]>`, `toSQL()` → raw SQL + params without executing.
+
+`sql` helpers:
+- `sql.identifier(value)` — safe table/column name. String, string[], or `{ schema, table, column, as }`.
+- `sql.values(rows)` — bulk-insert values list from a 2D array.
+- `sql.default` — the SQL `DEFAULT` keyword.
+- `sql.raw(value)` — **injects unparameterized SQL; bypasses injection protection. Only for trusted constants (e.g. `"DESC"`), never user input.**
+- `sql.unsafe(query, params?, { rowMode })` — raw query string with `$1` params; `rowMode` is `"array"` or `"object"`.
+
+### Transactions — use `pool`
+
+`db.pool` is a [`pg.Pool`](https://node-postgres.com/apis/pool). `BEGIN`/queries/`COMMIT` must run on the same connection:
+```ts
 const client = await db.pool.connect();
 try {
   await client.query("BEGIN");
-  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", [name, email]);
-  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [id, title]);
+  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", ["Ada", "ada@example.com"]);
+  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [1, "First post"]);
   await client.query("COMMIT");
 } catch (e) {
   await client.query("ROLLBACK");
@@ -290,76 +82,307 @@ try {
 }
 ```
 
-For third-party tools that need a raw connection string, import `getConnectionString` from `@netlify/database` — but prefer `getDatabase()` for application code.
+Own drivers:
+```ts
+import { getConnectionString } from "@netlify/database";
+import pg from "pg";
+const pool = new pg.Pool({ connectionString: getConnectionString() });
 
-### Manual migrations
-
-With the native driver, scaffold migration files via the CLI:
-
-```bash
-netlify database migrations new -d "create users table"
+// or the `postgres` driver via env var
+import postgres from "postgres";
+const sql = postgres(process.env.NETLIFY_DB_URL);
 ```
 
-This creates `netlify/database/migrations/<prefix>_<slug>/migration.sql` and prompts for the numbering scheme if it can't be detected from existing files. Open the file and write the SQL. The CLI auto-detects an existing scheme; for new projects it'll ask — choose `timestamp` unless you have a reason not to.
+## Drizzle ORM
 
-You can also write the file by hand if you prefer. Two layouts are supported:
+**Install both packages from `@beta` — required.** `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail.
+```bash
+npm install @netlify/database drizzle-orm@beta
+npm install -D drizzle-kit@beta
+```
 
-- **Flat:** `netlify/database/migrations/<prefix>_<slug>.sql`
-- **Subdirectory:** `netlify/database/migrations/<prefix>_<slug>/migration.sql` (what `migrations new` produces)
+`drizzle.config.ts` — you **MUST** set `out` to the Netlify migrations directory or Netlify won't apply generated migrations:
+```ts title="drizzle.config.ts"
+import { defineConfig } from "drizzle-kit";
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./db/schema.ts",
+  out: "netlify/database/migrations",   // NOT the default "drizzle"
+});
+```
 
-In both, `<prefix>` is digits (timestamp like `20260417143022` or sequential like `0001`) and `<slug>` is lowercase letters, numbers, hyphens, or underscores. Files apply in lexicographic order. See `references/migrations.md`.
+```ts title="db/schema.ts"
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+export const users = pgTable("users", {
+  id: serial().primaryKey(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  createdAt: timestamp().defaultNow(),
+});
+```
 
-Once a migration has been applied to any database, never modify it — roll forward with a new migration instead.
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";  // native adapter, auto-configured
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
 
-## Connection — don't reach for the env var
+```ts title="netlify/functions/api.ts"
+import { desc } from "drizzle-orm";
+import type { Config, Context } from "@netlify/functions";
+import { db } from "../../db";
+import { users } from "../../db/schema";
 
-`NETLIFY_DB_URL` is set automatically across builds, functions, edge functions, and local dev. Use the `getDatabase()` / `getConnectionString()` helpers above rather than reading it directly — only reach for the raw env var for third-party tools that demand a bare string.
+export default async (req: Request, context: Context) => {
+  if (req.method === "GET") {
+    const allUsers = await db.select().from(users).orderBy(desc(users.createdAt));
+    return Response.json(allUsers);
+  }
+  if (req.method === "POST") {
+    const { name, email } = await req.json();
+    const [user] = await db.insert(users).values({ name, email }).returning();
+    return Response.json(user, { status: 201 });
+  }
+  return new Response("Method not allowed", { status: 405 });
+};
 
-`NETLIFY_DB_URL` is intentionally different from the legacy extension's `NETLIFY_DATABASE_URL`. The two coexist so a project mid-migration doesn't break. Don't rename between them.
+export const config: Config = { path: "/api/users" };
+```
 
-## Preview branching
+Generate migrations after editing the schema: `npx drizzle-kit generate`.
 
-Each deploy preview runs against its own database branch forked from production data — schema and data changes in a preview don't affect production until the branch is merged and published. Migrations run against the preview branch first (failures fail the preview, not production), and ad-hoc preview edits (UI data browser or a direct client) don't propagate to production — always express production changes as migrations.
+**Never run `drizzle-kit push` against a Netlify-hosted database, and never run `drizzle-kit migrate` against `NETLIFY_DB_URL`.** Schema reaches hosted DBs only as committed migration files applied by the deploy. `generate` writes files; the deploy applies them.
 
-## Changing existing data — production or preview?
+## Migrations
 
-A request to change existing data — "rename this category", "fix the broken row for user X" — is **ambiguous about where it should land**: production, or only the current preview branch. Resolve that fork *before* changing anything: if the prompt didn't say, ask. When acting on someone's behalf, default to **not** touching production unless they explicitly asked.
+Files live in `netlify/database/migrations/`. Two formats:
+```text
+netlify/database/migrations/20260301143000_create_users.sql          # single SQL file
+netlify/database/migrations/20260318091500_add_posts/migration.sql   # subdir form
+```
 
-Once it's production-bound, express it as a **DML migration**, never a direct write:
+Naming: `<number>_<slug>` — `number` is digits (timestamp or `0001`…) defining order; `slug` is lowercase letters/numbers/hyphens/underscores. Sorted **lexicographically**, applied in order. **Use timestamp prefixes** (`netlify database migrations new` handles this) to avoid out-of-order rejection.
 
-- **Don't run the `UPDATE`/`INSERT`/`DELETE` against production** (or ad-hoc in a preview). Generate a DML migration in `netlify/database/migrations/` (raw SQL or Drizzle-generated) and commit it — the deploy applies it, like a schema migration.
-- Tell the user you created a data migration; merging the branch applies it to production. Have them **verify in the deploy preview first** (it runs against a forked copy of production data).
+```sql title="netlify/database/migrations/20260425103000_create_comments.sql"
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id),
+  author_id INTEGER NOT NULL REFERENCES users(id),
+  body TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
 
-Covers seed data, backfills, cleanups, CSV imports, and single-row fixes. Full detail in `references/migrations.md`.
+**When applied:**
+- Production deploy: applied immediately before publish; a failure blocks publish. With auto-publish off, Netlify waits for manual publish before applying.
+- Deploy preview: applied on every deploy before it goes live; a failure fails the deploy.
+- Local: **not** automatic — run `netlify database migrations apply` yourself.
 
-## Netlify CLI commands for Netlify Database
+**Migration footguns (all detected as drift / rejected):**
+- **Never edit an applied migration** — checksum drift: `migration "<name>" has been modified after being applied`. Write a new corrective migration.
+- **Never remove an applied migration** — `... has been removed after being applied`. Restore it.
+- **Out-of-order:** a prefix ≤ the highest applied version is rejected. Timestamps avoid this.
+- Prefer backwards-compatible migrations. Breaking changes (rename/drop column) → expand-and-contract across multiple deploys. New table / nullable column → single migration is fine.
 
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`). Requires CLI 26.0.0+. Most commands accept `--json` for machine-readable output — useful when scripting or reading results from an agent.
+Bring-your-own migration system: pick a directory **other than** `netlify/database/migrations` to avoid automatic detection, and you own applying to preview branches and production.
 
-Full per-command reference — `init`, `status`, `connect`, `migrations new` / `apply` / `pull` / `reset`, and `reset` — is in `references/cli-commands.md`. The one rule that applies across all of them: **never run DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`) through `connect`, `psql`, or any direct connection** — schema changes go through migration files.
-
-## Iterating on migrations
-
-When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
-
-- **Already applied** to any database (local dev DB, a preview branch, or production) → treat as immutable. Roll forward with a new migration that applies the correction.
-- **Only on disk** (not yet applied anywhere) → don't edit the SQL or snapshot files by hand. Run `netlify database migrations reset`, update `db/schema.ts`, then re-run `npm run db:generate`. Hand-editing desyncs Drizzle Kit's internal state and tends to produce broken migrations on the next generate.
+See `references/migrations.md`.
 
 ## Local development
 
-`netlify dev` runs against a local Postgres-compatible database — no remote connection, no risk to production. The local DB is the only one you migrate yourself (`netlify database migrations apply`).
+Local is **one** database that all code targets — branches are a deploy-time concept and don't exist locally. It's a real Postgres-compatible engine mirroring production, but single-process (not for load testing); auto-scale/sleep settings don't apply.
 
-## Common mistakes
+Start it — either path, state is interchangeable:
+```bash
+netlify dev                                    # CLI starts + tears down the local DB
+```
+Or the Vite plugin:
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import netlify from "@netlify/vite-plugin";
+export default defineConfig({ plugins: [netlify()] });
+```
 
-1. **Missing `@beta`** — `drizzle-orm`/`drizzle-kit` must be `@beta`; `latest` lacks the `drizzle-orm/netlify-db` adapter.
-2. **Wrong output dir** — set `out: "netlify/database/migrations"` in `drizzle.config.ts`; migrations elsewhere aren't applied by the deploy.
-3. **Self-applying hosted migrations** — never `drizzle-kit migrate`/`push` or DDL via `connect` against production/preview; commit migration files and let the deploy apply them.
+Common commands (while local DB is running):
+```bash
+netlify database migrations apply                        # apply pending locally
+netlify database migrations new -d "add users table"     # scaffold new migration
+netlify database migrations pull                          # overwrite local migrations from remote
+netlify database status                                   # enabled? installed? applied/pending migrations
+netlify database connect                                  # interactive SQL REPL
+netlify database connect --query "SELECT * FROM users LIMIT 10"
+netlify database reset                                    # drop all schemas/tables — LOCAL ONLY
+netlify database migrations reset                         # delete unapplied local migration files
+```
 
-## References
+External tools (works while `netlify dev` runs):
+```bash
+psql "$(netlify database connect --json | jq -r .connection_string)"
+```
 
-- [Migrations](references/migrations.md) — full migration workflow, expand-and-contract for breaking changes, and production DML
-- [CLI commands](references/cli-commands.md) — `init`, `status`, `connect`, and `migrations new` / `apply` / `pull` / `reset`
-- [Local development](references/local-dev.md) — running against a local Postgres-compatible database with `netlify dev`
-- [Operational footguns](references/operational-footguns.md) — client reuse, cold starts, preview-data (PII) exposure, legacy-extension deletion
-- [Legacy `@netlify/neon` extension](references/legacy-extension.md) — recognizing and coexisting with the older extension
-- [Migrating from the extension](references/migration-from-extension.md) — switching from `@netlify/neon` or other external Postgres, including the one-time data import
+See `references/local-dev.md`.
+
+## Setup
+
+New project: describe your app to Agent Runners at https://app.netlify.com/start, or `netlify create "<description>"` locally.
+
+Existing project:
+```bash
+netlify database init      # installs @netlify/database, picks Drizzle or raw SQL, scaffolds a migration
+netlify database init --yes # non-interactive (CI / agents)
+netlify dev
+```
+Manual: `npm install @netlify/database`, write a migration under `netlify/database/migrations/`, write a function, `netlify dev`, deploy.
+
+**If `@netlify/database` is NOT installed, Netlify will NOT auto-provision a database** — you'd have to create one manually from the UI **Database** menu. Install the package.
+
+## CLI reference (`netlify database`)
+
+Prereqs: Node ≥ 20.12.2, Netlify CLI ≥ 26.0.0 (`npm install -g netlify-cli`). All commands support `--json`.
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `init` | Set up DB in project | `-y, --yes` |
+| `status` | State: enabled, installed, connection string, applied/pending migrations | `-b, --branch`, `--show-credentials` |
+| `connect` | SQL REPL, or `--query` one-shot | `-q, --query`, `--json` |
+| `migrations apply` | Apply pending to local DB | `--to <name>` |
+| `migrations new` | Scaffold a migration | `-d, --description`, `-s, --scheme sequential\|timestamp` |
+| `migrations pull` | Overwrite local files from a branch | `-b, --branch`, `--force` |
+| `migrations reset` | Delete unapplied local migration files | `-b, --branch` |
+| `reset` | Drop all data/tables — **local only** | — |
+
+See `references/cli-commands.md`.
+
+## REST API
+
+Scoped to a site, rooted at `https://api.netlify.com/api/v1`, OAuth 2. Full reference: https://open-api.netlify.com.
+
+| Method + path | Purpose |
+|---------------|---------|
+| `POST /sites/{site_id}/database` | Create DB (returns existing conn string if present); `region` optional |
+| `GET /sites/{site_id}/database` | Get connection string |
+| `POST /sites/{site_id}/database/branch` | Create branch; body `deploy_id` (req), `parent_branch_id` (opt, defaults to production) |
+| `GET /sites/{site_id}/database/branch/{deploy_id}` | Get branch conn string (404 if none) |
+| `DELETE /sites/{site_id}/database/branch/{deploy_id}` | Delete a deploy's branch |
+| `POST /sites/{site_id}/database/snapshot` | Snapshot a branch (defaults production) |
+| `GET /sites/{site_id}/database/snapshots` | List snapshots |
+| `DELETE /sites/{site_id}/database/snapshot/{snapshot_id}` | Delete a snapshot |
+| `POST /sites/{site_id}/database/snapshot/{snapshot_id}/restore` | Restore snapshot to a branch (defaults production) |
+
+**Branch delete and snapshot restore are destructive and require explicit user confirmation first.** Snapshot restore is not a routine production-rollback lever.
+
+## Testing
+
+Bare Postgres for unit/integration tests (no functions):
+```ts title="db.test.ts"
+import { NetlifyDB } from "@netlify/database-dev";  // npm i -D @netlify/database-dev
+import { Client } from "pg";
+import { afterAll, beforeAll, expect, test } from "vitest";
+
+let db: NetlifyDB, connectionString: string;
+beforeAll(async () => {
+  db = new NetlifyDB();
+  connectionString = await db.start();
+  await db.applyMigrations("./netlify/database/migrations");
+});
+afterAll(async () => { await db.stop(); });
+
+test("inserts and reads a user", async () => {
+  const client = new Client({ connectionString });
+  await client.connect();
+  await client.query("INSERT INTO users (name) VALUES ($1)", ["Ada"]);
+  const { rows } = await client.query("SELECT name FROM users");
+  expect(rows).toEqual([{ name: "Ada" }]);
+  await client.end();
+});
+```
+`NetlifyDB(options?)`: `directory` (persist to disk; omit = in-memory), `port` (default random), `logger`.
+
+Full Netlify environment (functions/edge functions read `NETLIFY_DB_URL` as in production):
+```ts
+import { NetlifyDev } from "@netlify/dev";  // npm i -D @netlify/dev
+const netlifyDev = new NetlifyDev({ projectRoot: "./fixtures/my-project" });
+await netlifyDev.start();  // sets NETLIFY_DB_URL in the runtime
+// ...tests...
+await netlifyDev.stop();
+```
+
+## Database branches (deploy-time)
+
+Production deploys are the only deploys that touch the production database. Each deploy preview gets its own branch, seeded with a copy of production data at preview-creation time; schema/data changes there never affect production. Wired up automatically, no code changes.
+
+**Preview branches can contain production data, including PII — and preview deploy links are public. Warn the user before sharing a preview link.**
+
+## Runtime gotchas
+
+- **`Environment not configured`** (`getDatabase()` can't resolve a connection string): running outside Netlify, on **Functions in Lambda compatibility mode**, or an outdated CLI. Fix: pass `connectionString` explicitly.
+  ```ts
+  const db = getDatabase({ connectionString: "postgres://..." });
+  ```
+  Lambda compatibility mode is the one primitive where you must pass `connectionString` yourself.
+- **`database feature not available for this account`** — requires a Credit-based plan.
+- **`compute customization requires a Pro or higher plan`** — auto-scale / sleep settings need Pro+; Free/Personal use defaults.
+- **`branch limit reached: maximum <N> branches...`** — each active deploy preview consumes a branch; delete unneeded branches or upgrade.
+- **`database not found`** — no DB provisioned; run `netlify database init`.
+- **`cannot reset the production branch`** — reset is non-production only.
+
+## Constraints
+
+- **Plan:** Netlify Database is available on Credit-based plans only; active DBs consume credits for compute and bandwidth. Storage is free until July 1, 2026.
+- **Permissions:** only a Team Owner can delete a database; only Team Owners and Developers can view connection strings (`Access Denied` = insufficient role).
+- **Secrets:** connection strings contain username + password. Never commit them; store in a secret manager / env var provider.
+
+## Switch an existing Postgres project to Netlify Database
+
+Three phases: provision (baseline schema on a branch), rehearse (swap code, copy data into a preview branch, validate), cut over (import data into production, merge). Works from any Postgres source (Neon, Supabase, RDS, self-managed, legacy `@netlify/neon`). Uses `pg_dump`/`pg_restore` (versions matching the source). There is a brief data-loss window — writes to the source between final export and production deploy don't cross over.
+
+Phase 2/3 code swap (Drizzle):
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
+
+Full step-by-step (dump flags, rollback, cleanup): `references/migration-from-extension.md` and `references/legacy-extension.md`.
+
+<!-- Gaps: plan-tier naming (Credit-based vs Free/Personal/Pro) not reconciled in source; exact plan limits, permission tables, and snapshot UI flows live on pages outside this grouping. -->
+
+<!-- system: agent-context/database/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (database)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Production data changes are expressed as DML migrations — agents never
+   edit rows directly (UI row editing exists for humans; it is not an agent
+   surface).
+2. Preview branches can contain production data, including PII — and preview
+   deploy links are public. Warn before sharing.
+3. Use only documented surfaces: no raw psql against internal endpoints, no
+   `netlify api` scraping, no reading tokens from local CLI config files.
+4. Deep guides live in this skill: `references/operational-footguns.md`,
+   `references/migrations.md`, `references/local-dev.md`,
+   `references/cli-commands.md`, `references/migration-from-extension.md`,
+   `references/legacy-extension.md`.
+5. Schema changes reach hosted databases only as committed migration files
+   applied by the deploy. Never run `drizzle-kit push` in any form against a
+   Netlify-hosted database, never run `drizzle-kit migrate` against
+   `NETLIFY_DB_URL`, and never apply DDL via `netlify database connect` or
+   any direct connection.
+6. When a `netlify` command or a deploy fails, surface the exact error, the
+   deploy log URL, and the affected site/branch to the user and stop — do
+   not invent recovery commands or escalate to lower-level tools.
+7. First-deploy `401 Access Denied` on `createSiteDatabase`: if it happened
+   on a `--prod`-first deploy, retry preview-first (`netlify deploy`, no
+   `--prod`); if a preview also fails, report and stop. Never curl
+   `api.netlify.com`, run `netlify api createSiteDatabase`, or pull tokens
+   from local CLI config to work around it.
+8. A request to change existing data is ambiguous between production and the
+   preview branch — if the prompt didn't say, ask. When acting on someone's
+   behalf, default to not touching production.
+9. Destructive database operations — REST branch delete, snapshot restore,
+   any reset — require explicit user confirmation first. The body must not
+   present snapshot restore as a routine production-rollback lever.
+10. Pin: `drizzle-orm` and `drizzle-kit` must be installed from `@beta` —
+    `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail. The
+    body may not soften this to a recommendation.

--- a/agent-plugin/skills/netlify-deploy/SKILL.md
+++ b/agent-plugin/skills/netlify-deploy/SKILL.md
@@ -1,153 +1,186 @@
 ---
 name: netlify-deploy
-description: Deploy, host, and publish web projects on Netlify with the Netlify CLI. Use when the user wants to deploy a site or repository to Netlify, link a local project to a Netlify site, ship a production or preview/draft deploy, set up Git-based continuous deployment, run a manual or local deploy, configure CI deploys, or troubleshoot a failed or misconfigured deploy. Also use to view or tail a deployed site's runtime logs — function and edge-function output, deploy logs — via `netlify logs` when debugging what a live site is doing (recent errors, recent activity, streaming output).
+description: Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons, drag-and-drop, and per-context netlify.toml build settings. Use when linking a repo, deploying from the CLI, setting up Deploy Previews or branch deploys, configuring deploy contexts, adding skew protection, fixing a failed or secrets-flagged deploy, or wiring build hooks and Deploy to Netlify buttons.
 ---
 
-# Netlify Deployment
+# Netlify deploy
 
-Install the CLI, link a project to a Netlify site, and deploy it — either through Git-based continuous deployment (the primary path) or a manual CLI upload (for prototypes and CI). Environment-variable management lives in the **netlify-config** skill; local development lives in the **netlify-frameworks** skill.
+## Deploy context config (netlify.toml, current form)
 
-## Installation
+Configure per-context build settings in `netlify.toml` at the repo root. Five predefined contexts: `production`, `deploy-preview`, `branch-deploy`, `preview-server`, `dev`. Branch names also work as custom contexts (a `staging` branch matches a `staging` context).
 
-```bash
-npm install -g netlify-cli    # Global (for local dev)
-npm install netlify-cli -D    # Local (for CI)
+```toml
+[context.production]
+  command = "make production"
+  [context.production.environment]
+    ACCESS_TOKEN = "super secret"
+  # Plugins context REQUIRES double brackets:
+  [[context.production.plugins]]
+    package = "@netlify/plugin-sitemap"
+
+[context.deploy-preview.environment]
+  ACCESS_TOKEN = "not so secret"
+
+[context.branch-deploy]
+  command = "make staging"
+
+[context.dev.environment]
+  NODE_ENV = "development"
+
+# Specific-branch context (overrides branch-deploy):
+[context.feature]
+  command = "make feature"
+
+[context."features/branch"]
+  command = "gulp"
 ```
 
-Requires Node.js 18.14.0+. You can also invoke the CLI without installing it using `npx netlify <command>`.
+Precedence: site globals < context overrides; production overrides globals when building production; more specific contexts (a named branch) override general ones (`branch-deploy`). Only explicitly-set options are overridden. File-based config overrides UI settings.
 
-## Authentication
+**Footgun — secrets in netlify.toml:** `netlify.toml` is committed to your repo. Do not put sensitive env values here, especially for public repos. Set secrets via the Netlify UI/CLI/API instead. Also: env vars declared in `netlify.toml` are NOT available to the deploy environment (Functions/Runtime/Post-processing scopes) — only UI/CLI/API-created vars are.
 
-```bash
-netlify login       # Opens browser for OAuth
-```
-
-For CI, set the `NETLIFY_AUTH_TOKEN` environment variable instead of logging in interactively. Generate a token from **User settings → Applications → Personal access tokens** in the Netlify UI.
-
-**CI also needs a site to target.** `NETLIFY_AUTH_TOKEN` only authenticates you — it does **not** select which site a deploy publishes to. In CI there is no linked `.netlify/state.json`, so also set `NETLIFY_SITE_ID` (the site's API/Project ID, shown as **Project ID** in the site's configuration) as an environment variable so `netlify deploy` knows where to publish. Without it, a CI deploy has no site to target and fails or tries to prompt. Locally this is handled by `netlify link`, which writes the site ID into `.netlify/state.json`; CI has no such file.
-
-Don't pre-check auth as a separate step. Run the real operation (`netlify deploy`, `netlify link`) directly; only if it fails with an authentication error do you surface `netlify login` (or setting `NETLIFY_AUTH_TOKEN`) as the fix.
-
-## Linking a Site
-
-Linking connects the local directory to a Netlify site and writes the site ID into `.netlify/state.json`.
+## CLI deploys
 
 ```bash
-# Interactive — pick an existing site
-netlify link
-
-# By Git remote (if the project has one)
-netlify link --git-remote-url https://github.com/org/repo
-
-# Create a new site
-netlify init           # With Git CI/CD setup
-netlify init --manual  # Without Git CI/CD
+netlify create              # new project from a natural-language prompt
+netlify deploy              # manual deploy, no continuous deployment
+netlify deploy --prod       # deploy directly to production
+netlify deploy --allow-anonymous   # temp deploy, claim within 1 hour
+npm update -g netlify-cli   # skew protection needs CLI v23.11.0+
 ```
 
-Run `netlify link` directly rather than pre-checking link status. If the command reports the project isn't linked to any site (or the site can't be found), that failure is the signal to link or create one with `netlify link` / `netlify init`.
+Manual deploys do NOT run a build command (exception: Netlify Drop builds for you when logged in). Anonymous deploys create a temporary project claimable within one hour; on claim it adopts the team's default visibility.
 
-**Always add `.netlify` to `.gitignore`** — every linking path (`netlify link`, `netlify init`, `netlify init --manual`) writes site state to `.netlify/state.json`, which shouldn't be committed. Mention this whenever you link or create a site.
+**Footgun — link writes `.netlify/state.json`:** every linking/create path writes `.netlify/state.json`. Add `.netlify` to `.gitignore` so it is never committed.
 
-## Deploying
+**Footgun — manual `--prod` on a Git-connected site:** the next push to the production branch silently replaces your hand-shipped deploy. Warn the user before running it; if the deploy must stay live, lock the published deploy.
 
-### Git-Based Deploys (Continuous Deployment) — primary path
+## Git continuous deployment
 
-The standard way to deploy on Netlify is to connect the site to a Git repository (set up with `netlify init`, or in the UI). Netlify then builds and deploys automatically on every push:
+Connect a Git repo (Git provider OAuth2 or the Netlify GitHub App). Netlify runs your build command and deploys on every push. Production deploys are triggered by pushes to the production branch (default `main`); Deploy Previews are built for pull/merge requests and agent runs.
 
-- **Push to the production branch → production deploy.**
-- **Open a pull request → deploy preview** with its own unique URL.
-- **Push to other branches → branch deploy**, but **only if branch deploys are enabled** — they are off by default. Turn them on (per branch or for all branches) in the site's build & deploy settings.
+## Deploy Previews & branch deploys
 
-The build runs on Netlify's servers, not your machine. Configure build settings (command, publish directory, base directory) in `netlify.toml` — see the **netlify-config** skill for the full configuration reference.
+- Deploy Previews build by default for PRs/MRs and agent runs. Base branch of a Deploy Preview must be a production branch or a branch with branch deploys enabled.
+- Branch deploys are OFF by default — a Developer/Owner must enable them: Project configuration > Build & deploy > Continuous Deployment > Branches and deploy contexts > Configure. Add individual branches, use a `features/*` prefix wildcard, or select **All**.
+- URL prefixes: branch deploys `<branch>--`; PR/MR previews `deploy-preview-<number>--`; agent previews `agent-<runID>--`; permalinks `<deployID>--`.
+- While the initial Deploy Preview builds, its URL returns `Not Found`.
 
-**`netlify.toml` overrides the UI.** File-based configuration in `netlify.toml` takes precedence over the equivalent build settings configured in the Netlify UI. When the same option is set in both places, the committed `netlify.toml` wins — editing that setting in the dashboard has no effect until you change the file and redeploy. This surprises people who tweak the build command, publish directory, or base directory in the UI and watch the old committed value keep applying on every deploy.
+**Deploy Preview entry path** — set in the PR/MR description (updates the PR comment link):
+```markdown
+@netlify /start/choose-your-path
+```
+Push a new (or empty) commit to regenerate the link. Once set in the PR/MR, you cannot override the entry path in the Netlify Drawer.
 
-**Monorepo config discovery order.** In a monorepo, Netlify searches for the `netlify.toml` in this order and uses the **first** one it finds: (1) the package directory, then (2) the base directory, then (3) the repository root. Put a site-specific `netlify.toml` in the package directory (the subdirectory that contains that site) so it takes precedence over any root-level config. A base directory set in a root-level `netlify.toml` also overrides the base directory configured in the UI.
+## Skip a deploy
 
-**The publish directory is resolved relative to the base directory.** When a `base` directory is configured, the publish directory is interpreted relative to that base, **not** the repository root. A top-level `publish = "dist"` combined with `base = "apps/web"` publishes `apps/web/dist`, not `dist` at the repo root. Set `publish` relative to the base so the built output is found.
+Add `[skip ci]` or `[skip netlify]` to a PR/MR title (skips the Deploy Preview) or anywhere in a commit message (skips branch/production deploy). For a multi-commit push, put it in the most recent commit. The next commit without the token deploys all skipped changes.
 
-### Manual / Local Deploys (No Git Required) — secondary path
+## Deploy to Netlify button
 
-Build the site, then upload the output directly with the CLI. This bypasses Netlify's build servers and is the right tool for prototypes, local-only projects with no Git remote, or a CI pipeline that builds elsewhere and uploads the artifact.
+Template code must be in a **public** GitHub.com or GitLab.com repo.
 
-```bash
-netlify deploy             # Draft deploy (preview URL)
-netlify deploy --prod      # Production deploy
-netlify deploy --dir=dist  # Specify the directory to upload
+```md title="Markdown"
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
 ```
 
-For sites with Git continuous deployment connected, prefer pushing to Git — a manual upload is the exception, not the default.
-
-**A manual `--prod` deploy is replaced by the next Git push.** If the same site also has Git continuous deployment connected, the next push to the production branch triggers a new build that auto-publishes and **replaces** your manually shipped `--prod` deploy — the hand-shipped build silently disappears from production. To keep a specific deploy live, **lock the published deploy** ("Stop auto publishing") from the site's Deploys list in the UI: while locked, new pushes still build but do not auto-publish until you unlock or manually publish. Mixing manual `--prod` deploys with Git CD on the same production branch is otherwise a race the next commit wins.
-
-### Deploy URLs are public by link
-
-Draft deploys (`netlify deploy`), Deploy Previews, branch deploys, and deploy permalinks each get a **unique URL that anyone with the link can open** — they are not private just because the URL is unguessable and unlisted. Don't treat a preview URL as a safe place for confidential or unreleased content on that basis alone. To actually restrict access, enable site protection in the UI (Password Protection, or Team/SSO protection). You can scope that protection to all deploys, or to non-production deploys only (Deploy Previews and branch deploys) while leaving production open. See the **netlify-access-control** skill for the full picture.
-
-## When a command fails, surface and stop
-
-When a `netlify` command or a deploy fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
-
-## Error Handling
-
-Common issues and what to do:
-
-**"Not logged in"**
-→ Run `netlify login` (or set `NETLIFY_AUTH_TOKEN` in CI).
-
-**"No site linked"**
-→ Run `netlify link` (existing site) or `netlify init` (new site).
-
-**"Build failed" / "Function bundling failed" / deploy marked failed**
-→ A failed deploy does **not** publish — the site keeps serving the last successful deploy, so it isn't down, and there's nothing to "roll back." The only way to get the new code live is to fix the failure and redeploy.
-→ Get the exact error from the deploy log (the CLI prints a log URL; the dashboard has the full build log), then address the actual cause — the build command or publish directory in `netlify.toml`, a missing dependency, or the function that failed to bundle — and re-run the deploy.
-→ Don't route around a failed build to force the site live: no `netlify api` publish/restore, no direct `https://api.netlify.com/...` calls, no reading auth tokens off disk, and don't ship a previous deploy in place of the failing one. If the log doesn't resolve it, report the exact error + log URL + affected site to the user and stop.
-→ Even if the user *asks* how to "roll back" or restore a previous deploy, correct the premise rather than complying: because the failed deploy never published, the previous deploy is still live and there is nothing to restore. Do **not** hand over `netlify api restoreSiteDeploy` / `publishDeploy` (or a dashboard rollback) as the answer — the fix is to resolve the build failure and redeploy.
-
-**"Secrets scanning found secrets" / deploy fails after a successful build**
-→ Netlify scans the build output and source for secret values (env-var values, known key formats) *after* the build succeeds and **fails the deploy** if it finds one — so an otherwise-green build can still fail here. Read the log: it names the offending key and where it appeared.
-→ If it's a real secret (an API/DB key that ended up in bundled or published output), that's a genuine leak — stop writing it into client/published files, and rotate the key if it was committed. Silencing the scanner over a real leak just ships the secret.
-→ If the flagged value is legitimately non-secret (e.g. a value that must ship to the browser), scope the exception narrowly with build environment variables: `SECRETS_SCAN_OMIT_KEYS` to exclude specific env-var keys, or `SECRETS_SCAN_OMIT_PATHS` to exclude specific paths. Prefer these over `SECRETS_SCAN_ENABLED=false`, which disables scanning across the entire build.
-
-**"Publish directory not found"**
-→ Run the build yourself (`netlify build`, which mimics the Netlify build environment, or the project's own build command) and look at which directory it actually emits — don't guess the output dir from the framework name, and don't just `ls` for a folder that isn't there.
-→ If the build itself **fails**, that's the real problem — surface the build error to the user and stop; don't change the `publish` path to paper over a broken build.
-→ Once the build succeeds, set the `publish` path (in `netlify.toml`, or `--dir`) to match that real output directory — remembering it's resolved relative to any configured `base` directory (see above).
-
-## Logs
-
-The simplest command is the right default: bare `netlify logs` shows recent logs from both the `functions` and `edge-functions` sources, covering roughly the last 10 minutes. Add flags only to scope or extend it:
-
-```bash
-netlify logs                                       # recent functions + edge-functions logs (~last 10m)
-netlify logs --follow                              # stream live
-netlify logs --source functions --function my-fn   # one function's logs
-netlify logs --source deploy --source functions    # include deploy logs (sources combine)
-netlify logs --since 24h                           # longer historical window
+URL parameters (query params; env vars go in the URL hash):
+```txt
+# require/set env vars via hash (values may be null; processed client-side, not logged)
+...?repository=REPO#SECRET_TOKEN=value&CUSTOM_LOGO=
+&fullConfiguration=true   # extra step to install SDK extensions + configure before deploy
+&base=blog                # alternate base dir for monorepos (repo still fully cloned)
+&create_from_path=examples/hello   # clone only this subdirectory
+&branch=beta-feature      # set production branch to this branch
 ```
 
-`--source` accepts `functions`, `edge-functions`, and `deploy`. This is the documented CLI logs surface — reach for it before the dashboard, and see [CLI commands](references/cli-commands.md) for more.
+File-based template config in root `netlify.toml` `[template]` section:
+```toml
+[template]
+  incoming-hooks = ["Contentful"]
+  required-extensions = ["supabase"]
+[template.environment]
+  SECRET_TOKEN = "change me for your secret token"   # label only; cannot set real values
+```
+`[template]` cannot set env var values (use the URL hash) or a base directory (use `base`). With an alternate `base`, the `netlify.toml` in the base directory wins over root config for that site's builds. `USAGE.md` at repo root shows extra instructions during the `fullConfiguration` flow.
 
-## Useful Commands
+## Drag and drop (Netlify Drop)
 
-| Command | Description |
-|---|---|
-| `netlify build` | Run the build locally (mimics the Netlify build environment) |
-| `netlify deploy` | Draft deploy (preview URL) |
-| `netlify deploy --prod` | Production deploy |
-| `netlify deploy --dir=<dir>` | Deploy a specific directory |
-| `netlify clone org/repo` | Clone, link, and set up in one step |
-| `netlify open` | Open the site in the Netlify dashboard |
-| `netlify logs` | Recent function + edge-function logs (see Logs above) |
+Drag a folder to https://app.netlify.com/drop. Logged in: Netlify detects the framework and builds before publishing (a pre-built output folder also works). Not logged in: files publish as-is. Update a drag-and-drop site by dropping the new output folder at the dropzone on the site's **Deploys** page (works for any non-Git site).
 
-## Related skills
+## Build hooks
 
-- **netlify-config** — `netlify.toml` (build settings, redirects, headers, deploy contexts) and environment-variable management (`env:set`, `env:get`, `env:list`, context scoping).
-- **netlify-frameworks** — framework adapter/plugin setup and local development (`netlify dev`, the Netlify Vite plugin).
-- **netlify-access-control** — restricting who can reach a site or its deploys.
+Build hooks give unique URLs to trigger builds/deploys. Builds from build hooks are treated as trusted and are NOT subject to the Deploy Request Policy.
 
-## References
+## Managing deploys
 
-- [CLI commands](references/cli-commands.md)
-- [Deployment patterns](references/deployment-patterns.md)
-- [netlify.toml guide](references/netlify-toml.md)
+- **Find:** Deploys tab; search by deploy ID or branch; filter by time frame, deploy context, and status.
+- **Lock (pause publishing):** on the Deploys list, **Lock to stop auto publishing**. New deploys still build but don't publish. **Unlock to start auto publishing** to resume. Use this to keep a specific deploy live.
+- **Cancel:** on the in-progress deploy's detail page, **Cancel deploy**.
+- **Retry:** builds from the branch HEAD — if HEAD moved past the original deploy SHA, it still builds from HEAD.
+- **Download:** deploy detail page — single file via **Deploy file browser**, or all files as ZIP via header **Download**.
+- **Delete:** Developer/Team Owner only. You cannot delete the currently-published deploy or one in progress. Permanent; does not reduce cost or preserve build minutes.
+
+Netlify auto-deletes deploys older than 30 days (90 days on paid plans); failed/canceled deploys are cleaned up on the same schedule. It never auto-deletes the published deploy, the most recent successful production deploy, or the most recent successful branch deploy per branch.
+
+**Fix a failed deploy:** a failed deploy never publishes — the previously published deploy stays live, so there is nothing to restore. Fix forward: use the **"Why did it fail?"** diagnosis above the deploy log, revert the offending commit, and let CI redeploy. Retry (optionally clearing cache) rebuilds from branch HEAD.
+
+## Skew protection
+
+Available on all plans. Routes requests to the server version that matches each client, avoiding version skew across deploys. Requires Netlify CLI v23.11.0+ for CLI deploys.
+
+- **Production context only.** Branch deploys, Deploy Previews, and permalinks bypass skew protection and serve the latest deploy for that context.
+- Framework support: Astro 5.15.0+ (on by default via the Netlify adapter); Next.js (optional; older versions need a config change). Framework maintainers add support via `netlify/v1/skew-protection.json`.
+- **Password protection:** works only if you protect non-production deploys only. Protecting production deploys (or all deploys) disables/ignores skew protection.
+- Netlify discards skew signals on hard navigation (`Sec-Fetch-Mode: navigate`, or `Sec-Fetch-Site` present and not `same-origin`).
+
+## Secrets scanning failures
+
+If a deploy fails secrets scanning and the flagged value is a real secret, that is a leak: stop shipping it in client/published output and rotate it. Never disable the scanner over a real leak. For genuine non-secrets, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` / `SECRETS_SCAN_OMIT_PATHS` — never `SECRETS_SCAN_ENABLED=false`.
+
+## Constraints
+
+- **54,000 files per directory** max — any directory in your publish dir over this limit fails the deploy. No limit on total files.
+- Deploys are atomic: only changed files upload; nothing goes live until the whole deploy is ready.
+- Only the published production deploy and most recent branch deploys are indexable; other previews get `X-Robots-Tag: noindex`.
+- Deploy Request Policy: private-repo deploys build only for recognized authors (Owners, Developers, Git Contributors; Marketplace bots count). Non-team-member deploys land as **Pending approval** until a Team Owner approves/matches them. Build-hook builds are exempt.
+- Retention limit is adjustable only on Enterprise (up to 365 days). Lock/unlock event notifications: Pro and Enterprise.
+
+## More
+
+Deep guides in this skill: `references/netlify-toml.md`, `references/cli-commands.md`, `references/deployment-patterns.md`.
+
+<!-- Gap: deploy-overview states failed/canceled deploys are deleted at 6 months, contradicting the 30/90-day cleanup figure used above; the 30/90-day value is stated here as the documented default. -->
+
+<!-- system: agent-context/deploy/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (deploy)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Agents do not roll back deploys: never call `restoreSiteDeploy` or
+   `publishDeploy` to restore an older deploy. Fix forward — revert the
+   commit and let CI deploy it.
+2. A failed deploy never publishes; on failure there is nothing to roll
+   back.
+3. Deep guides live in this skill: `references/netlify-toml.md`,
+   `references/cli-commands.md`, `references/deployment-patterns.md`.
+4. The frontmatter description must never advertise rollback or restore as a
+   capability — no "roll back", "restore a deploy", or equivalent.
+5. When the user asks to roll back or restore a previous deploy, correct the
+   premise rather than complying: after a failed deploy the previous deploy
+   is still live and there is nothing to restore; for a bad published deploy,
+   fix forward per rule 1. Do not hand over `restoreSiteDeploy` /
+   `publishDeploy` or a dashboard rollback as the answer.
+6. Always add `.netlify` to `.gitignore` when linking or creating a site —
+   every linking path writes `.netlify/state.json`, which must not be
+   committed. Mention it whenever you link.
+7. Secrets-scanning deploy failures: if the flagged value is a real secret,
+   that is a leak — stop shipping it in client/published output and rotate
+   it; never silence the scanner over a real leak. For genuinely non-secret
+   values, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` /
+   `SECRETS_SCAN_OMIT_PATHS`, never `SECRETS_SCAN_ENABLED=false`.
+8. Before running a manual `netlify deploy --prod` on a site with Git CD
+   connected, warn the user that the next push to the production branch
+   silently replaces the hand-shipped deploy; suggest locking the published
+   deploy if it must stay live.

--- a/agent-plugin/skills/netlify-edge-functions/SKILL.md
+++ b/agent-plugin/skills/netlify-edge-functions/SKILL.md
@@ -1,180 +1,259 @@
 ---
 name: netlify-edge-functions
-description: Guide for writing Netlify Edge Functions. Use when building middleware, geolocation-based logic, request/response manipulation, authentication checks, A/B testing, or any low-latency edge compute. Covers Deno runtime, context.next() middleware pattern, geolocation, and when to choose edge vs serverless.
+description: Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use when adding request/response manipulation at the edge — auth middleware, geolocation redirects, A/B testing and personalization, content localization, redirects/rewrites, SSR at the edge, or transforming responses — or when configuring path routing, response caching, or edge error handling. Triggers on tasks like "add auth middleware", "geo-based redirect", "A/B testing at the edge", "rewrite requests", or editing files in netlify/edge-functions.
 ---
 
 # Netlify Edge Functions
 
-Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
+**Reach for this (modern):** default-export handler + inline `config` export with a narrowly-scoped `path`. Import types from `@netlify/edge-functions`.
 
-## Check the framework adapter first
+```ts
+import type { Config, Context } from "@netlify/edge-functions";
 
-For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+export default async (request: Request, context: Context) => {
+  // return Response | URL (rewrite) | undefined (continue chain)
+};
 
-## Syntax
+export const config: Config = { path: "/products/*" };
+```
 
-```typescript
+**Avoid:** import maps in `deno.json` (unsupported — use a separate file via `deno_import_map`). Do not hand-write a function your framework's adapter already generates (Next.js, Astro, Remix, SvelteKit, Nuxt, etc.) — check the framework adapter/reference first; duplicating adapter middleware causes conflicts.
+
+## File location
+
+- Default directory: `YOUR_BASE_DIRECTORY/netlify/edge-functions`.
+- Custom directory: `edge_functions` key under `[build]` in `netlify.toml`. Keep it **outside** the publish directory so source files aren't deployed.
+- `.js`/`.ts`/`.jsx`/`.tsx` all supported. If a `.ts` and `.js` file share a name, the `.ts` is ignored and the `.js` deploys.
+
+## ⚠️ A function without a route silently never runs
+
+Edge functions are **not** auto-assigned a URL. No `config` export and no `netlify.toml` declaration = deploys clean, no build error, no warning, never executes. If "my edge function does nothing," check the route first.
+
+## Request handling patterns
+
+Handler receives `(request: Request, context: Context)`. Return one of:
+- `Response` — respond directly (ends the chain; declared redirects for the path do not run)
+- `URL` — rewrite to a **same-site** URL with 200 status (address bar unchanged)
+- `undefined` / empty `return;` — bypass this function, continue the chain
+
+Netlify adds no headers to edge requests — use `context` for client info.
+
+### Redirect
+```ts
+export default async (req: Request, { cookies, geo }: Context) => {
+  if (geo.city === "Paris" && cookies.get("promo-code") === "15-for-followers") {
+    return Response.redirect(new URL("/subscriber-sale", req.url));
+  }
+};
+```
+
+### Rewrite (same-site only)
+```ts
+export default async (request: Request, { geo }: Context) => {
+  if (geo.city === "Paris") return new URL("/subscriber-sale", request.url);
+};
+```
+To reach another site or external content, use `fetch()` — rewrite via `URL` is same-site only.
+
+### Middleware transform
+```ts
+import type { Context } from "@netlify/edge-functions";
+
+export default async (request: Request, context: Context) => {
+  const response = await context.next();
+  const text = await response.text();
+  return new Response(text.toUpperCase(), response);
+};
+```
+`context.next()` runs the rest of the chain and returns the origin `Response`. Only call it if you need the response body (it costs latency otherwise).
+
+To transform a **different** path, use `fetch()` — but this starts a **new** request chain and re-runs any edge functions matching that path. Use `context.next()` to hit a static asset/serverless function at the same internal path without re-running edge functions.
+
+### Read the request body
+A body can only be read once. If you read it, pass a fresh request to `next()`:
+```ts
+export default async (req: Request, context: Context) => {
+  const body = await req.json();
+  if (!isValid(body.access_token)) return new Response("forbidden", { status: 403 });
+  return context.next(new Request(req, { body: JSON.stringify(body) }));
+};
+```
+
+### Conditional requests
+`next()` normally forces a full response. For client caching control:
+```ts
+const res = await next({ sendConditionalRequest: true });
+if (res.status === 304) return res;
+```
+
+## `Context` object
+
+- **`geo`** — `city`, `country {code,name}`, `subdivision {code,name}`, `latitude`, `longitude`, `timezone`, `postalCode`.
+- **`cookies`** — `get(name)`, `set(options)`, `delete(name|options)` (CookieStore web standard). ⚠️ Cross-subdomain cookies require a **custom domain** — `netlify.app` is on the Public Suffix List.
+- **`next(options?)` / `next(request, options?)`** — continue the chain; `options.sendConditionalRequest`.
+- **`params`** — path params, e.g. `/pets/:name` → `{ name: "winter" }`. Query string: use `request.url`.
+- **`ip`**, **`requestId`**, **`server.region`**.
+- **`site`** — `id`, `name`, `url`. **`account.id`**. **`deploy`** — `context`, `id`, `published`, `skewProtectionToken`.
+- **`waitUntil(promise)`** — run work after the response is sent (analytics, logs) without blocking it. Still subject to the CPU time limit.
+
+`Netlify.context` gives the same context inside the handler (`null` outside it).
+
+## Environment variables
+
+Access via `Netlify.env.get(name)` (also `has`, `set`, `delete`, `toObject`). `set`/`delete` are invocation-scoped only — they do **not** persist; use the Netlify env API to update.
+
+```ts
+const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
+```
+
+⚠️ **Gotchas:**
+- Variables in `netlify.toml` are **NOT** available to edge functions.
+- Scope must include **Functions** to reach runtime. **Build**-scoped vars are build-only — embed them at build time if needed.
+- Values are frozen at deploy time. Change a var → new deploy required. Deploy Previews/branch deploys use their deploy-time values.
+
+## Configuration / routing
+
+Config via inline `config` export or `netlify.toml`. Properties:
+- **`path`** — `URLPattern` string or array; must start with `/`. e.g. `["/", "/products/*"]`.
+- **`excludedPath`** — exclude routes from `path`; must start with `/`. e.g. `["/*.css", "/*.js"]`.
+- **`pattern`** / **`excludedPattern`** — regex alternatives to `path`/`excludedPath`.
+- **`method`** — string or array of HTTP methods (inline only).
+- **`header`** — object of header conditions: `true` (present), `false` (absent), or a regex string on the value. Names case-insensitive; multiple same-name values matched as comma-joined list.
+- **`cache`** — `"manual"` to opt into caching.
+- **`onError`** — error handling (see below).
+
+### ⚠️ Scope `path` narrowly
+
+`path: "/*"` intercepts **every** request including static assets — adds latency to each and **bills an edge invocation** for each. Match only the paths you need.
+
+### netlify.toml (for ordering / multiple functions on a path)
+```toml
+[[edge_functions]]
+  path = "/admin"
+  function = "auth"
+
+[[edge_functions]]
+  path = "/admin"
+  function = "injector"
+  cache = "manual"
+```
+Header matching uses an `[edge_functions.header]` sub-table.
+
+### Execution order
+Config-file declarations run before inline; framework-generated before user; non-cached before cached. Within `netlify.toml`: top-to-bottom. Within inline: **alphabetical by file name**. To control order, prefer `netlify.toml`. If the same function is declared both inline and in toml, they merge and inline fields win.
+
+Caveats: a function on the **target** of a static rewrite does **not** run for rewritten requests. If a function returns a `Response`, redirects for that path are skipped.
+
+## Response caching (opt-in)
+
+### ⚠️ Both parts or neither
+Cache headers on the `Response` do **nothing** without `cache: "manual"` in config — and `cache: "manual"` without headers still caches nothing. You need **both**:
+
+```ts
 import type { Config, Context } from "@netlify/edge-functions";
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello from the edge!");
+  return new Response("Hello world", {
+    headers: { "cache-control": "public, s-maxage=3600" },
+  });
 };
 
-export const config: Config = {
-  path: "/hello",
-};
+export const config: Config = { cache: "manual", path: "/hello" };
 ```
 
-Place files in `netlify/edge-functions/`. Uses `.ts`, `.js`, `.tsx`, or `.jsx` extensions.
+- Use caching only for endpoint-style responses reusable across clients (e.g. shared SSR HTML). **Never** for middleware, routing, or per-client personalization.
+- Cached responses do **not** count toward invocations.
+- ⚠️ A cached function **shadows real static files**: `cache:"manual"` on `/*` makes `/cat.png` serve the function, not the static file.
+- Supported headers: `Cache-Control`, `CDN-Cache-Control`, `Netlify-CDN-Cache-Control`, `Expires`, `Vary`, `Netlify-Vary`. Headers must be set inline in code.
+- New deploy in the same context voids `s-maxage`/`max-age`/`Expires` (atomic deploys).
+- No local caching — cache headers are ignored under `netlify dev`.
 
-## Config Object
+## Error handling (`onError`, inline only)
 
-```typescript
-export const config: Config = {
-  path: "/api/*",                    // URLPattern path(s)
-  excludedPath: "/api/public/*",     // Exclusions
-  method: ["GET", "POST"],           // HTTP methods
-  onError: "bypass",                 // "fail" (default), "bypass", or "/error-page"
-  cache: "manual",                   // Enable response caching
-};
+- **`"fail"`** (default) — generic error page, stops the chain.
+- **`"/custom-path"`** — rewrite to a same-site path (starts with `/`), served without invoking that path's edge functions.
+- **`"bypass"`** — skip the erroring function, continue the chain.
+
+Guidance: fail **closed** for critical logic (auth); fail **open** for progressive enhancement (localization → `bypass`).
+
+## Runtime & modules
+
+Deno runtime with many standard Web APIs (`fetch`/`Request`/`Response`/`URL`, `console`, `atob`/`btoa`, `TextEncoder`/`Decoder`(`Stream`), Web Crypto `crypto.randomUUID/getRandomValues/subtle`, `WebSocket`, timers, Streams API, `URLPattern`, `Performance`).
+
+- **Node built-ins:** `import { randomBytes } from "node:crypto"` (`node:` prefix).
+- **Deno modules:** URL import, e.g. `import React from "https://esm.sh/react"`.
+- **npm packages (beta):** `npm install` then import by name. ⚠️ Packages needing native binaries (Prisma) or runtime dynamic imports (cowsay) may fail — prefer `node:` built-ins / Deno URLs.
+- **Import maps:** separate file only (not `deno.json`), declared via `deno_import_map` in `[functions]`.
+
+### SSR at the edge (.tsx)
+```tsx
+import React from "https://esm.sh/react";
+import { renderToReadableStream } from "https://esm.sh/react-dom/server";
+import type { Config, Context } from "@netlify/edge-functions";
+
+export default async function handler(req: Request, context: Context) {
+  const stream = await renderToReadableStream(
+    <html><body><h1>Hello {context.geo.country?.name}</h1></body></html>
+  );
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/html" } });
+}
+
+export const config: Config = { path: "/hello" };
 ```
 
-**Scope `path` narrowly — `path: "/*"` intercepts every request, including static assets.** A `/*` match runs the edge function on every CSS, JS, image, and font request, not just your HTML pages — adding latency to each asset and billing an edge invocation for it. Match only the routes you need (e.g. `path: "/"`, `path: "/app/*"`), or keep a broad path but exclude static assets with `excludedPath` (e.g. `excludedPath: ["/*.css", "/*.js", "/*.png", "/*.woff2"]`).
+## Edge vs serverless
 
-**Cache headers on an edge response do nothing without `cache: "manual"`.** Setting `Cache-Control` (or any cache header) on the `Response` an edge function returns has no effect unless the function also opts in with `config.cache = "manual"`. It's both or neither: without the flag the response is never cached, no matter what headers you set.
-
-## Declaring edge functions: inline config vs netlify.toml
-
-An edge function runs only if it is bound to a path. Bind it either with an inline `export const config = { path: ... }` in the function file (shown above), or with an `[[edge_functions]]` entry in `netlify.toml` that names the file:
-
-```toml
-[[edge_functions]]
-  path = "/admin/*"
-  function = "auth"        # runs netlify/edge-functions/auth.ts
-```
-
-**A file in `netlify/edge-functions/` with no path binding still deploys, but silently never runs.** There is no build error and no warning — nothing routes a request to it, so it is never invoked. If an edge function "isn't doing anything," first confirm it declares a `path` inline or has a matching `[[edge_functions]]` entry.
-
-### Chaining multiple edge functions on one path
-
-When several edge functions match the same path, they run as a chain in this order:
-
-1. Functions declared in `netlify.toml` run first, **in the order they appear** in the file (top to bottom).
-2. Functions declared inline (via `export const config`) run next, **in alphabetical order by filename**.
-3. Functions configured for caching (`cache: "manual"`) always run after non-caching ones.
-
-To guarantee a specific order (e.g. an auth gate that must run before a personalization rewrite), declare the functions in `netlify.toml` in the order you want — don't depend on inline config, whose order is alphabetical by filename and easy to get wrong. Declaring the same function both inline and in `netlify.toml` merges them into an inline declaration (inline config wins), which forfeits the deterministic `netlify.toml` ordering.
-
-## Edge functions run before redirects
-
-In Netlify's request chain, edge functions execute **before** redirect and rewrite rules (`[[redirects]]`, `_redirects`). Two consequences bite often:
-
-- An edge function is matched against the **original** requested URL, not a redirect/rewrite destination. Scope its `path` to the URL the client actually requests — an edge function declared on the *target* of a rewrite will not fire for requests that only reach that target via the rewrite.
-- If an edge function returns a `Response`, the request chain stops there and redirect rules for that path **never run**. Return `context.next()` (or `undefined`) if you want redirects to still apply.
-
-## Middleware Pattern
-
-Use `context.next()` to invoke the next handler in the chain and optionally modify the response:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  // Before: modify request or short-circuit
-  if (!isAuthenticated(req)) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  // Continue to origin/next function
-  const response = await context.next();
-
-  // After: modify response
-  response.headers.set("x-custom-header", "value");
-  return response;
-};
-```
-
-Return `undefined` to pass through without modification:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  if (!shouldHandle(req)) return; // continues to next handler
-  return new Response("Handled");
-};
-```
-
-## Geolocation and IP
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const { city, country, subdivision, timezone } = context.geo;
-  const ip = context.ip;
-
-  if (country?.code === "DE") {
-    return Response.redirect(new URL("/de", req.url));
-  }
-};
-```
-
-Local dev with mocked geo: `netlify dev --geo=mock --country=US`
-
-## Cookies
-
-Read and write cookies through the `context.cookies` helper instead of hand-parsing the `Cookie` header or building `Set-Cookie` strings:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const bucket = context.cookies.get("bucket");            // read from the request
-  context.cookies.set({ name: "bucket", value: "a" });     // set on the response
-  context.cookies.delete("legacy_session");                // tell the client to delete it
-  return context.next();
-};
-```
-
-- `cookies.get(name)` — reads a named cookie from the incoming request.
-- `cookies.set(options)` — sets a cookie on the outgoing response (same option shape as the web `CookieStore.set` standard).
-- `cookies.delete(name)` — instructs the client to delete the cookie.
-
-## Environment Variables
-
-Use `Netlify.env` (not `process.env` or `Deno.env`):
-
-```typescript
-const secret = Netlify.env.get("API_SECRET");
-```
-
-## Module Support
-
-- **Node.js builtins**: `import { randomBytes } from "node:crypto";`
-- **npm packages**: Install via npm and import by name
-- **Deno modules**: URL imports (e.g., `import X from "https://esm.sh/package"`)
-
-For URL imports, use an import map:
-
-```json
-// import_map.json
-{ "imports": { "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts" } }
-```
-
-```toml
-# netlify.toml
-[functions]
-  deno_import_map = "./import_map.json"
-```
-
-## When to Use Edge vs Serverless
-
-| Use Edge Functions for | Use Serverless Functions for |
-|---|---|
-| Low-latency responses | Long-running operations (up to 15 min) |
-| Request/response manipulation | Complex Node.js dependencies |
-| Geolocation-based logic | Database-heavy operations |
-| Auth checks and redirects | Background/scheduled tasks |
-| A/B testing, personalization | Tasks needing > 512 MB memory |
+Edge for low-latency request/response manipulation, geolocation, auth checks/redirects, A/B personalization. Serverless for long-running work (up to 15 min), heavy Node deps, database-heavy operations, background/scheduled tasks, or memory above 512 MB.
 
 ## Limits
 
-| Resource | Limit |
-|---|---|
-| CPU time | 50 ms per request |
-| Memory | 512 MB per deployed set |
-| Response header timeout | 40 seconds |
-| Code size | 20 MB compressed |
+- Code size: **20 MB** compressed (bundle).
+- Memory: **512 MB** per deployed set.
+- CPU execution: **50 ms** per request (excludes waiting on resources; `waitUntil` work still counts).
+- Response header timeout: **40 s**.
+- Invocations/month vary by plan; cached responses don't count.
+
+## Local dev, deploy, monitor
+
+```bash
+npm install netlify-cli -g
+netlify dev      # runs edge functions on local requests at :8888
+```
+- Geo mocking: `--geo=mock` (San Francisco) or `--geo=mock --country=XX`. Debug: `--edge-inspect` / `--edge-inspect-brk`.
+- Manual deploys require CLI **12.2.8+** (older versions error). Deploys are atomic.
+- Logs: **Logs & Metrics > Edge Functions** in the UI; each `console` log names the emitting function. Filter by name/path (glob) and time. Retention ≥24h (7 days on some plans).
+
+## Feature limitations
+
+- Split Testing enabled → edge functions do **not** run.
+- Custom Headers (incl. basic auth headers) do **not** apply to edge functions.
+- Prerendering does **not** apply to paths served by an edge function.
+- Multiple framework plugins generating edge functions may collide.
+- Not part of Netlify's HIPAA-compliant offering.
+
+<!-- system: agent-context/edge-functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (edge-functions)
+
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-edge-functions skill; owned
+by the skills maintainer.
+
+1. Check the framework's adapter/reference first: a custom edge function that
+   duplicates adapter-generated middleware causes conflicts. Only hand-write
+   an edge function when the framework doesn't already generate one for the
+   job.
+2. Scope `path` narrowly. `path: "/*"` intercepts every request — including
+   static assets — adding latency to each one and billing an edge invocation
+   for it.
+3. An edge function without a route (no config export, no netlify.toml
+   declaration) still deploys, but silently never runs: no build error, no
+   warning. When "my edge function does nothing", check the route first.
+4. Choose edge vs serverless by workload shape: edge functions for low-latency
+   request/response manipulation, geolocation logic, auth checks/redirects,
+   and A/B personalization; serverless functions for long-running work (up to
+   15 min), heavy Node.js dependencies, database-heavy operations,
+   background/scheduled tasks, or memory needs above 512 MB.
+5. Cache headers on an edge response do nothing without `cache: "manual"` in
+   config — it's both or neither. Setting `Cache-Control` on the returned
+   `Response` has no effect unless the function also opts in.

--- a/agent-plugin/skills/netlify-forms/SKILL.md
+++ b/agent-plugin/skills/netlify-forms/SKILL.md
@@ -1,195 +1,196 @@
 ---
 name: netlify-forms
-description: Guide for using Netlify Forms for HTML form handling. Use when adding contact forms, feedback forms, file upload forms, or any form that should be collected by Netlify. Covers the data-netlify attribute, spam filtering, AJAX submissions, file uploads, notifications, and the submissions API.
+description: Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam, and sends notifications. Use when adding a contact form, lead-capture form, file-upload form, or newsletter signup to a Netlify site; wiring AJAX form submission; setting up a custom thank-you page; adding a honeypot or reCAPTCHA to a form; getting forms working in Next.js, Nuxt, SvelteKit, Astro, or Gatsby; reading form submissions via the Netlify API; or debugging missing submissions and forms that silently fail to register.
 ---
 
 # Netlify Forms
 
-Netlify Forms collects HTML form submissions without server-side code. Form detection must be enabled in the Netlify UI (Forms section).
+Mark a form for detection with `data-netlify="true"` (or the bare `netlify` attribute — equivalent) on the `<form>` tag. Forms are detected by **parsing the final built HTML at deploy time** — there is no runtime API call or backend code. Client-side/JS-rendered/SSR forms are NOT in the built HTML and are never detected on their own; they require a static skeleton file (see below).
 
-> **Enabling detection only affects future deploys.** Netlify scans for forms at deploy time, so turning on (or re-enabling) form detection does **not** rescan your current live deploy. After enabling detection you must trigger a new deploy/build before an already-published form is registered and starts collecting submissions.
+Prerequisite: form detection must be enabled once in the Netlify UI (Forms > **Enable form detection**). Takes effect on the next deploy.
 
-## Basic Setup
-
-Add `data-netlify="true"` and a unique `name` to the form:
+## Static HTML form
 
 ```html
 <form name="contact" method="POST" data-netlify="true">
-  <label>Name: <input type="text" name="name" /></label>
-  <label>Email: <input type="email" name="email" /></label>
-  <label>Message: <textarea name="message"></textarea></label>
-  <button type="submit">Send</button>
+  <p><label>Your Name: <input type="text" name="name" /></label></p>
+  <p><label>Your Email: <input type="email" name="email" /></label></p>
+  <p><label>Message: <textarea name="message"></textarea></label></p>
+  <p><button type="submit">Send</button></p>
 </form>
 ```
 
-Netlify's build system detects the form and injects a hidden `form-name` input automatically. For a custom success page, add `action="/thank-you"` to the form tag. Use paths without `.html` extension — Netlify serves `thank-you.html` at `/thank-you` by default, and the `.html` path returns 404.
+- `name` sets the form name in the UI and **must be unique per site**.
+- At deploy, Netlify strips the `data-netlify`/`netlify` attribute and injects `<input type="hidden" name="form-name" value="contact" />`.
+- Add an `<input name="email">` so the notification email's `Reply-to` is set to the submitter.
 
-## JavaScript-Rendered Forms (React, Vue, SSR Frameworks)
+## JS-rendered / SSR / framework forms (Next.js, Nuxt, SvelteKit, Astro, Gatsby)
 
-For forms rendered by JavaScript frameworks (React, Vue, Astro, TanStack Start, Next.js, SvelteKit, Remix, Nuxt), Netlify's build parser cannot detect the form in static HTML. You MUST create a static HTML skeleton file for build-time form detection:
+Two required pieces:
 
-> **Form detection parses prerendered HTML only.** A `data-netlify` form is registered only if it appears in HTML produced at build time. On an Astro route that is server-rendered on demand (`export const prerender = false`, or an `output: "server"` route), the form is generated per request and is never scanned at build — so it is never registered. Put the form on a prerendered page, or add the static skeleton file below.
-
-Create a static HTML file in `public/` (e.g. `public/__forms.html`) containing a hidden copy of each form:
+**1. Static skeleton file `public/__forms.html`** — a hidden copy of each form with `data-netlify="true"`, a hidden `form-name` input, and every field the component submits, with names matching **exactly** (Netlify validates field names against the registered form). Without this file, submissions silently fail.
 
 ```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" />
-      <input type="email" name="email" />
-      <textarea name="message"></textarea>
-      <input name="bot-field" />
-    </form>
-  </body>
-</html>
+<!-- public/__forms.html -->
+<form name="pizzaOrder" data-netlify="true" hidden>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" />
+</form>
 ```
 
-**Rules:**
-- The form `name` must exactly match the `form-name` value used in your component's fetch call
-- Include every field your component submits — Netlify validates field names against the registered form
-- Without this file, Netlify cannot detect the form and submissions will silently fail
-
-Your component must also include a hidden `form-name` input:
+**2. The rendered form** carries a matching hidden `form-name` input:
 
 ```jsx
-<form name="contact" method="POST" data-netlify="true">
-  <input type="hidden" name="form-name" value="contact" />
-  {/* ... fields ... */}
+<form name="pizzaOrder" method="post" data-netlify="true" onSubmit={handleSubmit}>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" onChange={handleChange} />
+  <input type="submit" />
 </form>
 ```
 
-## AJAX Submissions
+**⚠️ SSR POST target:** In SSR apps, `fetch("/")` is intercepted by the SSR catch-all function and never reaches form processing. POST to the static skeleton file itself — `/__forms.html` — not `/` or an arbitrary path.
 
-> **Netlify Forms does not accept JSON.** The submission body must be `application/x-www-form-urlencoded` (encode the fields with `URLSearchParams`) or `multipart/form-data` (a raw `FormData` object, for file uploads). A `fetch` that sends `JSON.stringify(...)` with `Content-Type: application/json` is silently **not** recorded as a submission — always send URL-encoded key/value pairs (or `FormData`), never JSON.
+**⚠️ Astro on-demand routes:** Routes with `export const prerender = false` or `output: "server"` are never scanned at build time, so their forms are never registered. Put the form on a prerendered page, or rely on the static skeleton file.
 
-### Vanilla JavaScript
+**Next.js Runtime v5 (Next.js 13.5+):** extract form definitions to the static skeleton file and submit via AJAX rather than full-page navigation. See https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview#v5-breaking-changes
 
-```javascript
-const form = document.querySelector("form");
-form.addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const formData = new FormData(form);
-  await fetch("/", {
+## AJAX submission
+
+```js
+const handleSubmit = event => {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  fetch("/__forms.html", {   // static sites may POST to "/"; SSR must target the skeleton file
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(formData).toString(),
-  });
+    body: new URLSearchParams(formData).toString()
+  })
+    .then(() => alert("Thank you for your submission"))  // or navigate("/thank-you")
+    .catch(error => alert(error));
+};
+document.querySelector("form").addEventListener("submit", handleSubmit);
+```
+
+- **Body MUST be URL-encoded. JSON is NOT supported.**
+- If the rendered form has no hidden `form-name` input, you MUST include a `form-name` field in the POST body.
+- The honeypot field name and `g-recaptcha-response` (if used) must be in the body — automatic with `FormData()`.
+
+## File uploads
+
+Add `type="file"`; optionally `enctype="multipart/form-data"` on the `<form>`. For AJAX file uploads, **do NOT set a `Content-Type` header** — let the browser set it (with the multipart boundary).
+
+```js
+document.forms.fileForm.addEventListener("submit", event => {
+  event.preventDefault();
+  fetch("/", { body: new FormData(event.target), method: "POST" })  // no headers
+    .then(() => { /* success */ });
 });
 ```
 
-> **SSR frameworks (TanStack Start, Next.js, SvelteKit, Remix, Nuxt):** The `fetch` URL must target the static skeleton
-> file path (e.g. `"/__forms.html"`), **not** `"/"`. In SSR apps, `fetch("/")` is intercepted by the SSR catch-all
-> function and never reaches Netlify's form processing middleware. See the React example and troubleshooting section below.
+Limits: one file per field (use multiple fields for multiple files) · 8 MB max request size · 30 s upload timeout · after form deletion, uploaded files stay at their direct URL for 24 h. PII uploads need extra security (Very Good Security integration).
 
-### React Example
+## Custom success page
 
-```tsx
-function ContactForm() {
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    // For SSR apps, use the skeleton file path instead of "/" (e.g. "/__forms.html")
-    const response = await fetch("/__forms.html", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(formData as any).toString(),
-    });
-    if (response.ok) {
-      // Show success feedback
-    }
-  };
+Add an `action` path relative to site root, starting with `/`. **Use extensionless paths** — Netlify serves `thank-you.html` at `/thank-you`; the `.html` path returns 404.
 
-  return (
-    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" placeholder="Name" />
-      <input type="email" name="email" placeholder="Email" />
-      <textarea name="message" placeholder="Message" />
-      <button type="submit">Send</button>
-    </form>
-  );
-}
+```html
+<form name="contact" action="/thank-you" method="POST" data-netlify="true"></form>
 ```
 
-> **SSR troubleshooting:** If form submissions appear to succeed (200 response) but nothing shows in the Netlify Forms
-> UI, the POST is likely being intercepted by the SSR function. Ensure `fetch` targets the skeleton file path (e.g.
-> `"/__forms.html"`), not `"/"`. The skeleton file path routes through the CDN origin where Netlify's form handler runs.
+Custom success *alert* is only possible via AJAX (substitute the redirect with your own logic).
 
-## Spam Filtering
+## Spam prevention
 
-Netlify uses Akismet automatically. Add a honeypot field for extra protection:
+All submissions are filtered by Akismet. Passed → **Verified submissions**; flagged → **Spam submissions**. Honeypot/reCAPTCHA failures are rejected and appear in neither list.
+
+**Honeypot:** add `netlify-honeypot="bot-field"` to the `<form>` and include a CSS-hidden field of that name. Any value entered → submission quietly rejected.
 
 ```html
 <form name="contact" method="POST" netlify-honeypot="bot-field" data-netlify="true">
-  <p style="display:none">
-    <label>Don't fill this out: <input name="bot-field" /></label>
-  </p>
-  <!-- visible fields -->
+  <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
+  <!-- real fields -->
 </form>
 ```
 
-For reCAPTCHA, add `data-netlify-recaptcha="true"` to the form and include `<div data-netlify-recaptcha="true"></div>` where the widget should appear.
+**Netlify reCAPTCHA 2:** add `data-netlify-recaptcha="true"` to the `<form>` AND an empty `<div data-netlify-recaptcha="true"></div>` where it renders. Only ONE Netlify-provided challenge per page — for multiple, use custom reCAPTCHA. For JS-rendered forms, also add the `div` to the static skeleton file.
 
-By default Netlify provisions and verifies the reCAPTCHA for you — do **not** add a site key/secret or load Google's reCAPTCHA script yourself. To use **your own** reCAPTCHA v2 keys, keep the same `data-netlify-recaptcha="true"` markup and set the credentials as Netlify environment variables: `SITE_RECAPTCHA_KEY` (the site key, scoped to Builds and Runtime) and `SITE_RECAPTCHA_SECRET` (the secret, scoped to Runtime). Netlify picks these up automatically — the secret stays server-side as an env var (never hardcoded in client code), and you still don't render the widget with Google's own script or build a custom Function to verify the token.
+**Custom reCAPTCHA 2:** your own reCAPTCHA snippet + `data-netlify-recaptcha="true"` on the `<form>`, plus env vars:
+- `SITE_RECAPTCHA_KEY` — site key (scopes: Builds + Runtime)
+- `SITE_RECAPTCHA_SECRET` — secret (scope: Runtime)
 
-> **Spam submissions are silent.** Akismet-flagged submissions are moved to a separate **Spam** list in the Forms UI — they do **not** appear in the verified submissions list and do **not** trigger email/Slack notifications. Submissions caught by a honeypot field or a failed reCAPTCHA challenge are discarded entirely and never appear in either list. So a "missing" legitimate submission is usually a false-positive spam classification, not a delivery bug: check the Spam list (or the Submissions API with `?state=spam`) and mark it verified — do not build a custom Function to "recover" it or disable spam filtering as a first resort.
+## Email notifications & subject line
 
-## File Uploads
+Default sender: `formresponses@netlify.com`. Set subject via a hidden `subject` input **or** the Netlify UI (Configuration > Notifications) — **not both; the HTML value always overrides the UI.**
 
 ```html
-<form name="upload" enctype="multipart/form-data" data-netlify="true">
-  <input type="text" name="name" />
-  <input type="file" name="attachment" />
-  <button type="submit">Upload</button>
-</form>
+<input type="hidden" name="subject" value="New lead from %{formName} (%{submissionId})" />
 ```
 
-For AJAX file uploads, use `FormData` directly — do **not** set `Content-Type` (the browser sets it with the correct boundary):
+Variables: `%{formName}`, `%{siteName}`, `%{submissionId}`. Forms created before **May 5, 2023** carry a `[Netlify]` subject prefix — remove it by adding the `data-remove-prefix` attribute to the `subject` input.
 
-```javascript
-await fetch("/", { method: "POST", body: new FormData(form) });
-```
+Set up notifications (email/webhook/Slack) in the UI: Configuration > Notifications > Form submission notifications > **Add notification**.
 
-**Limits:** 8 MB max request size, 30-second timeout, one file per input field.
+## Reading submissions via the API
 
-## Notifications
+Use only documented surfaces. Do NOT invent `api.netlify.com` endpoints or read tokens from local CLI config files. Reference: https://open-api.netlify.com/#tag/submission/operation/listFormSubmissions
 
-Configure in the Netlify UI under **Project configuration > Notifications**:
+- **Page through results using the `Link` header** — code that reads only the first response silently drops the rest.
+- `listFormSubmissions` returns data from old/removed fields no longer shown in the UI.
+- Query spam with `?state=spam`.
 
-- **Email**: Auto-sends on submission. Add `<input type="hidden" name="subject" value="Contact form" />` for custom subject lines.
-- **Slack**: Via Netlify App for Slack.
-- **Webhooks**: Trigger external services on submission.
+## Submission summary (field order matters)
 
-## Submissions API
+The UI summary is derived from field **type**, not name:
+- **Title**: first non-hidden text `<input>` that isn't email-like (`type="email"`, or name matching `email`/`mail`/`from`/`twitter`/`sender`); falls back to a field named `title` or `subject`.
+- **Body**: first `<textarea>`.
 
-Access submissions programmatically:
+Field order in the HTML affects what appears in the summary.
 
-```
-GET /api/v1/forms/{form_id}/submissions
-Authorization: Bearer <PERSONAL_ACCESS_TOKEN>
-```
+## Debugging missing submissions
 
-Key endpoints:
+- **First suspect: Akismet false positive.** A missing legitimate submission is usually spam-flagged — check the **Spam** list (or API `?state=spam`) and mark it verified. Do NOT build a custom recovery function or disable spam filtering as a first resort.
+- Test submissions get flagged as spam: use a real email (not `test@test.com`), write full sentences, don't hammer from one IP.
+- No submissions at all: confirm form detection is enabled and redeploy.
+- SSR/JS forms silently failing: verify the static skeleton file exists with exactly-matching field names and that AJAX targets the skeleton file, not `/`.
+- Missing old-field data: the UI shows only fields from the last deployed form version. Mark old fields `hidden` instead of removing them to keep them visible; old data remains available via `listFormSubmissions`.
 
-| Action | Method | Path |
-|---|---|---|
-| List forms | GET | `/api/v1/sites/{site_id}/forms` |
-| Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
-| Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
-| Delete submission | DELETE | `/api/v1/submissions/{id}` |
+## Constraints
 
-### Pagination
+- Deleting a form is permanent: future submissions return `404`, past submissions become unavailable. Export CSV first.
+- Submitted code is sanitized (`<script>` → escaped entities).
+- For PII, export and delete data regularly.
+- Data is stored in Netlify's database, not accessible except via UI/API/CSV.
 
-The Netlify API paginates any response over 100 items (100 per page by default). Pass `?page=` (1-based) and optionally `?per_page=` (max 100), and follow the `Link` response header — it carries the `rel="next"` and `rel="last"` page URLs. To sync **every** submission, page through until there is no `rel="next"` link (or a page returns fewer than `per_page` items). A single request does **not** return all submissions once a form has more than 100 — code that reads only the first response silently drops the rest.
+<!-- system: agent-context/forms/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (forms)
 
-## Use only documented surfaces
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-forms skill; owned by the
+skills maintainer.
 
-To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
-
-- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
-- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
-
-If a documented path fails, report the exact error and context to the user and stop.
+1. In SSR apps (Next.js, Nuxt, SvelteKit, etc.), `fetch("/")` is intercepted
+   by the SSR catch-all function and never reaches Netlify's form processing.
+   POST the AJAX submission to the static skeleton file itself (e.g.
+   `/__forms.html`), not to an arbitrary path.
+2. Use only documented surfaces: do not curl `https://api.netlify.com/...`
+   with an invented endpoint shape, and do not read tokens out of local CLI
+   config files (`~/Library/Preferences/netlify/config.json`).
+3. When reading submissions via the API, page through results (`Link`
+   header); code that reads only the first response silently drops the rest.
+4. For JS-rendered and SSR forms, always create the static skeleton file
+   `public/__forms.html`: a hidden copy of each form with
+   `data-netlify="true"`, a hidden `form-name` input, and every field the
+   component submits — names matching exactly (Netlify validates field names
+   against the registered form). Without this file, submissions silently fail.
+5. Astro routes rendered on demand (`export const prerender = false`, or
+   `output: "server"` routes) are never scanned at build time, so their forms
+   are never registered. Put the form on a prerendered page or rely on the
+   static skeleton file.
+6. A "missing" legitimate submission is usually an Akismet false positive:
+   check the Spam list (or the API with `?state=spam`) and mark it verified.
+   Do not build a custom recovery function or disable spam filtering as a
+   first resort.
+7. For custom success pages, use extensionless `action` paths (`/thank-you`,
+   not `/thank-you.html`) — Netlify serves `thank-you.html` at `/thank-you`
+   and the `.html` path returns 404.

--- a/agent-plugin/skills/netlify-frameworks/SKILL.md
+++ b/agent-plugin/skills/netlify-frameworks/SKILL.md
@@ -1,116 +1,241 @@
 ---
 name: netlify-frameworks
-description: Guide for deploying web frameworks on Netlify. Use when setting up a framework project (Vite/React, Astro, TanStack Start, Next.js, Nuxt, SvelteKit, Remix) for Netlify deployment, configuring adapters or plugins, running a framework project locally with Netlify's platform features, or troubleshooting framework-specific Netlify integration. Covers what Netlify needs from each framework, how adapters handle server-side rendering, and the general local development options (`netlify dev` versus the Netlify Vite plugin family).
+description: Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and env vars. Use when setting up or fixing a framework deploy (Next.js / Astro / Nuxt / SvelteKit / Remix / React Router / TanStack Start / SolidStart / Gatsby / Angular / Vite / Express / Hydrogen / Hugo / Eleventy / Vue / React), adding SSR or edge functions or middleware wired to Netlify context, fixing SPA redirect and catch-all rules, setting a build command or publish directory, or debugging "why isn't my env var updating" and framework build failures.
 ---
 
-# Frameworks on Netlify
+Route framework-specific deep work to the guides in this skill: `references/astro.md`, `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`, `references/tanstack.md`, `references/vite.md`.
 
-Netlify supports any framework that produces static output. For frameworks with server-side capabilities (SSR, API routes, middleware), an adapter or plugin translates the framework's server-side code into Netlify Functions and Edge Functions automatically.
+## Env vars: modern rules (read first)
 
-## How It Works
+Env values are injected **at build time**. Any change (client- or server-side) requires a **redeploy** — editing a var in the UI/CLI does NOT reach the live site or already-deployed functions until a new build runs.
 
-During build, the framework adapter writes files to `.netlify/v1/` — functions, edge functions, redirects, and configuration. Netlify reads these to deploy the site. You do not need to write Netlify Functions manually when using a framework adapter for server-side features.
+**Never use a client prefix for secrets.** Client-prefixed vars are inlined into the browser bundle:
+`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`.
 
-## Detecting Your Framework
+Client-embed prefixes by framework: CRA `REACT_APP_`, Gatsby `GATSBY_`, Next `NEXT_PUBLIC_`, Nuxt `NUXT_ENV_`, Vue CLI `VUE_APP_`.
 
-Check these files to determine the framework:
+**Scopes:** build-time access needs **Builds** scope; SSR/DSG runtime access needs **both Functions and Builds**. `netlify.toml` is read only during build — functions cannot read it at runtime; set runtime vars in UI/CLI/API.
 
-| File | Framework |
-|---|---|
-| `astro.config.*` | Astro |
-| `next.config.*` | Next.js |
-| `nuxt.config.*` | Nuxt |
-| `vite.config.*` + `react-router` | Vite + React (SPA or Remix) |
-| `vite.config.*` + `@tanstack/react-start` | TanStack Start |
-| `svelte.config.*` | SvelteKit |
-
-## Framework Reference Guides
-
-Each framework has specific adapter/plugin requirements and local dev patterns:
-
-- **Vite + React (SPA or with server routes)**: See [references/vite.md](references/vite.md)
-- **Astro**: See [references/astro.md](references/astro.md)
-- **TanStack Start**: See [references/tanstack.md](references/tanstack.md)
-- **Next.js**: See [references/nextjs.md](references/nextjs.md)
-- **Nuxt**: See [references/nuxt.md](references/nuxt.md)
-- **SvelteKit**: See [references/sveltekit.md](references/sveltekit.md)
-
-## Local Development
-
-Running a framework project locally with Netlify's platform features (environment variables, Functions, Edge Functions) generally comes from one of two places:
-
-### `netlify dev`
-
-```bash
-netlify dev
-```
-
-Wraps the framework's own dev server and adds:
-- Environment variable injection
-- Functions and Edge Functions
-- Redirects and headers processing
-
-Works with any framework — run `netlify dev` in place of the framework's native dev command (e.g. instead of `npm run dev`).
-
-Custom dev-server wiring — a non-standard `command`, a `port`/`targetPort`, or the `framework` key — goes in `netlify.toml`'s `[dev]` block; see the **netlify-config** skill for the full syntax. One easy-to-miss rule: if you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`, otherwise Netlify Dev runs its own detector and silently ignores your command.
-
-### Netlify Vite plugin family (Vite-based frameworks)
-
-For frameworks built on Vite, a Netlify Vite plugin exposes platform primitives (Functions, Blobs, DB, environment variables) directly inside the framework's own dev server, so no `netlify dev` wrapper is needed — run the framework's normal dev command (e.g. `npm run dev`) once the plugin is registered in `vite.config.ts`.
-
-- Vite-based projects (React SPA, SvelteKit, Remix): `@netlify/vite-plugin` — see [references/vite.md](references/vite.md)
-- TanStack Start: `@netlify/vite-plugin-tanstack-start` — see [references/tanstack.md](references/tanstack.md)
-
-The per-framework reference guides may also document other local dev options (e.g. `netlify dev`) — check the guide for your framework for setup specifics.
-
-### Running a single command with the Netlify environment loaded
-
-```bash
-netlify dev:exec <cmd>
-```
-
-Loads the Netlify environment (env vars, etc.) for a single command without starting a dev server — useful for scripts, tests, or one-off tasks that need Netlify-managed environment variables.
-
-## General Patterns
-
-### Client-Side Routing (SPA)
-
-For single-page apps with client-side routing, add a catch-all redirect:
-
+Netlify build variables can't be used as values in the UI or `netlify.toml` env sections. Set them inline before the build command:
 ```toml
-# netlify.toml
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+[build]
+  command = "REACT_APP_CONTEXT=$CONTEXT npm run build"
 ```
 
-> **Remove this catch-all when you adopt an SSR adapter.** A `/* → /index.html` rule left over from an SPA setup will shadow your server routes: user-defined redirects in `netlify.toml`/`_redirects` take precedence over the routes a framework adapter generates, so every request — including SSR pages and API/function routes — is served the static `index.html` with a 200. When you migrate a client-rendered app to SSR, delete the SPA catch-all.
+## SPA redirects and the SSR catch-all footgun
 
-### Custom 404 Pages
+SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.html` for `pushState`:
+```
+/* /index.html 200
+```
 
-- **Static sites**: Create a `404.html` in your publish directory. Netlify serves it automatically for unmatched routes.
-- **SSR frameworks**: Handle 404s in the framework's routing (the adapter maps this to Netlify's function routing).
+**Remove any SPA catch-all when adopting an SSR adapter.** A leftover `/* → /index.html 200` silently serves static `index.html` for SSR pages and API routes — user redirects beat adapter-generated routes.
 
-### Environment Variables in Frameworks
+## Local dev with platform emulation (no Netlify CLI)
 
-Each framework exposes environment variables to client-side code differently:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
 
-| Framework | Client prefix | Access pattern |
-|---|---|---|
-| Vite / React | `VITE_` | `import.meta.env.VITE_VAR` |
-| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_VAR` |
-| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_VAR` |
-| Nuxt | `NUXT_PUBLIC_` | `useRuntimeConfig().public.var` |
+| Framework | Plugin/module | Run |
+|-----------|---------------|-----|
+| Astro (5.12+) | built-in (Netlify Vite plugin auto-loaded) | `astro dev` |
+| Nuxt | `@netlify/nuxt` | `nuxt dev` |
+| React Router | `@netlify/vite-plugin` | `react-router dev` |
+| SolidStart 2 | `@netlify/vite-plugin` | `vite dev` |
+| TanStack Start | `@netlify/vite-plugin-tanstack-start` | (vite) |
+| Vite | `@netlify/vite-plugin` | `npx vite` |
 
-In server-side code, prefer `Netlify.env.get("VAR")` to read environment variables. `process.env.VAR` also works inside Netlify Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps server code working in both.
+Still need `netlify dev` (Netlify CLI) for: Gatsby generated functions (run `netlify build` first), Angular SSR local test (`netlify serve`), and frameworks without a Vite plugin.
 
-**Never use a client prefix (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) for secrets.** Client-prefixed variables are inlined into the client bundle and exposed to the browser.
+**`netlify dev` gotcha:** with both a custom `command` and a `targetPort` in `[dev]`, you must set `framework = "#custom"` — otherwise the detector runs and your custom command is silently ignored.
 
-### Environment Variable Changes Require a Redeploy
+## Build settings by framework
 
-Client-prefixed vars (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`) are **inlined into the client bundle at build time** — their values are compiled into the JavaScript shipped to the browser. Editing one in the Netlify UI or CLI has no effect on the live site until a new build runs. The same applies server-side: Netlify injects environment variables at build time, so changing a value in the dashboard does **not** propagate to already-deployed functions on the next request. Any env var change — client- or server-side — requires a redeploy to take effect. If a value looks stale after you changed it, trigger a new deploy.
+| Framework | Build command | Publish |
+|-----------|---------------|---------|
+| Angular (standard) | `ng build --prod` | `dist/YOUR_PROJECT_NAME` |
+| Astro | `astro build` | `dist` |
+| Create React App | `react-scripts build` | `build` |
+| Eleventy | `eleventy` | `_site` |
+| Gatsby | `gatsby build` | `public` |
+| Hugo | `hugo` | `public` |
+| Hydrogen | `remix vite:build` | `dist/client` |
+| Next.js (SSR/hybrid) | `next build` | `.next` |
+| Next.js (static export) | `next build && next export` | `out` (`NETLIFY_NEXT_PLUGIN_SKIP=true`) |
+| Nuxt 3 | `nuxt build` | `dist` |
+| Nuxt 2 | `nuxt generate` | `dist` |
+| React Router | `react-router build` | `build/client` |
+| Remix (Vite) | `remix vite:build` | `build/client` |
+| SolidStart 2 (Vite plugin) | `vite build` | `dist/client` |
+| SolidStart 2 (Nitro) | `vite build` | `dist` |
+| SolidStart 1.x | `vinxi build` | `dist` |
+| SvelteKit | `vite build` | `build` |
+| TanStack Start (1.132.0+) | `vite build` | `dist/client` |
+| Vite | `vite build` | `dist` |
+| Vue CLI | `vue-cli-service build` | `dist` |
 
-### Runtime File Reads in Adapter-Generated Functions
+Detection suggests these; override in `netlify.toml` or UI (project configuration > Build & deploy > Continuous deployment > Build settings).
 
-When an adapter turns your server code into a Netlify Function, only traced module dependencies are bundled. Arbitrary files you read from disk at runtime — a local JSON/Markdown data file, an email template, an `fs.readFile()` target — are **not** uploaded with the function unless you declare them. Such a read succeeds under `npm run dev` (the whole project is on disk) but throws `ENOENT` in production. Declare the files so they ship with the function: in Next.js set `outputFileTracingIncludes` in `next.config`; for a hand-written Netlify Function use `included_files` in its `config`. Never assume the project filesystem is present at function runtime.
+## SSR / adapter setup
+
+### Astro
+`npx astro add netlify` installs the adapter and edits `astro.config.mjs`. Adapter needed for SSR and out-of-the-box Image CDN for `<Image />`. SSR → Netlify Functions; middleware → Edge Functions. Adapter-less deploy only if no server features and no Image CDN need. Skew protection from 5.15.0.
+
+### Next.js (13.5+ only)
+Zero-config via the OpenNext adapter (`@netlify/plugin-nextjs`). Do NOT pin the version — Netlify auto-updates each build. Treat the legacy adapter as read-only history, never a recommendation.
+Adapter provisions: serverless function for SSR/ISR/PPR/route handlers/Server Actions; Edge Function for Middleware; Full Route + Data Cache; Image CDN with `next/image`.
+Skew protection is opt-in: set `NETLIFY_NEXT_SKEW_PROTECTION=true`, redeploy. No automatic support for client `fetch` — direct calls with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`. Details in `references/nextjs.md`.
+
+### SvelteKit
+```bash
+npm install -D @sveltejs/adapter-netlify
+```
+```js
+import adapter from '@sveltejs/adapter-netlify';
+export default { kit: { adapter: adapter() } };
+```
+Replace `@sveltejs/adapter-auto` with the specific import. SSR routes → a `render` function.
+- `split: true` → one function per route. **Incompatible with Edge Functions** (`edge: false` or omit).
+- `edge: true` → SSR in a Deno edge function; can't combine with `split`.
+- **Redirects NOT supported in `netlify.toml`** — use `_redirects`.
+- Edge functions don't work locally with `netlify dev` for SvelteKit.
+
+### React Router (7+)
+New: `npx create-react-router@latest --template netlify/react-router-template`. Existing:
+```bash
+npm install @netlify/vite-plugin-react-router
+```
+Add `netlifyReactRouter()` to Vite plugins. Default target = Serverless Functions.
+**Edge (Deno):** needs plugin v2.1.1+, set `edge: true`, and you **must** create `app/entry.server.tsx`:
+```typescript
+export { default } from 'virtual:netlify-server-entry'
+```
+Exclude your own function paths: `netlifyReactRouter({ edge: true, excludedPaths: ['/api/*'] })`.
+**Moving back to Serverless:** remove `edge: true` AND delete `app/entry.server.tsx`.
+Middleware (React Router v7.9.0+, plugin v2.0.0+): opt in via `future.v8_middleware`; import `netlifyRouterContext` from `@netlify/vite-plugin-react-router/serverless` (or `/edge` when `edge: true`); access `context.get(netlifyRouterContext)`.
+
+### Remix
+New: `npx create-remix@latest --template netlify/remix-template` (CLI prompts functions vs Edge Functions). Manual (Remix Vite required):
+```bash
+npm install --save-dev @netlify/remix-adapter
+```
+Add `netlifyPlugin()` from `@netlify/remix-adapter/plugin` to Vite plugins.
+
+### Nuxt
+SSR via Nitro, automatic on Nuxt 3. Local parity via `@netlify/nuxt` (`npx nuxi module add @netlify/nuxt`).
+- SSR on Edge Functions requires a different Nitro deployment preset (not auto-detected).
+- pnpm + Nuxt 3: set `PNPM_FLAGS=--shamefully-hoist`.
+- `nuxt/image` auto-uses Netlify Image CDN; set remote domains in `nuxt.config.ts`.
+
+### SolidStart
+SolidStart 2 builds on Vite — **no SolidStart-specific adapter**. Install `@netlify/vite-plugin`:
+```ts
+import netlify from "@netlify/vite-plugin";
+import { solidStart } from "@solidjs/start/config";
+import { defineConfig } from "vite";
+export default defineConfig({
+  plugins: [solidStart(), netlify({ build: { enabled: true } })],
+});
+```
+Publish `dist/client`. SSR routes, server functions, middleware → Netlify Functions, zero extra config.
+**Nitro alternative:** add `nitro()`, use plain `netlify()` (no `build.enabled`), publish `dist`.
+SolidStart 1: Nitro auto-configures; optionally set `preset: "netlify"` in `app.config.ts`; `vinxi build` / `dist`.
+
+### TanStack Start
+React (and Solid.js) full-stack; SSR/Server Routes/Server Functions/middleware → serverless functions.
+```bash
+npm install -D @netlify/vite-plugin-tanstack-start
+```
+Add `netlify()` to Vite plugins alongside `tanstackStart()`; `vite build` / `dist/client` (1.132.0+). Netlify CLI deploys require netlify-cli 17.31+. Older versions: see `references/tanstack.md`.
+
+### Gatsby
+- **5.12.0+ (adapter):** auto-detects and installs `gatsby-adapter-netlify` (zero-config). Generates functions `SSR`, `DSG`. No Essential Gatsby plugin needed.
+- **5.11.0 or earlier (Essential Gatsby plugin):** auto-installs `@netlify/plugin-gatsby`; also manually install `gatsby-plugin-netlify` (required for SSR, Gatsby redirects, asset caching). Generates `__api`, `__ssr`, `__dsg`, `__ipx`. Skip via `NETLIFY_SKIP_GATSBY_FUNCTIONS` (all) / `NETLIFY_SKIP_API_FUNCTION` / `NETLIFY_SKIP_SSR_FUNCTION` / `NETLIFY_SKIP_DSG_FUNCTION`.
+- Gatsby 5 requires Node 18.
+- Large sites: set `GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE` to load datastore from CDN (avoids max function deploy size; slower first SSR/DSG load).
+- Image CDN: set `NETLIFY_IMAGE_CDN=true` (Contentful/Drupal/WordPress source plugins). **Not supported on 5.12.x with adapter — upgrade to 5.13.0+.**
+- `StaticImage` and `gatsby-transformer-sharp` don't work for SSR/DSG — host images on a CDN.
+
+### Angular
+SSR auto-configured via an Edge Function. Suggested dev: `ng serve` / `4200`.
+- **SSR pages are NOT subject to `_redirects` or `netlify.toml` redirects** — SSR uses Edge Functions that run before redirects. Use Angular's built-in redirects.
+- Access `Request`/`Context` in SSR via `netlify.request` / `netlify.context` providers (from `@netlify/edge-functions`); unavailable client-side or during prerendering. Test locally with `netlify serve`.
+- `NgOptimizedImage` auto-uses Image CDN; set `remote_images` (array of regex) under `[images]` in `netlify.toml`.
+
+### Express
+Node 18.14.0+. Deploy as a Netlify Function via `serverless-http`:
+```bash
+npm i express serverless-http @netlify/functions @types/express
+```
+```ts
+// netlify/functions/api.ts
+import express, { Router } from "express";
+import serverless from "serverless-http";
+const api = express();
+const router = Router();
+router.get("/hello", (req, res) => res.send("Hello World!"));
+api.use("/api/", router);
+export const handler = serverless(api);
+```
+```toml
+[functions]
+  external_node_modules = ["express"]
+  node_bundler = "esbuild"
+[[redirects]]
+  force = true
+  from = "/api/*"
+  status = 200
+  to = "/.netlify/functions/api/:splat"
+```
+No frontend: set a placeholder build command (e.g. `echo Building Functions`). All Function limits apply; not recommended as background/scheduled functions.
+
+### Hydrogen
+Shopify stack on React Router 7. **SSR only on Netlify Edge Functions — Netlify Functions NOT officially supported.** Node 24+. Use the starter:
+```bash
+npm create @shopify/hydrogen@latest -- --template https://github.com/netlify/hydrogen-template
+cp .env.example .env && npm run dev
+```
+
+## Static-site gotchas
+
+### Hugo
+Set `HUGO_VERSION` (any release after 0.19) in `[build.environment]` — a missing/mismatched version causes `exit code: 255`. Install themes as **git submodules** (`git submodule add ...`), not `git clone`.
+
+### Eleventy
+`eleventy` / `_site`. **Build plugins require editing `.gitignore`: change `node_modules` to `**/node_modules/**`** — otherwise Netlify plugins and Eleventy collide on `.netlify/plugins/node_modules/` and the build errors.
+
+## Vite meta-framework support matrix
+Astro (auto on 5.12+), Nuxt (via `@netlify/nuxt`), TanStack Start (via `@netlify/vite-plugin-tanstack-start`), React Router, SolidStart — all **full**. SvelteKit — **experimental**.
+
+## Deploy via CLI (Express, Nuxt, React, Vite)
+```sh
+npm install netlify-cli -g
+netlify init
+```
+Follow prompts to create/link the site and set build settings.
+
+<!-- Node version floors (18.14.0+) are stated per-framework where documented; no cross-framework build-image default is given in sources. -->
+
+<!-- system: agent-context/frameworks/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (frameworks)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Per-framework deep guides live in this skill: `references/astro.md`,
+   `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`,
+   `references/tanstack.md`, `references/vite.md` — route framework-specific
+   work there before improvising.
+2. Next.js: modern runtime (v5, Next ≥13.5) only — treat the legacy adapter
+   as read-only history, never a recommendation.
+3. Remove any SPA catch-all (`/* → /index.html 200`) when adopting an SSR
+   adapter — user redirects beat adapter-generated routes, so a leftover
+   catch-all silently serves static `index.html` for SSR pages and API routes.
+4. Any env var change — client- or server-side — requires a redeploy. Values
+   are injected at build time; editing one in the UI/CLI does not reach the
+   live site or already-deployed functions until a new build runs.
+5. `netlify dev` with both a custom `command` and a `targetPort` requires
+   `framework = "#custom"` in the `[dev]` block — otherwise the detector runs
+   and the custom command is silently ignored.
+6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
+   `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
+   client-prefixed vars are inlined into the browser bundle.

--- a/agent-plugin/skills/netlify-functions/SKILL.md
+++ b/agent-plugin/skills/netlify-functions/SKILL.md
@@ -1,286 +1,348 @@
 ---
 name: netlify-functions
-description: Guide for writing Netlify serverless functions. Use when creating API endpoints, background processing, scheduled tasks, or any server-side logic using Netlify Functions. Covers modern syntax (default export + Config), TypeScript, path routing, background functions, scheduled functions, streaming, and method routing.
+description: Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API endpoint or backend route, adding a contact form handler, wiring auth or Identity signup/login hooks, building streaming or AI-proxy responses, scheduling cron jobs, running long background jobs (batch processing/scraping), reacting to deploy or form events, setting up rate limiting or region/memory config, or reading environment variables and secrets inside a function. Covers file locations, the Request/Context/Response handler shape, path routing, config options, and local testing with netlify dev.
 ---
 
 # Netlify Functions
 
-## Modern Syntax
+Reach for the modern default-handler API (`.mts` TypeScript). Export a default async handler taking a web `Request` and a Netlify `Context`, returning a web `Response`. Avoid the legacy AWS Lambda handler shape unless writing Go or migrating old code (see Legacy at the end).
 
-Always use the modern default export + Config pattern. Never use the legacy `exports.handler` or named `handler` export.
+## File locations
 
-```typescript
-import type { Context, Config } from "@netlify/functions";
+- Default directory: `netlify/functions/` (relative to base directory). Keep it **outside** your publish directory or source files ship as static assets.
+- A function is one file or a subdirectory whose entry file is named `index` or matches the subdirectory name. All of these create a function `hello`:
+  - `netlify/functions/hello.mts`
+  - `netlify/functions/hello/hello.mts`
+  - `netlify/functions/hello/index.mts`
+- Use `.mts` (TS) / `.mjs` (JS) for ES modules. `.cts`/`.cjs` force CommonJS; `.ts`/`.js` follow the nearest `package.json` `"type"`.
+
+## Minimal function
+
+No `config` export. Serves at `/.netlify/functions/hello`.
+
+```ts title="netlify/functions/hello.mts"
+import type { Context } from "@netlify/functions"
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello, world!");
-};
-
-export const config: Config = {
-  path: "/api/hello",
-};
+  return new Response("Hello, world!")
+}
 ```
 
-The handler receives a standard Web API `Request` and returns a `Response`. The second argument is a Netlify `Context` object.
+Install types: `npm install @netlify/functions` (required for TS types; optional for JS).
 
-The bare default export shown above is the recommended form. The default export can also be an object with a `fetch` method — prefer this form only if (1) other functions in the project already use it, or (2) the function also subscribes to platform events (see [Event Handlers](#event-handlers) below), since events are exposed as named handlers on the same object:
+Read env vars and secrets with `Netlify.env.get()`:
 
-```typescript
+```ts
+const apiKey = Netlify.env.get("STRIPE_SECRET_KEY")
+```
+
+Never hardcode secrets. For the variable to exist at runtime its scope must include **Functions**. Variables set in `netlify.toml` are NOT available to functions. Values are frozen per deploy — change them and redeploy to apply.
+
+**Response headers are set in code** on the returned `Response`. `[[headers]]` in `netlify.toml`, `_headers`, and redirect header rules apply ONLY to static CDN responses, not function responses. Do not add CORS headers unless explicitly requested.
+
+## Custom path routing
+
+Set `config.path` to route to custom URLs. When set, the function serves ONLY at that path — not at `/.netlify/functions/<name>`.
+
+```ts title="netlify/functions/travel.mts"
+import type { Config, Context } from "@netlify/functions"
+
+export default async (req: Request, context: Context) => {
+  const { city, country } = context.params
+  return new Response(`You're visiting ${city} in ${country}!`)
+}
+
+export const config: Config = {
+  path: "/travel-guide/:city/:country",
+}
+```
+
+- Multiple paths: `path: ["/cats", "/dogs"]`.
+- Patterns: `path` supports [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) syntax — `path: ["/sale/*", "/item/:sku"]`. Named groups land on `context.params`. For the query string use `req.url`.
+- `excludedPath`: carve exceptions, e.g. `excludedPath: ["/product/*.css"]` with `path: "/product/*"`.
+- `preferStatic: true`: let a real static file at the URL win.
+- `method`: restrict methods, e.g. `method: ["GET", "POST"]`.
+
+## Fetchable module shape (alternative)
+
+Equivalent to the bare handler; carries `config` inline and lets you add event handlers.
+
+```ts
+import type { NetlifyFunction } from "@netlify/functions"
+
 export default {
-  fetch(req: Request, context: Context) {
-    return new Response("Hello, world!");
-  },
-};
+  fetch: (req, context) => new Response("Hello, world!"),
+  config: { path: "/hello" },
+} satisfies NetlifyFunction
 ```
 
-## File Structure
+## Context object
 
-Place functions in `netlify/functions/`:
+Second handler argument (or `getContext()` from `@netlify/functions` when out of handler scope — throws outside a request; wrap in try/catch).
 
-```
-netlify/functions/
-  _shared/           # Non-function shared code (underscore prefix)
-    auth.ts
-    db.ts
-  items.ts           # -> /.netlify/functions/items (or custom path via config)
-  users/index.ts     # -> /.netlify/functions/users
-```
+- `context.params` — named path params.
+- `context.geo` — `city`, `country.code/name`, `latitude`, `longitude`, `subdivision`, `timezone`, `postalCode`.
+- `context.ip` — client IP string.
+- `context.cookies` — `get(name)` / `set(options)` / `delete(name|options)`. Cross-subdomain cookies need a custom domain (`netlify.app` is on the Public Suffix List).
+- `context.site` — `id`, `name`, `url`. `context.deploy` — `context`, `id`, `published`, `skewProtectionToken`. `context.account.id`. `context.server.region`. `context.requestId`.
+- `context.waitUntil(promise)` — run work after the response is sent (analytics, logs) without blocking. Billing/log duration counts until the promise settles. Available for functions deployed on/after 2025-03-20.
 
-Use `.ts` or `.mts` extensions. If both `.ts` and `.js` exist with the same name, the `.js` file takes precedence.
+⚠️ Under `netlify dev`, `context.geo` and `context.ip` are **mocked** — placeholder values that never change. Don't conclude geo code is broken locally. Exercise branches with `netlify dev --geo=mock --country=DE` and verify on a real deploy.
 
-## Path Routing
+## Config object
 
-Define custom paths via the `config` export:
+Export `const config` (or the `config` property of a Fetchable module):
 
-```typescript
-export const config: Config = {
-  path: "/api/items",                    // Static path
-  // path: "/api/items/:id",            // Path parameter
-  // path: ["/api/items", "/api/items/:id"], // Multiple paths
-  // excludedPath: "/api/items/special", // Excluded paths
-  // preferStatic: true,                // Don't override static files
-};
-```
+- `path` / `excludedPath` — `string | string[]`, must start with `/`.
+- `method` — one method or array.
+- `preferStatic` — `boolean`.
+- `background` — `boolean` (see Background).
+- `schedule` — cron string (see Scheduled). Mutually exclusive with `path`/`excludedPath`.
+- `rateLimit` — `{ action: 'rate_limit'|'rewrite', aggregateBy: 'domain'|'ip'|[...], to?, windowSize, windowLimit }`.
+- `memory` / `vcpu` — see below; mutually exclusive.
+- `region` — airport code; see below.
 
-Without a `path` config, functions are available at `/.netlify/functions/{name}`. Setting a `path` makes the function available **only** at that path.
+## Integrations
 
-Access path parameters via `context.params`:
+```ts title="netlify/functions/users.mts"
+import type { Config } from "@netlify/functions"
+import { getDatabase } from "@netlify/database"
 
-```typescript
-// config: { path: "/api/items/:id" }
-export default async (req: Request, context: Context) => {
-  const { id } = context.params;
-  // ...
-};
-```
+const db = getDatabase()
 
-## Method Routing
-
-```typescript
-export default async (req: Request, context: Context) => {
-  switch (req.method) {
-    case "GET":    return handleGet(context.params.id);
-    case "POST":   return handlePost(await req.json());
-    case "DELETE": return handleDelete(context.params.id);
-    default:       return new Response("Method not allowed", { status: 405 });
-  }
-};
-
-export const config: Config = {
-  path: "/api/items/:id",
-  method: ["GET", "POST", "DELETE"],
-};
-```
-
-## Background Functions
-
-For long-running tasks (up to 15 minutes). The client receives an immediate `202` response; return values are ignored.
-
-Enable background mode by setting `background: true` in config:
-
-```typescript
 export default async (req: Request) => {
-  await someLongRunningTask();
-};
+  const users = await db.sql`SELECT id, email FROM users LIMIT 10`
+  return Response.json({ users })
+}
+
+export const config: Config = { path: "/users" }
+```
+
+Blobs: `import { getStore } from "@netlify/blobs"`; `getStore("uploads").set(key, await req.blob())`.
+
+`purgeCache()` from `@netlify/functions` invalidates the edge cache from inside a function:
+
+```ts
+import { purgeCache } from "@netlify/functions"
+
+export default async () => {
+  await purgeCache({ tags: ["products"] }) // omit tags to purge all
+  return new Response("Purged!", { status: 202 })
+}
+```
+
+## Streaming responses
+
+Return a `ReadableStream` as the `Response` body. Limits: **60s execution, 20 MB response**.
+
+```ts
+export default async (req: Request) => {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${Netlify.env.get("OPENAI_API_KEY")}`,
+    },
+    body: JSON.stringify({ model: "gpt-4o-mini", stream: true, messages: [/* ... */] }),
+  })
+  return new Response(res.body, { headers: { "content-type": "text/event-stream" } })
+}
+```
+
+To build a stream manually, `new ReadableStream({ start(controller) { controller.enqueue(...); controller.close() } })`.
+
+## Background functions (long-running)
+
+`config.background: true`. Client gets an immediate `202`; the return value is discarded; runs up to **15 minutes**. No streaming. Retries: on invocation error, retry after 1 min, then again 2 min later. Send results somewhere other than the client.
+
+```ts title="netlify/functions/process.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  // Long-running work. Client already has its 202.
+}
+
+export const config: Config = { background: true, path: "/process" }
+```
+
+Limits: background payload **256 KB**. Legacy `-background` filename suffix still works but prefer `config.background`.
+
+## Scheduled functions (cron)
+
+`config.schedule` with a cron expression, executed in **UTC**. The request body is JSON with `next_run` (ISO-8601). Inline config is TS/JS only — Go must use `netlify.toml`.
+
+Always compute the UTC time for the target local hour. E.g. 9 AM ET → `"0 13 * * *"` UTC (note this shifts by an hour across DST; pick the UTC offset you need). Prefer explicit cron over `@daily`/`@hourly` shortcuts, which can't target a specific local hour.
+
+```ts title="netlify/functions/daily-digest.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  const { next_run } = await req.json()
+  console.log("Next invocation at:", next_run)
+}
 
 export const config: Config = {
-  path: "/process",
-  background: true,
-};
+  schedule: "0 13 * * *", // 9 AM ET (EST); UTC
+}
 ```
 
-Store results externally (Netlify Blobs, database) for later retrieval.
+Via `netlify.toml` (all languages):
 
-The legacy filename convention (`process-background.ts`) is still supported, but new functions should use `config.background`.
-
-## Region
-
-Functions deploy to `cmh` (Ohio) by default for new sites. This is a deliberate choice: US East is centrally located for an international audience, has a broad provider ecosystem, and gives most projects the lowest overall latency without any configuration. Sites created before October 4, 2023 may have a different default region — check Project configuration > Build & deploy > Continuous deployment > Functions region to confirm.
-
-Do NOT override `config.region` unless the user has stated a specific reason — for example, a database or backend service in another region with measurable roundtrip savings, a data-residency requirement, or an audience concentrated in one region whose compute dependencies (database, backend services) also live in that region.
-
-Two constraints to be aware of before adding `config.region`:
-
-- A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
-- For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
-
-Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
-
-## Memory or vCPU
-
-Functions run with 1024 MB of memory and a proportional amount of compute by default. The default fits most workloads, and raising it has a direct cost impact: function billing scales linearly with the configured size.
-
-Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them when:
-
-- The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
-- The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
-
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
-
-## Scheduled Functions
-
-Run on a cron schedule (UTC timezone):
-
-```typescript
-export default async (req: Request) => {
-  const { next_run } = await req.json();
-  console.log("Next invocation at:", next_run);
-};
-
-export const config: Config = {
-  schedule: "@hourly", // or cron: "0 * * * *"
-};
+```toml
+[functions."daily-digest"]
+  schedule = "0 13 * * *"
 ```
 
-Shortcuts: `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`. Scheduled functions have a **30-second timeout** and only run on published deploys.
+Constraints: **30s limit** (use background for longer); only fire on **published deploys** (not Deploy Previews/branch deploys — invoke manually with **Run now**); no URL invocation; no streaming; no request payloads/POST data; incompatible with Split Testing. All extensions supported **except** `@reboot` and `@annually`.
 
-**Testing and triggering.** A scheduled function does **not** fire on its cron schedule under `netlify dev` — the local dev server never runs the schedule, so waiting for the clock will appear to do nothing. Test it by invoking it directly: `netlify functions:invoke <name>` calls the function once, on demand. In production a scheduled function also has **no public HTTP URL** — it is not reachable at `/.netlify/functions/{name}` and cannot be triggered by an external HTTP request; it runs only on its schedule. If you also need to trigger the same work over HTTP (a manual "run now" or a webhook), expose that logic through a separate ordinary HTTP function and share the implementation rather than trying to POST to the scheduled function.
+## Platform-event functions
 
-## Streaming Responses
+Export a default object with handlers named after events. They always run in the background — no response to a client. Combine with `fetch` in the same function. Every handler is fully typed; import event types from `@netlify/functions`.
 
-Return a `ReadableStream` body for streamed responses (up to 20 MB):
-
-```typescript
-export default async (req: Request) => {
-  const stream = new ReadableStream({ /* ... */ });
-  return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream" },
-  });
-};
-```
-
-## Event Handlers
-
-A function can subscribe to platform events by exporting an object instead of a function as its default. Each event has a named handler property:
-
-```typescript
-import type { DeploySucceededEvent, UserSignupEvent } from "@netlify/functions";
+```ts title="netlify/functions/on-deploy.mts"
+import type { DeploySucceededEvent, DeployFailedEvent } from "@netlify/functions"
 
 export default {
   deploySucceeded(event: DeploySucceededEvent) {
-    console.log(`Deploy ${event.deploy.id} succeeded`);
+    console.log(`Deploy ${event.deploy.id} succeeded for ${event.site.name}`)
   },
-
-  userSignup(event: UserSignupEvent) {
-    return {
-      user: {
-        ...event.user,
-        appMetadata: { ...event.user.appMetadata, roles: ["member"] },
-      },
-    };
+  deployFailed(event: DeployFailedEvent) {
+    console.log(`Deploy ${event.deploy.id} failed: ${event.deploy.errorMessage}`)
   },
-};
+}
 ```
 
-A single function can declare multiple handlers; multiple functions can also subscribe to the same event.
+**Deploy events** (`event.deploy`, `event.site`; return `void`): `deployBuilding`, `deploySucceeded`, `deployFailed`, `deployDeleted`, `deployLocked`, `deployUnlocked`.
 
-**Available handlers:**
+**Identity events** (`event.user`, only `id` guaranteed):
 
-| Handler | Trigger |
-|---|---|
-| `fetch` | HTTP request (equivalent to a bare function default export) |
-| `deployBuilding` / `deploySucceeded` / `deployFailed` / `deployDeleted` / `deployLocked` / `deployUnlocked` | Deploy lifecycle |
-| `userSignup` / `userLogin` / `userValidate` / `userModified` / `userDeleted` | Identity lifecycle |
-| `formSubmitted` | Form submission verified |
+| Handler | Can deny? | Can mutate? |
+|---|---|---|
+| `userValidate` | Yes | Yes |
+| `userSignup` | Yes | Yes |
+| `userLogin` | Yes | Yes |
+| `userModified` | Yes | Yes |
+| `userDeleted` | No | No |
 
-### Identity handlers: deny an action
+- Deny: call `event.deny()` inside the handler → end user gets `401`. First function to deny aborts the chain.
+- Mutate: return `{ user: {...} }` to persist changes; return `undefined` to pass through.
 
-`userSignup`, `userLogin`, `userValidate`, and `userModified` can reject the action by calling `event.deny()`. The end user receives a 401; no observability error is produced (unlike throwing).
+**Form events**: `formSubmitted` → `event.data` (object keyed by field name). Return `void`.
 
-```typescript
-export default {
-  userLogin(event: UserLoginEvent) {
-    if (!event.user.email?.endsWith("@example.com")) {
-      return event.deny();
-    }
-  },
-};
+Multiple functions can handle the same event (all run). Netlify signs each event (JWS) and verifies before invoking, blocking external requests. Legacy filename convention (file named after the event, payload via `await req.json()` → `payload`) still works but prefer typed handlers.
+
+## Region
+
+⚠️ Do NOT override `config.region` unless the user states a specific reason (co-located DB/backend, data residency, regional audience). The default `cmh` (US East, Ohio) is deliberate.
+
+When justified — e.g. an EU-resident database:
+
+```ts
+export const config: Config = { path: "/eu-data", region: "dub" }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain.
+Airport codes (self-serve): `cmh`, `dub`, `fra`, `gru`, `iad`, `lhr`, `nrt`, `pdx`, `sfo`, `sin`, `syd`, `yul`. Support-assisted: `cdg`, `mxp`. Each function runs in exactly one region (no multi-region geo-routing). Region selection needs Pro/Enterprise. Framework-adapter-generated functions can't take `export const config` — set region at project level in the UI. After changing region, **redeploy**. Function-level region beats the site-level UI setting.
 
-## Context Object
+## Memory / vCPU
 
-| Property | Description |
-|---|---|
-| `context.params` | Path parameters from config |
-| `context.geo` | `{ city, country: {code, name}, latitude, longitude, subdivision, timezone, postalCode }` |
-| `context.ip` | Client IP address |
-| `context.cookies` | `.get()`, `.set()`, `.delete()` |
-| `context.deploy` | `{ context, id, published }` |
-| `context.site` | `{ id, name, url }` |
-| `context.account.id` | Team account ID |
-| `context.requestId` | Unique request ID |
-| `context.waitUntil(promise)` | Extend execution after response is sent |
+⚠️ Do NOT set `config.memory` or `config.vcpu` speculatively — billing scales linearly with size. Raise them only for known memory/compute-intensive work (AI inference, image/PDF, large JSON/CSV) or observed OOM/timeouts caused by the function's own work.
 
-**`context.geo` and `context.ip` are mocked under `netlify dev`.** Locally these return placeholder values, not your real location or client IP, so a value that looks "stuck" on a default country does not mean your geo code is broken — real geolocation is populated only for deployed functions. To exercise geo branching locally, start dev with the geo flags: `netlify dev --geo=mock --country=DE` forces mock data (`--geo=mock`) and sets the mock country (`--country`). Don't conclude `context.geo` is broken because local values never change.
+When justified (e.g. observed OOM processing large PDFs):
 
-## Environment Variables
-
-Prefer `Netlify.env.get` inside functions:
-
-```typescript
-const apiKey = Netlify.env.get("API_KEY");
+```ts
+export const config: Config = { path: "/heavy", memory: "2gb" } // or memory: 2048
 ```
 
-`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
+- `memory`: 1024–4096 MB. `vcpu`: 0.5–2.0 (0.5 → 1024 MB, 2.0 → 4096 MB). Mutually exclusive; Netlify sizes the other automatically. Needs Credit-based Pro/Enterprise. Via `netlify.toml`: `[functions.heavy]\n  memory = "2gb"`.
 
-**Environment variables have a small total size budget.** Functions run on AWS Lambda, which caps the *combined* size of all environment variables at roughly 4 KB. A single large value — a service-account JSON credential, a PEM private key, a big config blob — can blow past that on its own and break the deploy or the function at runtime. Do not store large payloads in environment variables; keep only small secrets and config (API keys, connection strings) there and move anything large into a bundled file, Netlify Blobs, or a fetch at runtime. There is no Netlify setting that raises this cap.
+## Bundling & files on disk
 
-## Reading Files at Runtime
-
-Only a function's own code and the modules it `import`s are bundled and deployed. A file the function opens from disk at runtime — `fs.readFile`/`readFileSync` on a template, a JSON data file, a WASM binary, a fixture — is **not** part of the bundle unless you declare it. This is a classic "works locally, ENOENT in production" trap: under `netlify dev` the function reads the file straight from your working tree, but the deployed function only contains what was bundled.
-
-Declare runtime-read files with `included_files` in `netlify.toml` so they ship with the function:
+⚠️ Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM) are **not bundled**: works under `netlify dev`, ENOENT in production. Prefer importing static data as a module. Otherwise declare it in `netlify.toml`:
 
 ```toml
 [functions]
-  included_files = ["netlify/functions/templates/**"]
-
-# or scope it to one function:
-[functions."render-email"]
-  included_files = ["netlify/functions/templates/welcome.html"]
+  included_files = ["files/*.md"]
+  external_node_modules = ["package-1"]
 ```
 
-When the data is static, prefer importing it as a module (`import data from "./data.json"`) so bundling is automatic; reach for `included_files` for files you must read from the filesystem at runtime.
+⚠️ The combined env-var limit is **~4 KB** for ALL functions (they run on AWS Lambda) — no Netlify setting raises it. Keep large payloads (service-account JSON, PEM keys) out of env vars; use a bundled file, Blobs, or a runtime fetch.
 
-## Resource Limits
+JS-only esbuild: `[functions]\n  node_bundler = "esbuild"`.
 
-| Resource | Limit |
-|---|---|
-| Synchronous timeout | 60 seconds |
-| Background timeout | 15 minutes |
-| Scheduled timeout | 30 seconds |
-| Memory | 1024 MB default; configurable 1024–4096 MB (see [Memory or vCPU](#memory-or-vcpu)) |
-| Buffered payload | 6 MB |
-| Streamed payload | 20 MB |
+## Limits (not configurable)
 
-## Framework Considerations
+- Synchronous execution: **60s**. Scheduled: **30s**. Background: **15 min**.
+- Buffered request/response payload: **6 MB** (binary is Base64-encoded, ~30% overhead → effective **4.5 MB** binary limit).
+- Streamed response: **20 MB**. Background payload: **256 KB**.
 
-Frameworks with server-side capabilities (Astro, Next.js, Nuxt, SvelteKit, TanStack Start) typically generate their own serverless functions via adapters. You usually do not write raw Netlify Functions in these projects — the framework adapter handles server-side rendering and API routes. Write Netlify Functions directly when:
+## Local testing & deploy
 
-- Using a client-side-only framework (Vite + React SPA, vanilla JS)
-- Adding background or scheduled tasks to any project
-- Building standalone API endpoints outside the framework's routing
+- Most frameworks emulate functions in their dev server. Vite frameworks (Astro, Nuxt, TanStack Start, React Router): install `@netlify/vite-plugin` and run the dev server. Next.js and anything else: use the [Netlify CLI](https://docs.netlify.com/api-and-cli-guides/cli-guides/local-development/) (`netlify dev`).
+- Scheduled functions don't fire on a schedule locally — invoke once with `netlify functions:invoke <name>`.
+- Deploy: push to Git for continuous deployment, or use the Netlify CLI/API.
+- Logs & metrics live in the Netlify UI; stream with the CLI.
 
-See the **netlify-frameworks** skill for adapter setup.
+## Node runtime version
+
+Runtime follows the build's Node.js version (fallback: Node.js 24). Override by setting env var `AWS_LAMBDA_JS_RUNTIME` (e.g. `nodejs24.x`) via UI/CLI/API — **not** `netlify.toml` — then redeploy. ES modules: `__dirname`/`__filename` unavailable, use `import.meta.url`; named imports of CommonJS packages fail, use a default import.
+
+## Legacy / Go (avoid unless needed)
+
+Go must use the [Lambda-compatible API](https://docs.netlify.com/build/functions/lambda-compatibility/?fn-language=go); Go routing/region/memory are set in `netlify.toml`. For migrating Lambda-style JS/TS, `@netlify/aws-lambda-compat` wraps an AWS handler:
+
+```ts
+import { withLambda } from "@netlify/aws-lambda-compat"
+import type { HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/aws-lambda-compat"
+
+export default withLambda(async (event: HandlerEvent, context: HandlerContext): Promise<HandlerResponse> => {
+  const name = event.queryStringParameters?.name ?? "World"
+  return { statusCode: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ name }) }
+})
+```
+
+Lambda-compat mode enforces the 4 KB env-var limit; [upgrade to modern functions](https://developers.netlify.com/guides/migrating-to-the-modern-netlify-functions/) to remove it.
+
+<!-- system: agent-context/functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (functions)
+
+These are org conventions, not docs facts — they are merged into the rendered
+skill by ctx-gen and are never generated. Extracted from the previous
+hand-written netlify-functions skill; owned by the skills maintainer.
+
+1. Use TypeScript (`.mts`) when possible.
+2. Access environment variables via `Netlify.env.get()` (prefer it over
+   `process.env` for consistency).
+3. Never add CORS headers unless explicitly requested.
+4. Store secrets in environment variables, never in code.
+5. `context.geo` and `context.ip` are mocked under `netlify dev` — placeholder
+   values, not the real location or client IP. Don't conclude geo code is
+   broken because local values never change; exercise branches with
+   `netlify dev --geo=mock --country=DE` and verify on a deploy.
+6. Do NOT set `config.memory` or `config.vcpu` speculatively. Raise them only
+   for known memory/compute-intensive work or observed OOM/timeouts caused by
+   the function's own work — billing scales linearly with size.
+7. Do NOT override `config.region` unless the user has stated a specific
+   reason (co-located database/backend, data residency, regional audience).
+   The `cmh` default is a deliberate choice.
+8. Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM)
+   are not bundled: works under `netlify dev`, ENOENT in production. Prefer
+   importing static data as a module; otherwise declare the file with a
+   scoped `included_files` entry in `netlify.toml`.
+9. The ~4 KB combined environment-variable limit applies to ALL functions
+   (they run on AWS Lambda), not just Lambda-compat mode. Keep large payloads
+   (service-account JSON, PEM keys) out of env vars — use a bundled file,
+   Blobs, or a runtime fetch. No Netlify setting raises this cap.
+10. The body's FIRST function example must be the minimal default: no
+    `config` export at all, stating the function serves at
+    `/.netlify/functions/<name>`. Custom `path` routing appears only in a
+    later example — agents imitate the first example they see.
+11. Never demonstrate `memory`, `vcpu`, or `region` in a generic example —
+    show them only attached to an explicit stated reason (observed OOM,
+    co-located backend, data residency).
+12. Scheduled-function examples use a real cron expression with the UTC
+    conversion spelled out (e.g. 9 AM ET → `"0 13 * * *"` UTC, noting DST) —
+    never only `@hourly`/`@daily` shortcuts, which can't target a specific
+    local hour.
+13. The body must state that `[[headers]]` in netlify.toml, `_headers`, and
+    redirect header rules apply ONLY to static CDN responses — response
+    headers for a function are set in code on the returned `Response`.

--- a/agent-plugin/skills/netlify-identity/SKILL.md
+++ b/agent-plugin/skills/netlify-identity/SKILL.md
@@ -1,464 +1,293 @@
 ---
 name: netlify-identity
-description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity` for new projects; `netlify-identity-widget` and `gotrue-js` still work but are no longer recommended.
+description: Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social login (Google/GitHub/GitLab/Bitbucket), server-side user verification in Functions, role-based access control (RBAC), admin user management, and Identity event hooks. Use when adding a login/signup flow, "add social login", gating content by user role, protecting a function or page behind auth, assigning roles at signup, customizing auth emails, or handling OAuth/confirmation/recovery callbacks. Not for locking an entire site to a company/team — that is netlify-access-control.
 ---
 
 # Netlify Identity
 
-Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+Auth and user management for a Netlify site without requiring visitors to be Netlify users. Package: `@netlify/identity`.
 
-**Always use `@netlify/identity` for new projects.** `netlify-identity-widget` and `gotrue-js` still work and are maintained, but are no longer the recommended choice. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+**Reach for `@netlify/identity`.** Do NOT use the legacy `netlify-identity-widget` or `gotrue-js` for new work — same capabilities, simpler API, built-in server-side support.
 
-## Identity is app-level — don't confuse it with site access control
+## Footguns — read first
 
-Netlify Identity manages **your app's end users** (signups, logins, roles) and issues the `nf_jwt` cookie. It is a different layer from **Secure Access / Password Protection**, which gates *who can load the site at all* (Basic shared-password is Pro+; team-login/SAML gating is Enterprise), and from **Team/Org SAML SSO**, which controls *who can log in to the Netlify dashboard*. The same provider can appear in more than one (Google, say): Google as an Identity OAuth provider signs in *app users*; Google as a SAML IdP signs in *Netlify team members*. They are unrelated systems with separate sessions, which is where the confusion comes from.
-
-If the task involves "lock this site to my company," "only employees can access it," password protection, or SSO at the site/team level, **read the `netlify-access-control` skill first** to pick the right layer. This skill covers the app-level user-management layer only.
-
-## Dashboard configuration (user handoff required)
-
-**All Identity instance configuration is dashboard-only — there is no public API.** The agent owns the code, deploys, and the handoff checklist; the user owns flipping dashboard settings. Outside of a Netlify Agent Runner deploy, the Identity instance must be enabled in the dashboard before any auth flow will work. If you write Identity code first and only discover this when `/.netlify/identity/signup` 404s after a production deploy, that's wasted work — surface the dashboard handoff up front instead.
-
-**Dashboard URL pattern:** `https://app.netlify.com/projects/<project-slug>/configuration/identity` (it's under project configuration — not under Integrations, and not a top-level sidebar item).
-
-### Dashboard-only operations
-
-- **Enable Identity** — turns the Identity instance on for the site. **Required** before any auth flow works.
-- **Registration mode** — Open (anyone can sign up, the default) or Invite only.
-- **Autoconfirm** — ON skips the email-confirmation step on signup; OFF requires the new user to click a confirmation email before they can log in.
-- **External providers** — Add Google / GitHub / GitLab / Bitbucket. The "Use Netlify's app" option means no `client_id`/`secret` needed — good for prototypes. Adding an OAuth provider does NOT disable email/password — email/password is always available unless the front-end omits it.
-- **Custom email templates / SMTP** — advanced; out of scope for typical prototypes.
-
-There is no CLI command and no public API for any of these. **Do not** curl `https://api.netlify.com/...` to flip toggles, **do not** read auth tokens out of `~/Library/Preferences/netlify/config.json`, and **do not** probe for an undocumented endpoint. Give the user the dashboard URL and exact checklist instead.
-
-### Agent/user sequence
-
-1. Agent asks any missing auth-shape questions before scaffolding.
-2. Agent writes the Identity code and runs a draft deploy.
-3. User enables Identity and any OAuth providers in the dashboard using the handoff checklist.
-4. Agent verifies the draft URL and then runs the production deploy.
-
-### Recommended settings per use case
-
-| Use case | Registration | Autoconfirm | External providers |
-|---|---|---|---|
-| Prototype / demo | Open | ON | as requested |
-| Production with email signup | Open or Invite per product | OFF (real email confirmation) | configured with custom email templates / SMTP as needed |
-
-### Handoff checklist
-
-When the dashboard work is needed, give the user a copy-pasteable checklist **between the draft deploy and the production deploy** — not after the prod deploy fails:
-
-```
-Before this works end-to-end, flip these in the Netlify dashboard at
-https://app.netlify.com/projects/<your-slug>/configuration/identity:
-
-- [ ] Identity → Enable
-- [ ] Registration → Open (default) or Invite only
-- [ ] Autoconfirm → ON for prototypes; OFF for prod with email confirmation
-- [ ] External providers → Add Google (etc.) with "Use Netlify's app"
-
-Tell me when these are flipped and I'll run the production deploy.
-```
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any auth code — the answers shape both the dashboard config above and the auth UI you'll write:
-
-- Should the whole site be locked so only your company/team can even load it (a perimeter), should it be public with per-user accounts inside the app, or both? This decides whether Netlify Identity alone is enough or you also need site-level access control — if "company-only" or "both" comes up, check the `netlify-access-control` skill before scaffolding.
-- Which sign-in methods should this app expose: email/password, OAuth, or both?
-- Which parts of the app need authenticated access: the whole app, specific routes, or only specific actions?
-- Who can create accounts: public signup or invite-only?
-- Should new email/password users be able to log in immediately for a prototype (Autoconfirm ON), or confirm by email first for production (Autoconfirm OFF)?
-- Which OAuth providers should be enabled (Google, GitHub, GitLab, Bitbucket)?
-
-**If you don't have preferences here, tell me what you want overall and I'll pick sensible defaults** — typically email/password + Google OAuth, autoconfirm ON, registration Open for a prototype.
-
-Asking these *after* coding causes rework — both the auth UI shape and the dashboard config fall out of these answers.
-
-## When something fails, surface and stop
-
-If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
-
-## Never hardcode secrets
-
-Never hardcode secrets. Identity URLs, GoTrue endpoints, and OAuth `client_id`/`secret` values do not belong in client or server code — configure OAuth credentials in the Netlify dashboard, not the frontend, and store anything sensitive as a Netlify environment variable (mark it secret). The Identity **admin token** is not one of these: you don't set or read it — the Netlify Functions runtime injects it automatically for `admin.*` calls made inside a Function (see [Authorization and sessions](references/authorization-and-sessions.md)). Never hardcode an admin token or expose admin operations to the browser.
+- **Identity does not work under `netlify dev`.** Test auth flows on a deploy — Deploy Previews work. Local `netlify dev` cannot exercise `/.netlify/identity/*`.
+- **Never build a from-scratch third-party OAuth flow beside Identity** — no provider app registration in code, no `client_id`/`secret` in code, no custom callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`. Raw OAuth beside Identity is the single most common source of rework.
+- **Identity config has no public API — dashboard only.** Never curl `api.netlify.com` to flip/inspect Identity settings, never read tokens from `~/Library/Preferences/netlify/config.json`, never probe undocumented endpoints.
+- **RBAC redirects without a fallback = raw 404.** A visitor lacking the role gets a bare 404 with no way to log in. Always add a fallback rule.
+- **Server-side `login()`/`signup()`/`logout()` need CSRF protection.** Call `verifyRequestOrigin(req)` first, or an attacker can log a victim into the attacker's account.
+- **Site-gating** ("lock this site to my company", employees-only) → route to **netlify-access-control** first. Identity is the app-level user layer only.
+- **On failure** (callback 404s, `/.netlify/identity/*` unreachable, OAuth doesn't return): surface the error, the dashboard URL, and the setting to check — then stop. Do not invent recovery commands.
 
 ## Setup
+
+Identity must be enabled in the dashboard first (no API): **Project configuration > Identity** (`https://app.netlify.com/projects/{site_name}/configuration/identity`) → **Enable Identity**.
 
 ```bash
 npm install @netlify/identity
 ```
 
-The Identity instance must be enabled in the dashboard first (see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above). The one exception: a deploy created by a Netlify Agent Runner session that includes Identity code auto-enables the instance.
+HTTPS is required. On a custom domain, get HTTPS/SSL working before integrating Identity.
 
-### Local Development
+## Client / universal auth
 
-Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+```ts
+import { signup, login, logout, getUser, oauthLogin, handleAuthCallback } from '@netlify/identity'
 
-## Quick Start
+// Sign up — sends a confirmation email by default (skippable via autoconfirm setting)
+const user = await signup('jane@example.com', 'securepassword', { full_name: 'Jane Doe' })
 
-Log in from the browser:
+// Log in / log out
+await login('jane@example.com', 'securepassword')
+await logout()
 
-```typescript
-import { login, getUser } from '@netlify/identity'
+// Current user — null if not logged in (works in browser + server)
+const u = await getUser()
+if (u) console.log(u.email)
 
-const user = await login('user@example.com', '<password>')
-console.log(`Hello, ${user.name}`)
-
-// Later, check auth state
-const currentUser = await getUser()
+// OAuth — redirects browser to provider login
+oauthLogin('github') // 'google' | 'github' | 'gitlab' | 'bitbucket'
 ```
 
-Protect a Netlify Function:
+**Callback handling is mandatory.** Call `handleAuthCallback()` on your landing page. It processes ALL token types in the URL hash — OAuth redirect, email confirmation, password recovery, invite. Without it, confirmation links and OAuth redirects never complete.
 
-```typescript
-// netlify/functions/protected.mts
+```ts
+import { handleAuthCallback } from '@netlify/identity'
+
+const result = await handleAuthCallback()
+if (result) console.log(result.type, result.user.email) // may be falsy if nothing to process
+```
+
+Other client functions:
+- `recoverPassword()` — complete a password reset (alternative to letting `handleAuthCallback()` handle the `recovery_token`).
+- `acceptInvite()` — complete invite acceptance (alternative to `handleAuthCallback()` handling `invite_token`).
+- `refreshSession()` — refresh token/session so newly-assigned roles take effect.
+
+**Don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns.
+
+## Server-side (Functions / Edge Functions)
+
+Handlers are modern v2 functions: `export default async (req, context) => {}`. **v1 `export { handler }` is not supported** for `getUser()`/`login()`/`admin.*`.
+
+```ts
 import { getUser } from '@netlify/identity'
-import type { Context } from '@netlify/functions'
+import type { Context } from '@netlify/functions'      // or '@netlify/edge-functions' for Edge
 
 export default async (req: Request, context: Context) => {
   const user = await getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
+  if (!user.roles.includes('admin')) return new Response('Forbidden', { status: 403 })
   return Response.json({ id: user.id, email: user.email })
 }
 ```
 
-`getUser()` reads the request's `nf_jwt` cookie automatically — no argument is needed in a function or edge function. Server-side auth (`getUser`, `login`, `admin.*`) requires a **modern v2 function** (`export default`); v1 Lambda-compatible functions (`export { handler }`) are not supported.
+`getUser()` works in browser, Netlify Functions, and Edge Functions.
 
-## Core API
+**CSRF — always guard exposed `login`/`signup`/`logout` endpoints:**
 
-Import and use headless functions directly:
+```ts title="netlify/functions/login.ts"
+import { login, verifyRequestOrigin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-```typescript
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  signup,
-  oauthLogin,
-  onAuthChange,
-  getSettings,
-} from '@netlify/identity'
-```
-
-### Login
-
-```typescript
-import { login, AuthError } from '@netlify/identity'
-
-async function handleLogin(email: string, password: string) {
-  try {
-    const user = await login(email, password)
-    showSuccess(`Welcome back, ${user.name ?? user.email}`)
-  } catch (error) {
-    if (error instanceof AuthError) {
-      // Bad credentials → GoTrue returns 400 (invalid_grant) server-side; in the
-      // browser the status is undefined, so fall back to the message there.
-      showError(error.status === 400 ? 'Invalid email or password.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  verifyRequestOrigin(req)   // throws 403 on Origin mismatch; supports { allowedOrigins }
+  const { email, password } = await req.json()
+  await login(email, password)
+  return new Response(null, { status: 302, headers: { Location: '/dashboard' } })
 }
 ```
 
-### Signup
+### admin — Netlify Functions ONLY
 
-After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+`admin.*` uses a short-lived admin token and runs **only in Netlify Functions** — NOT browser, NOT Edge Functions.
 
-```typescript
-import { signup, AuthError } from '@netlify/identity'
+```ts
+import { admin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-async function handleSignup(email: string, password: string, name: string) {
-  try {
-    const user = await signup(email, password, { full_name: name })
-    if (user.emailVerified) {
-      // Autoconfirm ON — user is logged in immediately
-      showSuccess('Account created. You are now logged in.')
-    } else {
-      // Autoconfirm OFF — confirmation email sent
-      showSuccess('Check your email to confirm your account.')
-    }
-  } catch (error) {
-    if (error instanceof AuthError) {
-      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  const users = await admin.listUsers()   // array of users
+  return Response.json({ total: users.length })
 }
 ```
 
-### Logout
+- `admin.listUsers()` — array of users.
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
 
-```typescript
-import { logout } from '@netlify/identity'
+### Session cookies
+JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.
 
-await logout()
-```
+### The `User` object
+`id`, `email`, `roles` (array from `app_metadata.roles`, included in the JWT).
 
-### OAuth
+## Identity event functions
 
-**When Netlify Identity is the goal, never build a from-scratch third-party OAuth flow.** Don't tell the user to go register their own Google/GitHub OAuth app, don't ask for a `client_id`/`secret`, and don't write your own `/auth/callback` token-exchange handler. Identity already brokers the OAuth handshake: the provider is enabled in the dashboard with the **"Use Netlify's app"** option (no credentials needed — see the handoff checklist above), and your code just calls `oauthLogin(provider)` + `handleAuthCallback()`. Scaffolding raw OAuth alongside Identity is the single most common source of rework in this flow — it produces two competing auth systems that then have to be untangled by hand. Custom OAuth credentials exist only to *brand* the consent screen, and even then they're pasted into the dashboard, not wired into app code.
+Functions the platform invokes automatically on Identity events (you don't call them).
 
-OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+**Modern typed-handler syntax** — export a default object with a method per event. Typed handlers require `@netlify/functions` ≥ 5.2.0.
 
-```typescript
-import { oauthLogin } from '@netlify/identity'
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
-// Step 1: Redirect to provider (navigates away — never returns)
-function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
-  oauthLogin(provider)
+export default {
+  userSignup(event: UserSignupEvent) {
+    console.log(`New signup: ${event.user.email}`)
+  },
 }
 ```
 
-Providers must be enabled in the dashboard before `oauthLogin()` works — see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above. Registration is Open by default, so OAuth users can create accounts without any extra signup-related configuration; only the provider itself must be enabled.
+Handlers and triggers:
 
-Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, omit the email/password form from your UI; the front-end is the gate.
-
-### Handling Callbacks
-
-Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
-
-```typescript
-import { handleAuthCallback, AuthError } from '@netlify/identity'
-
-async function processCallback() {
-  try {
-    const result = await handleAuthCallback()
-    if (!result) return // No callback hash — normal page load
-
-    switch (result.type) {
-      case 'oauth':
-        showSuccess(`Logged in as ${result.user?.email}`)
-        break
-      case 'confirmation':
-        showSuccess('Email confirmed. You are now logged in.')
-        break
-      case 'recovery':
-        // User is authenticated but must set a new password
-        showPasswordResetForm(result.user)
-        break
-      case 'invite':
-        // User must set a password to accept the invite
-        showInviteAcceptForm(result.token)
-        break
-      case 'email_change':
-        showSuccess('Email address updated.')
-        break
-    }
-  } catch (error) {
-    if (error instanceof AuthError) showError(error.message)
-  }
-}
-```
-
-### Auth State
-
-```typescript
-import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
-
-// Check current user (never throws — returns null if not authenticated)
-const user = await getUser()
-
-// Subscribe to auth state changes (returns unsubscribe function)
-const unsubscribe = onAuthChange((event, user) => {
-  switch (event) {
-    case AUTH_EVENTS.LOGIN:
-      console.log('Logged in:', user?.email)
-      break
-    case AUTH_EVENTS.LOGOUT:
-      console.log('Logged out')
-      break
-    case AUTH_EVENTS.TOKEN_REFRESH:
-      break
-    case AUTH_EVENTS.USER_UPDATED:
-      console.log('Profile updated:', user?.email)
-      break
-    case AUTH_EVENTS.RECOVERY:
-      console.log('Password recovery initiated')
-      break
-  }
-})
-```
-
-### Settings-Driven UI
-
-You cannot see a project's live Identity configuration while you are writing the code — there is no API, MCP tool, or CLI command that reports whether Identity is enabled or which providers are on; that state lives in the dashboard. So **don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns, so the UI matches whatever the user actually enabled — and a provider you assumed was on but isn't won't render a dead button. (`getSettings()` hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev`, which proxies to the live service — but it can't tell you anything pre-run, so ask the user what's configured while you're still scaffolding.)
-
-```typescript
-import { getSettings } from '@netlify/identity'
-
-const settings = await getSettings()
-// settings.autoconfirm — boolean
-// settings.disableSignup — boolean
-// settings.providers — Record<AuthProvider, boolean>
-
-if (!settings.disableSignup) showSignupForm()
-
-for (const [provider, enabled] of Object.entries(settings.providers)) {
-  if (enabled) showOAuthButton(provider)
-}
-```
-
-## Minimal React Example
-
-```tsx
-import { useEffect, useState } from 'react'
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  oauthLogin,
-  onAuthChange,
-} from '@netlify/identity'
-
-function App() {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    ;(async () => {
-      await handleAuthCallback()
-      setUser(await getUser())
-      setLoading(false)
-    })()
-    return onAuthChange((_event, currentUser) => setUser(currentUser))
-  }, [])
-
-  const handleLogin = async (email, password) => {
-    const currentUser = await login(email, password)
-    setUser(currentUser)
-  }
-
-  const handleGoogleLogin = () => oauthLogin('google')
-
-  const handleSignOut = async () => {
-    await logout()
-    setUser(null)
-  }
-
-  if (loading) return <p>Loading...</p>
-  // Render login form or user details based on `user` state
-}
-```
-
-## Error Handling
-
-`@netlify/identity` throws two error classes:
-
-- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
-- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
-
-`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
-
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid login credentials — wrong email/password (GoTrue `invalid_grant`) |
-| 401 | Missing, invalid, or expired bearer token on an authenticated endpoint |
-| 403 | Action not allowed (e.g., signups disabled) |
-| 422 | Validation error (e.g., weak password, malformed email) |
-| 404 | User or resource not found |
-
-Note: in the browser, `login()` surfaces gotrue-js failures as an `AuthError` with `status` **undefined** (the HTTP status isn't propagated), so don't branch on `status` for bad-credentials UX there — fall back to `error.message`. Server-side (`login()` in a Function) passes the real status through, so `400` is reliable.
-
-## Identity Event Functions
-
-Functions can subscribe to Identity lifecycle events by exporting an object whose properties are named event handlers. See the **netlify-functions** skill for the full event-handler pattern.
-
-The typed handler API below (the `userSignup`/`userValidate`/… object export, the typed `*Event` types, and `event.deny()`) requires **`@netlify/functions` ≥ 5.2.0** — it isn't present in 5.1.x. On older installs, use the legacy filename convention described at the end of this section.
-
-**Available identity handlers:**
-
-| Handler | Trigger |
+| Handler | Fires when |
 |---|---|
-| `userValidate` | User attempts to sign up. Can deny. |
-| `userSignup` | User completes signup. Can deny or mutate. |
-| `userLogin` | User logs in. Can deny or mutate. |
-| `userModified` | User profile is updated. Can deny or mutate. |
-| `userDeleted` | User is deleted. Notification only. |
+| `userValidate` | User attempts signup, before account creation — block by email domain, rate-limit, custom validation. |
+| `userSignup` | Signup completes (email or external). Fires *after* email confirmation if confirmation is enabled. Assign roles, sync, notify. |
+| `userLogin` | User logs in — track logins, sync, block a user. |
+| `userModified` | Profile updated. |
+| `userDeleted` | User deleted (notification only). |
 
-Each handler receives a typed event with a parsed `user` object (camelCase fields: `appMetadata`, `userMetadata`, `confirmedAt`, etc.).
+**Deny an action:** call `event.deny()` from `userValidate`/`userSignup`/`userLogin`/`userModified` (NOT `userDeleted`). User gets a `401`; no observability error. With multiple subscribers, the first `event.deny()` aborts the chain.
 
-### Mutate the user
+```typescript title="netlify/functions/identity.mts"
+import type { UserValidateEvent } from "@netlify/functions"
 
-Return `{ user: ... }` to substitute the user record before it's persisted. This is the common pattern for role assignment at signup.
+export default {
+  userValidate(event: UserValidateEvent) {
+    if (!event.user.email?.endsWith("@example.com")) return event.deny()
+  },
+}
+```
 
-```typescript
-// netlify/functions/identity.mts
-import type { UserSignupEvent } from '@netlify/functions'
+**Assign roles at signup** — return `{ user: {...} }` to mutate the persisted record. Payload fields are **camelCase** (`appMetadata`, `userMetadata`, `confirmedAt`).
+
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
 export default {
   userSignup(event: UserSignupEvent) {
     return {
-      user: {
-        ...event.user,
-        appMetadata: {
-          ...event.user.appMetadata,
-          roles: ['member'],
-        },
-      },
+      user: { ...event.user, appMetadata: { ...event.user.appMetadata, roles: ["member"] } },
     }
   },
 }
 ```
 
-### Deny an action
+**Background mode** — action completes immediately, handler runs async:
 
-Call `event.deny()` to reject a signup, login, validation, or modification. The end user receives a 401. Do not throw — `event.deny()` is the canonical denial mechanism and does not produce an error in observability.
+```typescript title="netlify/functions/identity.mts"
+import type { Config, UserLoginEvent } from "@netlify/functions"
 
-```typescript
-import type { UserValidateEvent } from '@netlify/functions'
-
-export default {
-  userValidate(event: UserValidateEvent) {
-    if (!event.user.email?.endsWith('@example.com')) {
-      return event.deny()
-    }
-  },
-}
+export default { userLogin(event: UserLoginEvent) { /* async tracking */ } }
+export const config: Config = { background: true }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain — subsequent functions are not invoked.
+Event types from `@netlify/functions`: `UserValidateEvent`, `UserSignupEvent`, `UserLoginEvent`, `UserModifiedEvent`, `UserDeletedEvent`, `Config`.
 
-### Legacy filename convention
+## Registration & providers (dashboard)
 
-The previous syntax — files named `identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, exporting `handler` and signaling denial via non-2xx response — still works. New functions should prefer the typed handler syntax above.
+- **Registration preferences** — **Open** (default: any visitor signs up via `signup()`) or **Invite only** (all new users, including external-provider logins, must be invited first).
+- **Confirmation:** open registration sends a confirmation email; skip via **Emails > Confirmation template > Configure** (allow signup without verifying email / autoconfirm).
+- **External providers** — enable Google/GitHub/GitLab/Bitbucket under **Registration > External providers**. Set your own client ID/secret for branded OAuth (your app name shows on the provider screen). No email confirmation for external-provider signup, but Invite-only still requires an invite.
+- **Invitations** — **Project configuration > Identity > Users**; Netlify team users with any role can invite. Invite link carries an `invite_token` → process with `handleAuthCallback()` or `acceptInvite()`.
 
-## Roles and Authorization
+## Roles & metadata
 
-### First Admin User
+Stored on the User object; edit in **Identity > Users > Edit settings**:
+- **Name** — user-editable: `user_metadata.full_name`.
+- **Email** — user-editable; triggers email-change confirmation; changes login credentials: `user_metadata.email`.
+- **Roles** — NOT user-editable: `app_metadata.roles`. Read via `getUser()`.
 
-The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
+Set roles: at signup via `userSignup` handler returning `{ user: {...} }`; for existing users via `admin.updateUser()` in a Function. **Role changes take effect on next login or token refresh**, not immediately (they don't invalidate the current JWT — client can `refreshSession()`).
 
-1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
-2. Click **Invite users** and enter the admin user's email address
-3. After the user accepts the invite, click the user in the Identity list to open their detail page
-4. In the **Roles** field, add the `admin` role and save
+## Role-based access control (redirect rules)
 
-Once the first admin exists, subsequent users can be managed programmatically using Identity event functions (e.g., assigning roles in `identity-signup`) or role-based redirects.
+Enforced at the CDN edge (no origin round trip). Add a `Role` parameter to redirect rules.
 
-- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
-- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+```
+# _redirects — ALWAYS include a fallback or non-admins get a raw 404
+/admin/*  /admin/:splat  200!  Role=admin
+/admin/*  /login         401!
 
-### Role-Based Redirects
+# multiple roles, comma-chained
+/private/* /private/:splat  200!  Role=editor,admin
+```
 
 ```toml
 # netlify.toml
 [[redirects]]
   from = "/admin/*"
   to = "/admin/:splat"
+  force = true
   status = 200
-  conditions = { Role = ["admin"] }
-
-[[redirects]]
-  from = "/admin/*"
-  to = "/"
-  status = 302
+  conditions = {Role = ["editor", "admin"]}
 ```
 
-Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+Netlify Identity roles resolve at `app_metadata.roles`.
 
-## References
+### External JWT provider (Enterprise; alternative to Identity)
+You may use Identity **OR** an external JWT provider, **not both** — you cannot authenticate third-party JWT tokens while Identity is enabled. Set the secret at **Project configuration > Access & security > Visitor access > JWT secret** (project-level overrides team-level default).
 
-- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration
-- [Authorization and sessions](references/authorization-and-sessions.md) — where role gating is actually enforced (server-side vs client-side / SPA navigation), admin operations being Functions-runtime-only, and why a role change doesn't apply until the JWT refreshes
+- Tokens must be **HS256**; header requires `"alg": "HS256"`, `"typ": "JWT"`.
+- Payload requires `exp` (future Unix Epoch); other fields optional.
+- External-provider roles resolve at `app_metadata.authorization.roles`. Different path → contact support for a custom role path (support-configured, not self-service).
+
+## Emails (Pro+ for customization)
+
+Default sender `no-reply@netlify.com`. Custom sender (Pro+): set SMTP hostname/port/username/password under **Emails > Outgoing email address** (use SendGrid/Mailjet/etc. for volume).
+
+Custom templates (Pro+): publish HTML to a path on your deployed project, set the path (relative to domain, starting `/`) under **Emails**. Rules: inline CSS only, absolute image links, NO `<html>`/`<head>`/`<body>` tags. Keep template variables intact — don't let your build rewrite them.
+
+Go template variables: `{{ .Email }}`, `{{ .NewEmail }}` (email-change only), `{{ .SiteURL }}`, `{{ .ConfirmationURL }}`, `{{ .Token }}`. Custom link form: `{{ .SiteURL }}/path/#confirmation_token={{ .Token }}` (also `invite_token`, `recovery_token`, `email_change_token`).
+
+## Audit log (Pro+)
+
+**Project configuration > Identity > Identity audit log**. Search with a required scope prefix: `author:[string]` or `action:[string]`. Action names: `login`, `logout`, `user_signedup`, `user_deleted`, `user_modified`, `token_revoked`, `token_refreshed`, `user_recovery_requested`, `user_invited`.
+
+## Plan gating
+
+- Identity itself: all credit-based plans, no extra cost. Unlimited active + invite-only users, custom OAuth credentials, Functions integration — all plans.
+- **Pro+ only:** custom outgoing email, custom email templates, Identity audit log.
+- **Enterprise only:** external JWT providers.
+
+## Deep guides
+
+- `references/advanced-patterns.md` — SSR / session hydration.
+- `references/authorization-and-sessions.md`.
+
+## Legacy (avoid for new work)
+
+- `netlify-identity-widget` / `gotrue-js` — superseded by `@netlify/identity`.
+- Legacy event-function filenames (`identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, `-background` suffix) still work but prefer typed handlers. Legacy denial = return non-2xx status; new code uses `event.deny()`.
+
+<!-- getSettings() referenced in house rules but not documented in sources; its return shape/signature is not specified in the intermediate. -->
+
+<!-- system: agent-context/identity/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (identity)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Deep guides live in this skill: `references/advanced-patterns.md`
+   (SSR/session hydration) and `references/authorization-and-sessions.md`.
+2. Identity does not work under `netlify dev` — test auth flows on deploys
+   (Deploy Previews work).
+3. Identity configuration has no public API — it is dashboard-only. Never curl
+   `api.netlify.com` to flip or inspect Identity settings, never read auth
+   tokens from `~/Library/Preferences/netlify/config.json`, never probe for
+   undocumented endpoints.
+4. On failure (callback 404s, `/.netlify/identity/*` unreachable, OAuth flow
+   doesn't return), surface the error, the dashboard URL, and the setting to
+   check — then stop. Do not invent recovery commands.
+5. Never build a from-scratch third-party OAuth flow when Identity is in play —
+   no provider app registration, no `client_id`/`secret` in code, no custom
+   callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`;
+   raw OAuth beside Identity is the single most common source of rework.
+6. Server-side `getUser()`/`login()`/`admin.*` require modern v2 functions
+   (`export default`) — v1 `export { handler }` is not supported. Typed
+   Identity event handlers (`UserSignupEvent`, `event.deny()`) require
+   `@netlify/functions` ≥ 5.2.0; older installs use the legacy filenames.
+7. Don't hard-code which auth providers exist — call `getSettings()` at
+   startup and render the signup form and OAuth buttons from what it returns.
+8. Site-gating requests ("lock this site to my company", employees-only)
+   route to the netlify-access-control skill first — Identity is the
+   app-level user layer only.

--- a/agent-plugin/skills/netlify-image-cdn/SKILL.md
+++ b/agent-plugin/skills/netlify-image-cdn/SKILL.md
@@ -1,99 +1,157 @@
 ---
 name: netlify-image-cdn
-description: Guide for using Netlify Image CDN for image optimization and transformation. Use when serving optimized images, creating responsive image markup, setting up user-uploaded image pipelines, or configuring image transformations. Covers the /.netlify/images endpoint, query parameters, remote image allowlisting, clean URL rewrites, and composing uploads with Functions + Blobs.
+description: Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use when adding responsive images, generating thumbnails, converting formats (avif/webp/png), cropping to aspect ratios, tuning image quality, creating blurred placeholders, allowlisting remote image domains, serving user-uploaded images, or wiring framework image components (Next.js, Astro, Nuxt, Angular, Gatsby) to Netlify. Triggers on tasks like "optimize images", "add image thumbnails", "resize images on the fly", "serve images from an external domain", or "add blur placeholders".
 ---
 
 # Netlify Image CDN
 
-Every Netlify site has a built-in `/.netlify/images` endpoint for on-the-fly image transformation. No configuration required for local images.
+Transform images by requesting `/.netlify/images` with query parameters. No function or file authoring required — it's a built-in edge endpoint.
 
-## Basic Usage
-
-```html
-<img src="/.netlify/images?url=/photo.jpg&w=800&h=600&fit=cover&q=80" />
+```bash
+# resize + crop to a 50px square, retain left side, convert to webp at q=80
+curl -vs 'https://mysitename.netlify.app/.netlify/images?url=/owl.jpeg&fit=cover&w=50&h=50&position=left&fm=webp&q=80'
 ```
 
-## Query Parameters
+There is no legacy/deprecated form — the endpoint above is the only programmatic surface. Use framework image components where available (below) rather than hand-building URLs.
 
-| Param | Description | Values |
+## Endpoint & query parameters
+
+`GET /.netlify/images?url=<source>&...`
+
+| Param | Values | Notes |
 |---|---|---|
-| `url` | Source image path (required) | Relative path or absolute URL |
-| `w` | Width in pixels | Any positive integer |
-| `h` | Height in pixels | Any positive integer |
-| `fit` | Resize behavior | `contain` (default), `cover`, `fill` |
-| `position` | Crop alignment (with `cover`) | `center` (default), `top`, `bottom`, `left`, `right` |
-| `fm` | Output format | `avif`, `webp`, `jpg`, `png`, `gif`, `blurhash` |
-| `q` | Quality (lossy formats) | 1-100 (default: 75) |
+| `url` | relative path or full remote URL | **REQUIRED**. Only required param. |
+| `w` | integer px | width |
+| `h` | integer px | height |
+| `fit` | `contain` (default), `cover`, `fill` | resize behavior |
+| `position` | `center` (default), `top`, `bottom`, `left`, `right` | only applies when `fit=cover` |
+| `fm` | `avif`, `jpg`, `png`, `webp`, `gif`, `blurhash` | output format; `webp`/`gif` can be animated |
+| `q` | integer `1`–`100` (default `75`) | only for `avif`, `jpg`, `gif`, `webp` |
 
-When `fm` is omitted, Netlify auto-negotiates the best format based on browser support (preferring `webp`, then `avif`).
+### `fit` behavior
 
-### `fm=blurhash` returns a string, not an image
+| `fit=` | aspect ratio kept | crops excess | returns exact dimensions |
+|---|---|---|---|
+| `contain` | yes | no | no — one dimension may be smaller |
+| `cover` | no | yes | yes — scaled proportionally, then cropped |
+| `fill` | no | no | yes — stretched/squished if needed |
 
-`fm=blurhash` is special: the response body is a short BlurHash **text string**, not image bytes. Pointing an `<img src>` (or CSS `background-image`) straight at a `/.netlify/images?...&fm=blurhash` URL does not work — the browser receives text and has nothing to render. Use it as a placeholder workflow instead: obtain the blurhash string ahead of time (server-side, in a data loader, via a `fetch`, or at build time), decode it with a BlurHash decoder library into a rendered placeholder (a canvas or a data-URI), and show that while the real image loads. The real, displayable image is a **separate** `/.netlify/images` request **without** `fm=blurhash`.
+- **`fit=cover` requires BOTH `w` and `h`.** Supplying only one silently misbehaves.
+- `contain` with one dimension calculates the other to preserve aspect ratio.
 
-## Remote Image Allowlisting
+### Format & content negotiation
 
-External images must be explicitly allowed in `netlify.toml`:
+- Source-only request (just `url`, no size/format): image is unchanged in size/shape but **still reformatted** to `avif`/`webp` based on the browser's `Accept` header.
+- No `fm` specified → `webp` if accepted, else `avif` if accepted, else original.
+- `fm=blurhash` returns a BlurHash **text string, not image bytes.** Pointing `<img src>` or a CSS background at it renders nothing. Fetch the string server-side/ahead of time, decode it client-side with a BlurHash library (https://blurha.sh), then load the real image as a separate request without `fm=blurhash`.
+
+### Response codes
+
+- Invalid transformation param values → `404`.
+- Valid, new transformation → `200` with content + `content-type`.
+- Previously transformed → `304`.
+
+## Remote source images
+
+Remote `url` values require allowlisting the domain in `netlify.toml`:
 
 ```toml
 [images]
-remote_images = ["https://example\\.com/.*", "https://cdn\\.images\\.com/.*"]
+  remote_images = ["https://my-images.com/.*", "https://animals.more-images.com/[bcr]at/.*"]
 ```
 
-Values are regex patterns.
+Then percent-encode the remote URL and request it:
 
-A remote source URL that does **not** match any `remote_images` pattern is rejected with a **404** — Netlify does not fetch or proxy it. This is a strict allowlist, not a fallback: there is no automatic proxying of arbitrary external hosts. Add the host (as an escaped regex) to `remote_images` *before* referencing it through `/.netlify/images`, or every transform request for that source will 404. (Local images on the same site never need allowlisting.)
-
-When referencing an allow-listed remote image, **percent-encode the source URL** before placing it in the `url` parameter:
-
-```html
-<!-- source: https://cdn.example.com/marketing/banner.jpg -->
-<img src="/.netlify/images?url=https%3A%2F%2Fcdn.example.com%2Fmarketing%2Fbanner.jpg&w=800&fm=webp&q=80" />
+```js
+const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/owl.jpeg")}`;
 ```
 
-Percent-encode the source value (e.g. with `encodeURIComponent`) whenever it contains characters that would otherwise be read as Image CDN params — `?`, `&`, `=`, `#`, or whitespace. This applies to remote URLs and relative paths alike (a filename or user-generated key can contain them too, e.g. `url=/uploads/a%26b.jpg`). Basic paths without those characters don't need encoding.
+- **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
+- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
-## Clean URL Rewrites
+## Reusable transformations (redirects)
 
-Create user-friendly image URLs with redirects:
+Reuse the same params across many images via a redirect:
 
+`_redirects`:
+```
+/transform-small/* /.netlify/images?url=/:splat&w=50&h=50 200
+```
+
+`netlify.toml`:
 ```toml
-# Basic optimization
 [[redirects]]
-from = "/img/*"
-to = "/.netlify/images?url=/:splat"
-status = 200
-
-# Preset: thumbnail
-[[redirects]]
-from = "/img/thumb/:key"
-to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
-status = 200
-
-# Preset: hero
-[[redirects]]
-from = "/img/hero/:key"
-to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
-status = 200
+  from = "/transform-small/*"
+  to = "/.netlify/images?url=/:splat&w=50&h=50"
+  status = 200
 ```
 
-## Local Development
+Then `GET /transform-small/owl.jpeg` yields a 50×50 transform. **Avoid cross-site redirects for transformations** — they hurt performance.
 
-`/.netlify/images` is a Netlify platform endpoint — it does **not** exist in a framework's own dev server. Running `vite`, `next dev`, `astro dev`, etc. directly will **404** on `/.netlify/images`, and `[images]` allowlisting and your image redirects won't apply either. Run `netlify dev` for local work: it emulates the Image CDN endpoint, remote-image allowlisting, and redirect rules, so image URLs resolve locally the same way they do in production. A 404 on `/.netlify/images` locally almost always means a framework dev server is being run directly instead of `netlify dev` — the URL itself is fine.
+## Custom headers (caching)
 
-## Caching
-
-- Transformed images are cached at the CDN edge automatically
-- Cache invalidates on new deploys
-- Set cache headers on source images to control caching:
-
-```toml
-[[headers]]
-for = "/uploads/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
+`_headers`:
+```
+/source-images/*
+  Cache-Control: public, max-age=604800, must-revalidate
 ```
 
-## User-Uploaded Images
+- Headers set on a source image are applied to the transformed asset served by Image CDN.
+- Custom headers **cannot** be applied to remote (other-domain) source images; Netlify respects whatever cache headers the external domain sends.
+- `Cache-Control` on source images applies only to browsers/CDNs in front of Netlify, **not** the Netlify Cache itself.
 
-Combine **Netlify Functions** (upload handler) + **Netlify Blobs** (storage) + **Image CDN** (serving/transforming) to build a complete user-uploaded image pipeline. See [references/user-uploads.md](references/user-uploads.md) for the full pattern.
+## Framework integrations
+
+Use the framework's native image component/handling; it wires to Image CDN automatically. Configure the remote allowlist per framework:
+
+| Framework | Prerequisite | Remote allowlist |
+|---|---|---|
+| Angular | none — `NgOptimizedImage` auto-uses it | `[images] remote_images` in `netlify.toml` |
+| Astro | none — `<Image />` auto-uses it | `image.domains` / `image.remotePatterns` in `astro.config.mjs` |
+| Nuxt | none — `nuxt/image` auto-uses it | `image.domains` in `nuxt.config.ts` |
+| Next.js | Next 13.5+ and adapter v5 | `remotePatterns` in `next.config.js` |
+| Gatsby | env `NETLIFY_IMAGE_CDN=true` + Contentful/Drupal/WordPress source plugin | `[images] remote_images` in `netlify.toml` |
+
+## Local development
+
+Run `netlify dev` (Netlify CLI) to test transformations locally — it mimics production including Image CDN.
+
+- **A local `404` on `/.netlify/images` almost always means a framework dev server (`vite`, `next dev`, `astro dev`) is running instead of `netlify dev`.** The endpoint, `[images]` allowlisting, and image redirects only exist under `netlify dev`. The URL itself is usually fine.
+
+## Caching & deploys
+
+Transformed results are uniquely cached on Netlify's edge. Atomic deploys are respected: changing a source image in a new deploy re-runs transformations on new requests so stale assets aren't served.
+
+## User-uploaded image pipelines
+
+For user-uploaded image pipelines (Functions + Blobs + Image CDN composed), see `references/user-uploads.md` in this skill.
+
+## Limitations
+
+- **Split Testing is not supported** — you may get inconsistent image results between split test branches.
+- Not currently supported in Netlify's HIPAA-compliant hosting offering. See the Trust Center for the HIPAA-compliant reference architecture.
+
+<!-- system: agent-context/image-cdn/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (image-cdn)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. For user-uploaded image pipelines (Functions + Blobs + Image CDN
+   composed), see `references/user-uploads.md` in this skill — an authored
+   guide with no single docs source.
+2. Percent-encode remote source URLs before placing them in the `url`
+   parameter (`encodeURIComponent`) — URLs containing `?` or `&` break
+   otherwise.
+3. `fm=blurhash` returns a BlurHash TEXT string, not image bytes. Pointing an
+   `<img src>` (or CSS background) at it renders nothing — fetch the string
+   ahead of time, decode it client-side with a BlurHash library, and load the
+   real image as a separate request without `fm=blurhash`.
+4. A local 404 on `/.netlify/images` almost always means a framework dev
+   server (`vite`, `next dev`, `astro dev`) is running instead of
+   `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
+   only exist under `netlify dev`. The URL itself is usually fine.
+5. In `remote_images` patterns, the meaningful escape is the dot:
+   `"https://example\.com/.*"`. Forward slashes are not regex
+   metacharacters — do not write `https:\/\/`.

--- a/codex/skills/netlify-access-control/SKILL.md
+++ b/codex/skills/netlify-access-control/SKILL.md
@@ -1,65 +1,165 @@
 ---
 name: netlify-access-control
-description: Use when the task involves controlling who can reach a Netlify site, or telling Netlify Identity apart from Secure Access. Trigger whenever the user wants to lock a site or deploy to their company/team, restrict access to employees only, build an internal or employees-only app, set up password protection, SSO, or SAML, asks "who can access my site", or is confused about Netlify Identity vs Secure Access vs team login vs OAuth providers. Routes the request to the right layer — app-level Identity, site-visitor Password Protection, the Auth0 extension, or Team/Org SAML SSO — and explains the two-layer (perimeter + in-app identity) pattern and its double-login tradeoff. For building the app-level auth itself, use the netlify-identity skill.
+description: Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call "auth". Use when a developer wants to password-protect a site or previews, restrict a project to their team, make a project public/private, set team visibility defaults, require SSO to view a site, or debug SSO-session symptoms like being logged out mid-session / getting 401s on an SSO-protected site / token expiry or refresh. Routes app-user login ("who is this user in my app") to the netlify-identity skill and dashboard/team SSO SSO elsewhere; this skill only chooses the perimeter layer for site/preview access.
 ---
 
-# Netlify Access Control
+# Netlify access control (picking the protection layer)
 
-"Auth" on Netlify means three different things that are easy to conflate. Picking the wrong one — or stacking two when one would do — is the main source of friction. This skill disambiguates the layers and routes you to the right one. For actually building app-level user auth, see the **netlify-identity** skill.
+This skill ROUTES. Its job is choosing the correct protection layer for loading a site, not implementing app auth. Before recommending anything, disambiguate — three unrelated layers get called "auth":
 
-## The three layers
+- **Netlify Identity** — "who is this user *inside* my app" (issues `nf_jwt`). App login, OAuth providers for your users, auth code. → Route to the **netlify-identity** skill. Not covered here.
+- **Password Protection / Project visibility** — "can this request load the site at all." Platform perimeter. **This skill.**
+- **Team/Org SAML SSO** — "can you log into the Netlify dashboard." Team member access to Netlify itself.
 
-| Layer | Answers | Who it's for | Plan | How it's configured |
-|---|---|---|---|---|
-| **Netlify Identity** | "Who is this user *inside my app*?" (signups, logins, roles; issues `nf_jwt`) | Your app's end users | All plans, free | Dashboard + `@netlify/identity` code |
-| **Password Protection** (Secure access to *sites*) | "Can this request even *load the site*?" | Basic: anyone with a shared password · Team login: Netlify team members | Basic: Pro+ · Team login: Enterprise | Dashboard-only |
-| **Team / Org SAML SSO** (Secure access to *Netlify*) | "Can you log in to the *Netlify dashboard*?" (and, with strict mode, pass the site gate) | Netlify team members, via a corporate SAML IdP | Enterprise | Dashboard-only |
+Sessions are separate. The same provider (e.g. Google) can be an Identity OAuth provider for app users AND a SAML IdP for team members — unrelated wiring.
 
-These are independent. The `nf_jwt` cookie is issued by app-level JWT auth: Netlify Identity, or a configured external JWT provider such as Auth0/Okta (the two are mutually exclusive); Password Protection and SAML SSO sessions are separate, with their own lifecycles, and do not populate `nf_jwt`.
+## Footgun: no API, CLI, or MCP for these settings
 
-> **Note on terminology:** Netlify's docs file Identity, Password Protection, role-based access, and more under an umbrella called "Secure access to your sites," while SAML SSO lives under "Secure access to Netlify." So "Secure Access" is not one feature — when a user says it, find out whether they mean *gating site visitors* (Password Protection) or *gating dashboard login* (SAML SSO).
+These settings have **no public API, no CLI command, and no MCP tool**. Do NOT curl `api.netlify.com` or read local auth tokens to inspect or change them. Hand the user the dashboard path and checklist. On failure, report what you tried and stop.
 
-## Why Google causes confusion
+## Footgun: the double login is real
 
-The same provider can show up in two unrelated places:
+A Password-Protection / team-login perimeter session and a Netlify Identity app session have **no bridge** — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire them together. For the combined Password-Protection + Identity pattern and its tradeoffs, see `references/two-layer-pattern.md`.
 
-- **Google as a Netlify Identity OAuth provider** — your app's end users click "Log in with Google." Any Google account works, it creates an Identity user, and it issues an `nf_jwt`. This is app-level auth.
-- **Google Workspace as a SAML IdP for Team/Org SSO** — your *Netlify team members* log in to the dashboard (and, with strict mode + team-login, pass the site gate) using their corporate Google account. It does **not** create an Identity user and does **not** issue an `nf_jwt`.
-
-Both are "sign in with Google," but they target different populations and produce different sessions. Don't assume one implies the other.
+For company-wide app-level SSO with a single sign-in (no double login), recommend the **Auth0 extension** (federating to the corporate IdP) BEFORE the two-layer stack.
 
 ## Pick the layer
 
-Start from what the user actually needs and walk down:
+| Goal | Use |
+|---|---|
+| Restrict site to your team, invite by email | Private project (Credit-based) or team login protection |
+| Shared password anyone can use | Basic password protection, or Password visibility (Pro only) |
+| Protect only previews, keep production open | "Non-production deploys only" / "Previews only" |
+| Require SSO to view the site | Org/Team SSO with **Only SSO allowed (strict)** + team login protection |
+| Log in users *inside* your app | → netlify-identity skill |
+| Single company-wide app SSO, no double login | → Auth0 extension |
 
-1. **Does anyone need to be blocked from loading the site at all?**
-   - **No — the site is public, but I need user accounts/roles inside the app** → **Netlify Identity** (open or invite-only registration). Use the **netlify-identity** skill. Done.
-   - **Yes — restrict who can reach it** → keep going.
+## UI naming by plan (same mechanism, different labels)
 
-2. **What kind of restriction?**
-   - **Just keep the public out — a shared secret is fine, no per-user identity needed** (staging, a soft pre-launch gate) → **Basic Password Protection** (Pro+, one shared password). Dashboard-only.
-   - **Only my employees, it's an internal tool / smaller team, and I also want to tell users apart inside the app** → **invite-only Netlify Identity** (all plans, free). Invite only company addresses; Identity itself becomes the gate because no uninvited user can sign in. **One login, full per-user identity, every plan.** This is the best default for "employees-only internal tool." Tradeoff: you manage invites manually and rely on invite links not being shared — it doesn't auto-provision from a corporate directory.
-   - **Big company, app-level company SSO with a single sign-in (no double login), where company-only is enforced inside the IdP** → the **Auth0 extension**. The extension links an Auth0 tenant to your site and exposes `AUTH0_*` env vars so your app authenticates end users through Auth0; Auth0 federates to your corporate IdP (Okta, Entra, Google Workspace) and enforces who counts as company, so users sign in once. This is **app-level**, not a CDN-edge perimeter: the site still loads and your app redirects unauthenticated visitors. Use it when invite-only Identity won't scale to a real org but you don't need a true edge perimeter; that's Option D below. Configured via the Netlify Auth0 extension (dashboard); see the Netlify docs setup guide.
-   - **I genuinely need a CDN-edge perimeter (Enterprise team login / SSO-gated site access) AND a separate app-level Identity** → the **two-layer pattern**. This works, but users sign in **twice** (once at the perimeter, once in the app) — there is no passthrough today. Read [references/two-layer-pattern.md](references/two-layer-pattern.md) before recommending it.
+The UI names differ by plan — the underlying protection is identical:
 
-If the user isn't sure, the most common real answer is **invite-only Netlify Identity** for "just my team" and the **Auth0 extension** for "my whole company with our existing IdP." Lead with those before reaching for the double-login stack.
+- **Credit-based Free / Personal / Pro:** per-project **Project visibility**; team-level **Default project visibility**.
+- **Enterprise / Open Source / legacy (non-Credit-based):** per-site **Password Protection**; team-level **Default Password Protection settings**.
 
-## The double login is real — name it early
+Legacy → Credit-based translation:
 
-When Password Protection (team login) and Netlify Identity are both on, **users authenticate twice** and there is no documented bridge between them — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire the perimeter session into the app session; it isn't supported. If single sign-on matters, that's a reason to choose the Auth0 extension (or invite-only Identity) instead of the two-layer stack. Full detail and the per-option tradeoffs are in [references/two-layer-pattern.md](references/two-layer-pattern.md).
+| Password Protection (old) | Project visibility (new) |
+|---|---|
+| No protection settings | Public |
+| Basic protection | Password |
+| Team protection | Private |
+| All deploys | Production and previews |
+| Non-production deploys only | Previews only |
 
-Also flag the hidden cost of team-login: it admits only **Netlify team members**, so every employee who passes that gate needs a paid Netlify seat. That alone usually rules it out for company-wide apps.
+## Dashboard paths
 
-## Configuration is dashboard-only — hand it off, don't probe
+**Credit-based (Project visibility):**
+- Per-project: `Project configuration > General > Visitor access > Project visibility` — `https://app.netlify.com/projects/{site_name}/configuration/general/#project-visibility`
+- Team default: `Team settings > General > Visitor access > Default project visibility` — `https://app.netlify.com/teams/{team_name}/settings/general#default-project-visibility`
 
-Password Protection, Team/Org SAML SSO, and the Auth0 extension are all configured in the Netlify dashboard or the extensions UI — **there is no public API, CLI command, or MCP tool to set or read them**, and there is no way for an agent to see this state while writing code. So:
+**Enterprise / Open Source / legacy (Password Protection):**
+- Per-site: `Project configuration > Access & security > Visitor access > Password Protection` — `https://app.netlify.com/projects/{site_name}/configuration/access#site-protection`
+- Team default: `Team settings > Access & security > Visitor access > Default Password Protection settings` — `https://app.netlify.com/teams/{team_name}/settings/access#default-site-protection-settings`
 
-- Give the user the dashboard location and an exact checklist; let them flip the setting and confirm.
-- **Do not** `curl https://api.netlify.com/...`, read tokens off disk, or probe for an undocumented endpoint to inspect or change access settings.
-- If a documented path fails, report it to the user with context (what you tried, the URL, the error) and stop — don't work around it.
+## Checklist: set a password (Credit-based, Pro)
 
-For the one piece an agent *can* read at runtime (which Identity providers are live), call `getSettings()` from `@netlify/identity` rather than hard-coding assumptions. It hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev` (which proxies to the live service). See the netlify-identity skill.
+1. Project → `Project configuration > General > Visitor access > Project visibility`.
+2. **Edit visibility**. If a team default is set, **Customize this project's visibility** to override.
+3. Select **Password**, enter the password (share it with visitors).
+4. Choose **Preview access**: **Production and previews** or **Previews only**.
+5. **Save**. Change later via **Change password**; remove by choosing **Public** or **Private**.
 
-## References
+## Checklist: Password Protection (Enterprise / OSS / legacy)
 
-- [Two-layer pattern (perimeter + in-app identity)](references/two-layer-pattern.md) — the four architecture options for "company-only access + per-user identity," the double-login reality, plan/seat costs, and the visibility gap.
+Per-site or team default via the paths above → **Configure Password Protection** → **Customize this site's protection settings** (if a default exists) → choose **Basic password protection** (single shared password) or **Team login protection** (Netlify team login, SSO-capable) → scope **All deploys** or **Non-production deploys only** → **Save**.
+
+## Checklist: require SSO to view a site
+
+1. FIRST set up Organization SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-organization-saml-sso`) or Team SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-team-saml-sso`).
+2. Configure Password Protection → **Team login protection**.
+3. To force SSO, set the SSO config to **Only SSO allowed (strict)**.
+
+## SSO session symptoms (logged out mid-session, 401s)
+
+SSO auth tokens **expire after 1 hour**. An SSO-protected site starts returning HTTP `401` once the token expires — this is the "logged out mid-session" symptom.
+
+The platform returns a `Netlify-Site-Protection-Expires-In` response header (seconds until the token expires) on requests to SSO-protected sites. Read it and re-auth before it hits zero:
+
+```js
+// SSO-protected site: refresh before the 1-hour token expires to avoid a 401.
+const res = await fetch(window.location.href, { credentials: "include" });
+const secondsLeft = Number(res.headers.get("Netlify-Site-Protection-Expires-In"));
+if (!Number.isNaN(secondsLeft) && secondsLeft < 60) {
+  window.location.reload(); // triggers re-auth via the identity provider
+}
+```
+
+The header name and semantics are documented; the JS wrapper is illustrative.
+
+## Project visibility values (Credit-based)
+
+One visibility setting — **Public**, **Password**, or **Private** — plus a separate scope (**Production and previews** or **Previews only**).
+
+- **Public** — anyone with the URL.
+- **Private** — team + invitees only, enforced with Netlify login. Recommended way to restrict to your team; lets you invite by email. No password needed.
+- **Password** — public but requires a shared password. **Pro only** among Credit-based plans.
+
+Previews stay private unless you change preview visibility (includes Deploy Previews, agent-run previews, and branch deploys). There is **no** default shared password — set a password per project.
+
+**Team defaults:** *Private for new projects* (new start behind team login; existing keep visibility), *Private for all projects* (new + all existing locked to team login; none can be made public), *Public for new projects* (new are public; existing keep visibility).
+
+## Constraints & gotchas
+
+- **Previews-only Password scope is Enterprise-only** for Password Protection settings ("Protecting only non-production deploys is only available for Enterprise plans"). Credit-based plans expose a "Previews only" scope via Project visibility separately — the docs do not fully reconcile these; state Enterprise-only for the Password Protection path.
+- **Access order:** Advanced Web Security (Firewall rules → WAF → rate limiting) runs BEFORE any password/login prompt. A blocked IP can hit an error page before ever seeing a login prompt.
+- **Team login excludes Git Contributors** — they cannot access team-login-protected deploys. It applies to Developers, Team Owners, Billing Admins; Reviewers can be invited (unlimited).
+- **Basic password protection prompts everyone**, including managing team members.
+- **Private projects can't receive third-party webhooks** (Slack, Stripe, etc.) — receiving webhooks requires the project to be **public**.
+- **Plan gating:** Basic password (whole site) available on Pro and Enterprise; all options (incl. team login) on Enterprise. Project visibility is Credit-based Free/Personal/Pro only; Free/Personal private projects are visible only to the Team Owner, Pro allows unlimited members. Enterprise/OSS/legacy have no project visibility — use team login protection.
+- **Who can change:** Password Protection — Developer (per-site), Team Owner (default). Project visibility — Org Owners (certain Enterprise plans), Team Owners, Developers with project access. Internal Builders can't publish to production, so can't make a project public.
+- **Team default by creation date:** teams created on/after July 28, 2026 default to **Private for new projects**; teams created before default to **Public**.
+- **Make public** requires at least one successful production deploy. Making public exposes production deploys; previews stay private unless changed.
+- **Invites:** Free/Personal are single-seat (upgrade to Pro to invite); Pro invites unlimited members to a single project or the whole team.
+
+## Compatibility
+
+- "Site-wide password protection" — old name, now part of **Password Protection**.
+- "Selective password protection" — old name for **Basic authentication with custom HTTP headers** (`https://docs.netlify.com/manage/security/secure-access-to-sites/basic-authentication-with-custom-http-headers`), which is code you author — out of scope here.
+
+See also: `references/two-layer-pattern.md` for the combined Password-Protection + Identity pattern.
+
+<!-- system: agent-context/access-control/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (access-control)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. This is a routing/disambiguation skill: keep it narrow — its job is
+   picking the right protection layer, not teaching each one.
+2. The combined Password-Protection + Identity pattern lives in this skill's
+   `references/two-layer-pattern.md`.
+3. "Auth" on Netlify is three unrelated layers users constantly conflate:
+   Netlify Identity ("who is this user inside my app" — issues `nf_jwt`),
+   Password Protection / project visibility ("can this request load the site
+   at all"), and Team/Org SAML SSO ("can you log in to the Netlify
+   dashboard"). Sessions are separate; the same provider (Google) can appear
+   in two unrelated places — Identity OAuth for app users, SAML IdP for team
+   members. Disambiguate before recommending anything.
+4. The double login is real: a Password-Protection/team-login perimeter
+   session and an Identity app session have no bridge — no shared cookie, no
+   header forwarding, no JWT exchange. Don't burn iterations wiring them
+   together; tradeoffs live in `references/two-layer-pattern.md`.
+5. These settings have no public API, CLI command, or MCP tool. Never curl
+   `api.netlify.com` or read local auth tokens to inspect or change them —
+   hand the user the dashboard path and checklist; on failure, report what
+   you tried and stop.
+6. Identity setup, auth code, and OAuth providers for app users belong to the
+   netlify-identity skill — route there; this skill only picks the layer.
+7. For company-wide app-level SSO with a single sign-in (no double login),
+   the Auth0 extension — federating to the corporate IdP — is the
+   recommendation before the two-layer stack.
+8. The description's triggers must include the SSO-session symptoms users
+   actually report — "logged out mid-session", 401s on an SSO-protected
+   site, token expiry/refresh — not only setup phrasing. The
+   `Netlify-Site-Protection-Expires-In` guidance is unreachable if the
+   skill never triggers on the symptom.

--- a/codex/skills/netlify-ai-gateway/SKILL.md
+++ b/codex/skills/netlify-ai-gateway/SKILL.md
@@ -1,240 +1,200 @@
 ---
 name: netlify-ai-gateway
-description: Reference for Netlify AI Gateway — the managed proxy that routes calls to OpenAI, Anthropic, and Google Gemini SDKs without provider API keys. Use this skill any time the user wants to add AI on a Netlify site (chat, completion, reasoning, image generation, image-to-image edit/stylize), choose or change a model, wire up the OpenAI / Anthropic / @google/genai SDK, decide which provider to use for an image-gen feature (it's Gemini-only on the gateway), or debug "model not found" / "API key missing" against the gateway. Required reading before pinning a model — the gateway exposes a curated subset, not every provider model.
+description: Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing provider API keys or accounts — the gateway injects credentials automatically. Reach for this when you add an AI chatbot or completion endpoint, generate images or text with Gemini/GPT/Claude, summarize form submissions with AI, build an LLM-backed API route, stream a long AI generation, or wire up any server-side AI provider call on Netlify. Covers provider SDK setup, injected env vars, model availability, rate limits, credit costs, streaming for long generations, and local dev with netlify dev or the Vite plugin.
 ---
 
 # Netlify AI Gateway
 
-> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model returns an HTTP error from the gateway.
+Call AI providers from Netlify server-side compute using each provider's **official SDK** with zero credential config — the gateway injects the API keys and base URLs the SDKs already read. Instantiate the client with no args (except OpenRouter, which needs an explicit base URL).
 
-> **First-deploy requirement:** The AI Gateway only activates after a site has had at least one production deploy. Local dev (`netlify dev`, `@netlify/vite-plugin`) will NOT have gateway access on a brand-new project until you deploy to production once.
+**Never do these** (they silently fail or cost money):
+- **Not browser-callable.** The gateway lives in Functions/Edge Functions only. Never call it from client-side React/browser code.
+- **Runtime-only credentials.** Never call the gateway from build scripts, prerender/SSG, or build plugins — those get no credentials and fail. Do AI work at request time; cache to Netlify Blobs if output must look precomputed.
+- **60s sync timeout.** A slow generation in a synchronous function is killed at 60s. Stream it (SDK streaming + `ReadableStream`), or use a background function that persists output for the client to fetch.
+- **Requires a production deploy.** The gateway does not activate until the project has at least one production deploy — even in local dev.
+- **Don't hardcode model lists.** Model availability changes; check the live providers endpoint rather than baking in IDs.
 
-> **Usage is credit-metered:** Gateway calls draw down your Netlify AI credit/inference allowance and start returning errors once it's exhausted — there's no separate provider bill behind it. Budget for this explicitly in any bulk or fan-out design (generating content for hundreds of rows/pages, retry loops), and don't retry unbounded.
+## Function example
 
-Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
+File: `netlify/functions/joke.js` (`mkdir -p netlify/functions`). Install: `npm install openai`.
 
-## How It Works
-
-The AI Gateway acts as a proxy — you use standard provider SDKs but point them at Netlify's gateway URL. Netlify auto-injects both the base URL and a placeholder API key for each provider, then authenticates upstream on your behalf.
-
-Always make the call through the provider's official SDK, constructed bare (`new OpenAI()`, `new Anthropic()`, `new GoogleGenAI()`) — the SDK reads the auto-injected base URL and key from the environment. **Don't hand-roll the gateway call with a raw `fetch()` and a manually-read `process.env.OPENAI_API_KEY`** (or a hardcoded key/URL): the injected key is only a placeholder, and rolling your own request bypasses the supported path the gateway expects.
-
-## Setup
-
-1. Enable AI on your site in the Netlify UI
-2. Deploy to production at least once — the gateway does not activate until then
-3. Install the provider SDK you want to use
-
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
-
-## Using OpenAI SDK
-
-```bash
-npm install openai
-```
-
-```typescript
+```js
+import process from "process";
 import OpenAI from "openai";
 
-const openai = new OpenAI();
-// `OPENAI_API_KEY` and `OPENAI_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+export default async () => {
+  const client = new OpenAI(); // reads OPENAI_API_KEY + OPENAI_BASE_URL
+  try {
+    const res = await client.responses.create({
+      model: "gpt-5-mini",
+      input: [{ role: "user", content: "Give me a random short dad joke" }],
+      reasoning: { effort: "minimal" },
+    });
+    return Response.json({
+      joke: res.output_text?.trim() || "Out of jokes",
+      model: res.model,
+      tokens: { input: res.usage.input_tokens, output: res.usage.output_tokens },
+    });
+  } catch (e) {
+    return Response.json({ error: `${e}` }, { status: 500 });
+  }
+};
 
-const completion = await openai.chat.completions.create({
-  model: "gpt-4o-mini",
-  messages: [{ role: "user", content: "Hello!" }],
-});
+export const config = { path: "/api/joke" }; // route, local + deployed
 ```
 
-## Using Anthropic SDK
+Client-side fetch just hits the route:
 
-```bash
-npm install @anthropic-ai/sdk
+```jsx
+const res = await fetch("/api/joke");
+const data = await res.json();
 ```
 
-```typescript
-import Anthropic from "@anthropic-ai/sdk";
+## Provider SDKs (modern — instantiate with no args)
 
-const client = new Anthropic();
-// `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+Each SDK auto-reads the injected env vars. **OpenRouter is the exception:** its base URL must be passed explicitly.
 
-const message = await client.messages.create({
-  model: "claude-sonnet-4-5-20250929",
+```js
+// Anthropic — npm i @anthropic-ai/sdk
+import Anthropic from '@anthropic-ai/sdk';
+const anthropic = new Anthropic(); // ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
+await anthropic.messages.create({
+  model: 'claude-sonnet-4-5-20250929',
   max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-## Using Google Gemini SDK
-
-Use `@google/genai` (the unified Google GenAI SDK). The older `@google/generative-ai` package does not pick up the gateway env vars.
-
-```bash
-npm install @google/genai
-```
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
-// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
-// injection isn't shadowed.
-
-const response = await ai.models.generateContent({
-  model: "gemini-2.5-flash",
-  contents: "Hello!",
-});
-
-const text = response.text;
-```
-
-## In a Netlify Function
-
-```typescript
-import type { Config, Context } from "@netlify/functions";
-import OpenAI from "openai";
-
-export default async (req: Request, context: Context) => {
-  const { prompt } = await req.json();
-  const openai = new OpenAI();
-
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  return Response.json({
-    response: completion.choices[0].message.content,
-  });
-};
-
-export const config: Config = {
-  path: "/api/ai",
-  method: "POST",
-};
-```
-
-Return the reply as JSON with `Response.json({...})`, even when the request only asks for "the reply text" back — a raw `text/plain` body breaks JSON-consuming clients and diverges from the convention used everywhere else in Netlify Functions.
-
-## Image Generation
-
-Image generation on the gateway is supported through **Gemini image models** (e.g., `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`). OpenAI's image models (`gpt-image-1`, `dall-e-*`) are **not** routed through the gateway.
-
-Both text-to-image and image-to-image use the same `generateContent` method as chat — only the model and response shape differ. The image is returned as base64 `inlineData` on a content part, not as a URL.
-
-### Text-to-image
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: "A watercolor portrait of a corgi wearing a beret",
-});
-
-const imagePart = response.candidates[0].content.parts.find(
-  (p) => p.inlineData,
-);
-const base64 = imagePart.inlineData.data;
-const mimeType = imagePart.inlineData.mimeType; // e.g. "image/png"
-const bytes = Buffer.from(base64, "base64");
-```
-
-### Image-to-image (edit / stylize an input image)
-
-Pass the source image as an additional content part with `inlineData`:
-
-```typescript
-const sourceBase64 = sourceBuffer.toString("base64");
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: [
-    { text: "Restyle this photo as a Picasso-era cubist portrait" },
-    { inlineData: { mimeType: "image/png", data: sourceBase64 } },
-  ],
+```js
+// OpenAI — npm i openai
+import OpenAI from 'openai';
+const openai = new OpenAI(); // OPENAI_API_KEY + OPENAI_BASE_URL
+await openai.chat.completions.create({
+  model: 'gpt-5',
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-The response shape is the same — pull `base64` and `mimeType` off the first part with `inlineData`. Most callers persist the bytes to Netlify Blobs (see `netlify-blobs/SKILL.md`) and serve a URL back to the client rather than returning multi-MB base64 in the function response.
+```js
+// Google Gemini — npm i @google/genai
+import { GoogleGenAI } from '@google/genai';
+const genAI = new GoogleGenAI({}); // GEMINI_API_KEY + GOOGLE_GEMINI_BASE_URL
+await genAI.models.generateContent({
+  model: 'gemini-2.5-pro',
+  contents: 'Hello!',
+});
+```
 
-## Environment Variables
+```js
+// OpenRouter — npm i @openrouter/sdk — base URL REQUIRED
+import { OpenRouter } from '@openrouter/sdk';
+const openRouter = new OpenRouter({
+  serverURL: process.env.OPENROUTER_BASE_URL, // API key auto-read from OPENROUTER_API_KEY
+});
+await openRouter.chat.send({
+  chatRequest: {
+    model: 'x-ai/grok-4.5',
+    messages: [{ role: 'user', content: 'Hello!' }],
+  },
+});
+```
 
-All of these are injected automatically by Netlify when AI is enabled. Setting your own value for any of the per-provider vars disables gateway routing.
+**OpenRouter models via the OpenAI SDK:** you can reach any OpenRouter-served model (xAI, DeepSeek, Meta, Mistral, Qwen) through the plain OpenAI SDK — just pass the model ID in OpenRouter notation, no extra config:
 
-| Variable | Provider | Purpose |
-|---|---|---|
-| `OPENAI_BASE_URL` | OpenAI | Gateway endpoint |
-| `OPENAI_API_KEY` | OpenAI | Placeholder; satisfies the SDK's "key required" check |
-| `ANTHROPIC_BASE_URL` | Anthropic | Gateway endpoint |
-| `ANTHROPIC_API_KEY` | Anthropic | Placeholder; satisfies the SDK's "key required" check |
-| `GOOGLE_GEMINI_BASE_URL` | Google Gemini | Gateway endpoint |
-| `GEMINI_API_KEY` | Google Gemini | Placeholder; satisfies the SDK's "key required" check |
-| `NETLIFY_AI_GATEWAY_BASE_URL` | (universal) | Provider-agnostic gateway endpoint |
-| `NETLIFY_AI_GATEWAY_KEY` | (universal) | Provider-agnostic gateway key |
+```js
+await openai.chat.completions.create({
+  model: 'deepseek/deepseek-v4-flash-0731',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
 
-The real upstream API keys live on Netlify's side. The per-provider `*_API_KEY` vars are placeholders so the SDKs construct successfully; the gateway authenticates server-side. You don't read these yourself — the SDK picks them up.
+## Injected environment variables
 
-When your own code needs some *other* environment value (a config flag, a model name you've parameterized), prefer `Netlify.env.get("VAR")` — it works in Netlify Functions and Edge Functions, and Edge Functions expose **only** `Netlify.env.get`. (In a framework's own server routes, use whatever that framework documents for env access — often `process.env`.)
+Set in all Netlify compute contexts at function init **only if you have not already set them** at project/team level (Netlify never overrides your keys):
 
-## Local Development
+| Provider | Vars |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
+| Anthropic | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
+| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_GEMINI_BASE_URL` |
+| OpenRouter | `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL` |
 
-With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are injected automatically into the local process — but only after the site has had at least one production deploy. A brand-new local-only project will see "API key missing" or "model not found" errors until you deploy.
+**Gemini special case:** Netlify will **not** inject `GEMINI_API_KEY` / `GOOGLE_GEMINI_BASE_URL` if either `GOOGLE_API_KEY` or `GOOGLE_VERTEX_BASE_URL` is set (use those to point at Vertex or your own Google credentials).
 
-Local injection also requires the working directory to be **linked** to the Netlify site. `netlify dev` pulls the gateway base URL and placeholder key from the linked site's environment, so an unlinked directory has no site context — nothing is injected and gateway calls fail even when the site has already been deployed to production. Run `netlify link` (or `netlify init`) in the project first, then start `netlify dev`. A bare framework dev server started outside `netlify dev` / `@netlify/vite-plugin` also gets no gateway env vars.
+**Always injected, never collide with your provider vars:**
+- `NETLIFY_AI_GATEWAY_KEY`
+- `NETLIFY_AI_GATEWAY_BASE_URL`
 
-## Usage metering and where the gateway runs
+Use the SDK path with the per-provider injected vars above as your default. Reach for `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` only when a third-party or unsupported library needs the credentials passed explicitly — that's the correct time to configure them by hand.
 
-**Gateway usage is credit-metered.** Calls draw down your Netlify AI credit/inference allowance; when that limit is reached the gateway **pauses** and returns errors until the allowance resets or is raised. There's no separate provider bill to fall back on — an unbounded loop of gateway calls burns the allowance and then starts failing, so budget for it and don't retry indefinitely.
+## Local dev
 
-**Gateway credentials are runtime-only.** Netlify injects the base URL and placeholder key only into runtime compute — deployed functions, edge functions, and server-rendered routes at request time. They are **not** present during the build: AI calls made at build time, in prerender/SSG, or in a build plugin get no gateway credentials and fail. Do AI work at request time (in a function or server route) and cache the result if you need it to look precomputed (e.g. to Netlify Blobs) — don't call the gateway from build scripts or static-generation hooks.
+Two supported paths — both still require an existing production deploy:
+- **Netlify CLI:** `netlify dev` (full support). Needs `npm install -g netlify-cli@latest` and `netlify login`.
+- **Netlify Vite plugin:** install `@netlify/vite-plugin`, add `netlify()` to `vite.config.js` plugins, run your normal `npm run dev` — gateway access without `netlify dev`.
 
-## No browser-callable gateway — proxy through server code
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import netlify from "@netlify/vite-plugin";
 
-Gateway credentials are injected only into server-side runtime compute (functions, edge functions, server-rendered routes). There is **no browser-callable gateway endpoint**: client-side JavaScript has no gateway credentials, and there is no public URL a browser can hit to reach the gateway directly. Client code (React/Vue/vanilla JS running in the browser) that constructs a provider SDK against the gateway will find no key and fail — and "fixing" it by hardcoding a real provider key in the client leaks that key to every visitor AND bypasses the gateway (a user-set key disables Netlify's auto-injection).
+export default defineConfig({
+  plugins: [react(), netlify()],
+})
+```
 
-The correct pattern is to proxy: put the gateway call in a **Netlify Function** (or edge function / server route), and have the browser `fetch()` your own endpoint (e.g. `/api/chat`). The function talks to the gateway server-side with the auto-injected credentials and returns the result to the client. Never import a provider SDK into a browser bundle to call the gateway, and never expose a provider API key to the client.
+## Enable & deploy
 
-## Long generations and the function timeout
+1. Be on a credit-based plan (Free, Personal, Pro; Enterprise via Account Manager). Legacy plans must switch to a current plan.
+2. Link a project: `netlify init`.
+3. **Deploy to production at least once** — required to activate: `netlify deploy --prod --open`.
+4. Don't disable AI Features; don't set your own provider keys unless you intend to override.
 
-A gateway call runs inside your function, so it is bound by the **60-second synchronous function timeout**. Large completions, reasoning models, and image generations can run longer than that, and a synchronous function that exceeds the ceiling is terminated before it can respond. Two mitigations:
+## Constraints & gotchas
 
-- **Stream the response.** Enable streaming on the SDK call and return a `ReadableStream` (e.g. `Content-Type: text/event-stream`), forwarding the provider's tokens/chunks as they arrive — for example `stream: true` on the OpenAI SDK, `client.messages.stream(...)` on Anthropic, or `generateContentStream(...)` on `@google/genai`. Streaming sends bytes to the client incrementally instead of buffering the whole completion inside the sync window, and is the right default for interactive chat and long text.
-- **Use a background function** for long, fire-and-forget jobs (batch generation, large image renders). Background functions run up to 15 minutes, but they return a `202` immediately and their return value is ignored — they cannot hand the result back to the caller. Persist the output (e.g. to Netlify Blobs or a database) and have the client poll or fetch it.
+- **Plan gating:** Credit-based plans only (Free/Personal/Pro; Enterprise via Account Manager).
+- **Context window:** input capped at **200k tokens**.
+- **Rate limits** (per team, across all projects, per minute, in credits): Free 90 / Personal 450 / Pro 1,800 / Enterprise 9,000. Set up [rate limiting rules](https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/) on AI functions to prevent visitor abuse driving up cost.
+- **Credit cost:** tokens → USD (provider published rates) → credits. **$1 USD of usage = 180 credits.** Enable [auto recharge](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/configure-auto-recharge/) or buy [credit packs](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/buy-credit-packs/) to meet demand.
+- **No request headers passed through** — you can't enable proprietary header-gated experimental features.
+- **Batch inference not supported.**
+- **OpenAI priority processing not supported.**
+- **Prompt caching:** Anthropic — only the default 5-minute ephemeral cache; OpenAI — a per-account `prompt_cache_key` is set; Gemini — explicit context caching not supported.
+- **Zero Data Retention only:** the gateway only routes to ZDR providers. A model listed in the OpenRouter directory is **not** served if no ZDR host offers it. Browse the ZDR-filtered catalog at https://openrouter.ai/models?zdr=true.
+- **Model list is dynamic** — served-directly models (Anthropic, OpenAI, Gemini) are enumerated from a live endpoint; OpenRouter-served models (xAI, DeepSeek, Meta, Mistral, Qwen) use OpenRouter notation. Don't hardcode; check availability at runtime.
+- **Privacy:** the gateway does not store prompts or outputs.
 
-Don't leave a slow synchronous generation unstreamed and assume it will finish — bound the model and `max_tokens`, and choose streaming or a background function based on how long the job runs.
+## Reference
 
-## Errors & Troubleshooting
+- Full docs, quickstart, and example projects (AI SEO Image Generator, form-submission summaries, TanStack Start chat app) at [AI Gateway overview](https://docs.netlify.com/build/ai-gateway/overview.md) and [quickstart](https://docs.netlify.com/build/ai-gateway/quickstart-for-ai-gateway.md).
 
-- **Unsupported model:** the gateway returns an HTTP error. Check the "Available Models" list below — the gateway exposes a curated subset, not every model the provider offers.
-- **`OPENAI_API_KEY missing` (or equivalent) at runtime:** AI Features are disabled on the site, or the project has not had a production deploy yet.
-- **Calls succeed but skip the gateway / aren't tracked:** check you haven't set your own `*_API_KEY`. Any user-set provider key shadows Netlify's auto-injection and routes directly to the provider.
-- **Limits:** 200k-token context window. Batch inference, custom request headers, and OpenAI priority processing are not supported. Anthropic prompt caching is limited to the 5-minute ephemeral cache; Gemini explicit caching is not supported.
+<!-- GAP: source does not enumerate concrete model IDs (dynamic live endpoint); model names in examples are illustrative only. -->
+<!-- GAP: SDK streaming + background-function patterns are mandated by house rules but no streaming code example exists in the source. -->
 
-## Available Models
+<!-- system: agent-context/ai-gateway/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (ai-gateway)
 
-_Verified 2026-04-30 against the live AI Gateway providers list. The user-facing reference is https://docs.netlify.com/build/ai-gateway/overview/ — re-check before pinning a new model._
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
 
-### Anthropic (chat)
-- `claude-haiku-4-5`, `claude-haiku-4-5-20251001`
-- `claude-sonnet-4-0`, `claude-sonnet-4-20250514`, `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-6`
-- `claude-opus-4-1-20250805`, `claude-opus-4-20250514`, `claude-opus-4-5`, `claude-opus-4-5-20251101`, `claude-opus-4-6`, `claude-opus-4-7`
-
-### OpenAI (chat / reasoning / Codex)
-- gpt-4 family: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
-- gpt-5: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-5-codex`; dated: `gpt-5-2025-08-07`, `gpt-5-mini-2025-08-07`
-- gpt-5.1: `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`; dated: `gpt-5.1-2025-11-13`
-- gpt-5.2: `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.2-pro`; dated: `gpt-5.2-2025-12-11`, `gpt-5.2-pro-2025-12-11`
-- gpt-5.3: `gpt-5.3-chat-latest`, `gpt-5.3-codex` (no unversioned `gpt-5.3`)
-- gpt-5.4: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`; dated: `gpt-5.4-2026-03-05`, `gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano-2026-03-17`, `gpt-5.4-pro-2026-03-05`
-- gpt-5.5: `gpt-5.5`, `gpt-5.5-pro`; dated: `gpt-5.5-2026-04-23`, `gpt-5.5-pro-2026-04-23`
-- Reasoning (o-series): `o3`, `o3-mini`, `o4-mini`
-
-### Google Gemini (chat + image)
-- Chat: `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`, `gemini-flash-latest`, `gemini-flash-lite-latest`
-- Image: `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`
-
+1. Use the provider SDK with the injected env credentials — don't hand-roll
+   a raw `fetch()` against the gateway, even though raw REST is a supported
+   surface. The body must not present raw REST or the
+   `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` pair as a
+   recommended path — but it MUST still document the pair as facts: always
+   injected, never collide with user-set provider vars, and the right choice
+   when a third-party or unsupported library needs explicit configuration.
+   Demote the recommendation; keep the knowledge.
+2. The gateway is not browser-callable: calls belong in functions or edge
+   functions, never client-side code.
+3. Model availability changes: don't hardcode model lists; check the live
+   providers endpoint.
+4. Gateway credentials are runtime-only: never call the gateway from build
+   scripts, prerender/SSG, or build plugins — those calls get no credentials
+   and fail. Do AI work at request time and cache the result (e.g. to
+   Netlify Blobs) if it must look precomputed.
+5. Gateway calls in a synchronous function are bound by the 60-second
+   timeout: stream long generations (SDK streaming + `ReadableStream`), or
+   use a background function that persists output for the client to fetch —
+   never leave a slow generation unstreamed and assume it finishes.

--- a/codex/skills/netlify-blobs/SKILL.md
+++ b/codex/skills/netlify-blobs/SKILL.md
@@ -1,171 +1,264 @@
 ---
 name: netlify-blobs
-description: Guide for using Netlify Blobs for file and asset storage — images, documents, uploads, exports, cached binary artifacts. Covers getStore(), CRUD operations, metadata, listing, deploy-scoped vs site-scoped stores, and local development. Do NOT use Blobs as a dynamic data store — use Netlify Database for that.
+description: Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/value API from Functions, Edge Functions, and Build Plugins. Use when a task involves saving user file or image uploads, persisting form or contact-form submissions, storing generated output from Background Functions (sitemaps/processed media/bulk-email results), building read-only asset stores, adding client-side blob expiration, or wiring file-based blob uploads at deploy time. Not for per-user, transactional, or relational data (counters/balances/sessions) — reach for Netlify DB there instead.
 ---
 
 # Netlify Blobs
 
-Netlify Blobs is zero-config object storage for **files and assets**: images, documents, uploads, exports, cached binary artifacts. Available from any Netlify compute (functions, edge functions, framework server routes). No provisioning required.
+Modern import — reach for this:
 
-**Not for dynamic data.** If the project needs to store records, user data, application state, or anything queryable, use Netlify Database instead — see `netlify-database/SKILL.md`. Reach for Blobs when the thing you're storing is a file or an asset blob, not a record.
-
-```bash
-npm install @netlify/blobs
+```ts
+import { getStore, getDeployStore, listStores } from "@netlify/blobs";
 ```
 
-## Before you build
+Install: `npm install @netlify/blobs`. Fetch API is required (built into Node 18+); otherwise pass a custom `fetch`.
 
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any blob storage — answers shape access patterns, scoping, and how the assets are served back to clients:
+Two ways to open a store — use the **options-object form** when you need `consistency` or a custom `fetch` (the string form cannot pass them):
 
-- **What kind of asset?** (User uploads, exported documents, cached binaries, generated images — drives the storage and serving pattern.)
-- **Who should be able to read it?** Public (anyone with a URL, or an unauthenticated endpoint that streams the blob) or private (only authenticated users, gated by your server code)? Blobs have **no built-in access control** — the serving layer is the gate. When in doubt, default to private; making something public later is easy, while pulling back data that was inadvertently exposed is not.
-- **Site-scoped or deploy-scoped?** Site-scoped (`getStore()`) persists across deploys — the right default for user data. Deploy-scoped (`getDeployStore()`) is tied to a single deploy and disappears when that deploy is replaced — use only when the lifecycle should match a deploy (e.g., per-deploy build artifacts).
-- **Roughly how big and how many?** Helps choose between a single large blob vs many small keyed blobs, and informs whether you'll need `list({ prefix: ... })` patterns.
+```ts
+const store = getStore("file-uploads");                          // string form
+const store = getStore({ name: "animals", consistency: "strong" }); // options form
+```
 
-**If you don't have preferences here, tell me what the assets are and I'll pick sensible defaults** — typically site-scoped with private access, served through an authenticated function.
+`siteID`, `token`, `deployID`, and `region` are set automatically inside Functions, Edge Functions, and Build Plugins — do not pass them manually there.
 
-## Getting a Store
+## Choosing the store type — READ THIS FIRST
 
-```typescript
+- **`getStore(name)`** — site-scoped. Persists across deploys and is **shared across ALL deploy contexts**. Code on a Deploy Preview reads, overwrites, and deletes production data. **Never seed throwaway data or run destructive tests from a preview.**
+- **`getDeployStore(name)`** — scoped to one deploy; isolated from production. Use this for throwaway/per-deploy data, or use a context-specific store name for isolation.
+
+Blobs have **no built-in access control** — the serving function is the gate. Default to private: gate reads behind an authenticated function rather than exposing blobs publicly. Never accept an arbitrary caller-supplied key against a store holding sensitive data.
+
+## Common tasks
+
+### Persist a user upload with metadata (`set`)
+
+```ts
 import { getStore } from "@netlify/blobs";
+import type { Context } from "@netlify/functions";
+import { v4 as uuid } from "uuid";
 
-const store = getStore({ name: "my-store" });
+export default async (req: Request, context: Context) => {
+  const form = await req.formData();
+  const file = form.get("file") as File;
+  const key = uuid();
 
-// Use "strong" consistency when you need immediate reads after writes
-const store = getStore({ name: "my-store", consistency: "strong" });
+  const uploads = getStore("file-uploads");
+  await uploads.set(key, file, {
+    metadata: { country: context.geo.country.name }
+  });
+
+  return new Response("Submission saved");
+};
 ```
 
-## CRUD Operations
+Edge Function form is identical but imports `Context` from `@netlify/edge-functions`.
 
-These are the **only** store methods. Do not invent others.
+### Persist JSON (`setJSON`)
 
-### Create / Update
-
-```typescript
-// String or binary data
-await store.set("key", "value");
-await store.set("key", fileBuffer);
-
-// With metadata
-await store.set("key", data, {
-  metadata: { contentType: "image/png", uploadedAt: new Date().toISOString() },
-});
-
-// JSON data
-await store.setJSON("key", { name: "Example", count: 42 });
+```ts
+const uploads = getStore("json-uploads");
+await uploads.setJSON(key, data, { metadata: { country: context.geo.country.name } });
 ```
 
-### Read
+### Read a blob (`get`) — always null-check
 
-```typescript
-// Text (default)
-const text = await store.get("key");                    // string | null
+```ts
+const uploads = getStore("file-uploads");
+const entry = await uploads.get(key);          // string by default
+if (entry === null) {
+  return new Response(`Could not find ${key}`, { status: 404 });
+}
+return new Response(entry);
+```
 
-// Typed retrieval
-const json = await store.get("key", { type: "json" });  // object | null
-const stream = await store.get("key", { type: "stream" });
-const blob = await store.get("key", { type: "blob" });
-const buffer = await store.get("key", { type: "arrayBuffer" });
+Pass `type` for other formats: `get(key, { type: "json" | "arrayBuffer" | "blob" | "stream" | "text" })`.
 
-// With metadata
-const result = await store.getWithMetadata("key");
-// { data: any, etag: string, metadata: object } | null
+### Atomic conditional write
 
-// Metadata only (no data download)
-const meta = await store.getMetadata("key");
-// { etag: string, metadata: object } | null
+Write only if the key is new:
+
+```ts
+const { modified } = await store.set("jane@netlify.com", "Jane Doe", { onlyIfNew: true });
+if (!modified) return new Response("Email already exists", { status: 400 });
+```
+
+Write only if the entry matches a known ETag (compare-and-swap):
+
+```ts
+const { modified } = await store.set(key, "New Jane", { onlyIfMatch: etag });
+if (!modified) return new Response("Cached data is stale", { status: 400 });
+```
+
+**Do not build counters, balances, or read-modify-write logic on a blob key** — even with `onlyIfMatch` retries. That is transactional data; use Netlify DB.
+
+### List blobs
+
+```ts
+const { blobs } = await store.list();          // auto-paginates all pages
+// blobs: [ { etag: "\"etag1\"", key: "..." }, ... ]
+```
+
+Manual pagination (returns an `AsyncIterator`):
+
+```ts
+for await (const entry of store.list({ paginate: true })) {
+  console.log(entry.blobs);
+}
+```
+
+Hierarchical listing — group keys with `/`, set `directories: true` to list one level, and use a **trailing slash** on `prefix` to drill in (without it, `cats` would also match `catsuit`):
+
+```ts
+const { blobs, directories } = await store.list({ directories: true });      // top level
+const catList = await store.list({ directories: true, prefix: "cats/" });    // inside cats/
+```
+
+### List stores
+
+```ts
+const { stores } = await listStores();   // does NOT include deploy-specific stores
 ```
 
 ### Delete
 
-```typescript
-await store.delete("key");
+```ts
+await store.delete(key);                       // resolves undefined
+const { deletedBlobs } = await store.deleteAll(); // deletes the whole store; 0 if it didn't exist
 ```
 
-### List
+### Build plugin — write to a deploy-specific store
 
-```typescript
-const { blobs } = await store.list();
-// blobs: [{ etag: string, key: string }, ...]
+Build plugins can **READ from any of the site's stores, but can WRITE only to deploy-specific stores** (`getDeployStore`).
 
-// Filter by prefix
-const { blobs } = await store.list({ prefix: "uploads/" });
+```js
+import { readFile } from "node:fs/promises";
+import { getDeployStore } from "@netlify/blobs";
+import { v4 as uuid } from "uuid";
+
+export const onPostBuild = async () => {
+  const file = await readFile("some-file.txt", "utf8");
+  const uploads = getDeployStore("file-uploads");
+  await uploads.set(uuid(), file);
+};
 ```
 
-`store.list()` **auto-paginates**: a plain `await store.list()` transparently fetches every page and returns the complete `blobs` array — you do NOT hand-roll page cursors or offsets. For a very large store, pass `{ paginate: true }` to get an async iterator and stream results a page at a time instead of buffering every key in memory:
+### Client-side expiration (no server-side TTL)
 
-```typescript
-for await (const page of store.list({ paginate: true })) {
-  for (const { key } of page.blobs) {
-    // handle each key
-  }
+Blobs have no TTL. Store a timestamp in metadata, check it on read, and `delete` when expired:
+
+```ts
+await uploads.set(key, await req.text(), {
+  metadata: { expiration: new Date("2024-01-01").getTime() }
+});
+const entry = await uploads.getWithMetadata(key);
+const { expiration } = entry.metadata;
+if (expiration && expiration < Date.now()) {
+  await uploads.delete(key);
 }
 ```
 
-Pass `{ directories: true }` to group keys by the `/` delimiter (folder-style): the result's `blobs` holds keys at the current level and `directories` holds the common prefixes, which you drill into with `prefix`. Keys are a flat namespace — `/` is only a naming convention that `prefix` and `directories` let you navigate.
+### Conditional read with ETag (`getWithMetadata`)
 
-## Store Types
-
-- **Site-scoped** (`getStore()`): Persist across all deploys. Use for most cases.
-- **Deploy-scoped** (`getDeployStore()`): Tied to a specific deploy lifecycle.
-
-**A site-scoped store is shared across ALL deploy contexts.** Production, deploy previews, and branch deploys all read and write the *same* `getStore()` store — unlike Netlify Database, which forks a separate branch per preview, Blobs does not isolate previews. Code running on a deploy preview reads, overwrites, and deletes the same production data. Don't run destructive tests or seed throwaway data against a `getStore()` store from a preview — it hits production. When you need per-context isolation, use `getDeployStore()`, or partition by deploy context with a context-specific store `name` or key prefix.
-
-## Consistency and concurrency
-
-Blobs are **eventually consistent by default**: an immediate read right after a write may return the previous value or `null`. Opt into **strong** consistency when you need read-your-writes. You can set it once on the store, or request it per read:
-
-```typescript
-import { getStore } from "@netlify/blobs";
-
-const store = getStore({ name: "my-store", consistency: "strong" });
-
-// or just for a single read that must see the latest write:
-const fresh = await store.get("key", { consistency: "strong" });
+```ts
+const { data, etag } = await uploads.getWithMetadata("my-key", { etag: cachedETag });
+if (etag === cachedETag) {
+  // data is null — cached copy still fresh
+}
 ```
 
-Strong reads are **slower** than eventual reads, so don't make everything strong "to be safe" — reserve it for the reads that genuinely need the latest write (typically a read right after a write in the same request). For read-heavy access to data that rarely changes, the default eventual consistency is faster and is the right choice.
+`getWithMetadata` returns `{ data, etag, metadata }`, or `null` if the key is absent. `getMetadata(key)` returns `{ metadata, etag }` (no blob body) — use it to check existence cheaply.
 
-Blobs has **no concurrency control**: there is no locking and there are no transactions, and concurrent writes to the same key are **last-write-wins** — one silently overwrites the other. Do NOT build counters, balances, or any read-modify-write logic over a single blob key and expect it to be correct under concurrent traffic (two requests can both read the old value and both write back, losing an update). When you need atomic or transactional updates, use Netlify Database (see `netlify-database/SKILL.md`), which provides real transactions — not Blobs.
+## API surface
 
-## Limits
+Store instance methods:
+- `set(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`. `value` is `ArrayBuffer | Blob | string`.
+- `setJSON(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`.
+- `get(key, { consistency, type })` → blob in requested format, or `null`.
+- `getWithMetadata(key, { consistency, etag, type })` → `{ data, etag, metadata }` or `null`.
+- `getMetadata(key, { consistency, etag })` → `{ metadata, etag }` or `null`.
+- `list({ directories, paginate, prefix })` → `{ blobs, directories }` (auto-paginates unless `paginate: true`).
+- `delete(key)` → `undefined`.
+- `deleteAll()` → `{ deletedBlobs }`.
 
-| Limit | Value |
-|---|---|
-| Max object size | 5 GB |
-| Metadata per object | 2 KB |
-| Store name max length | 64 bytes |
-| Key max length | 600 bytes |
+Module functions:
+- `listStores({ paginate })` → `{ stores }`. Excludes deploy-specific stores.
 
-Object metadata is capped at **2 KB per object** — it's for small descriptors (content type, size, timestamps, a status flag), not a place to stash large JSON. Anything bigger belongs in the blob value itself, not in `metadata`.
+## Configuration
 
-## Local Development
+### Consistency
+Default is **eventual**: writes are globally readable immediately; updates and deletes propagate within **60 seconds**. Opt into **strong** consistency per store or per read:
 
-Local dev uses a sandboxed store (separate from production). For Vite-based projects, install `@netlify/vite-plugin` to enable local Blobs access. Otherwise, use `netlify dev`.
-
-**Common error**: "The environment has not been configured to use Netlify Blobs" — install `@netlify/vite-plugin` or run via `netlify dev`.
-
-## Inspecting blobs from the CLI
-
-The Netlify CLI can read and write blobs directly — useful for debugging, seeding, or a one-off fix without writing and deploying a function:
-
-```bash
-netlify blobs:list <store-name>
-netlify blobs:get <store-name> <key>
-netlify blobs:set <store-name> <key> <value>
-netlify blobs:delete <store-name> <key>
+```ts
+const store = getStore({ name: "animals", consistency: "strong" }); // whole store
+await store.get("dog", { consistency: "strong" });                  // single read
 ```
 
-These act on the linked site's store, so link the project first (`netlify link`). Reach for these documented subcommands for manual inspection or repair rather than the raw API.
+The CLI always uses strong consistency.
 
-## Uploading blobs at build time
+### Regions (deploy-specific stores)
+Deploy-specific stores default to the function's region. Override with `region`:
 
-You don't have to write blobs from runtime code — you can seed a store during the build by writing files into a special directory. Files placed in `.netlify/blobs/deploy/` during the build are uploaded to a **deploy-scoped** store and are then readable at runtime via `getDeployStore()`. The path under that directory becomes the blob key (so `.netlify/blobs/deploy/products/1.json` is stored under the key `products/1.json`). This avoids a runtime function looping over `store.set` on a cold start.
+```ts
+const uploads = getDeployStore({ name: "file-uploads", region: "ap-southeast-2" });
+```
 
-To attach metadata to a build-time blob, add a JSON sidecar whose name is the blob's filename prefixed with `$` and suffixed with `.json` — metadata for `logo.png` goes in `$logo.png.json`. Read these blobs back with `getDeployStore()`, not `getStore()`: they live in the deploy-scoped store and are replaced when the deploy is replaced.
+Available regions: https://docs.netlify.com/build/functions/configuration#region
 
-## When a store operation fails
+### File-based uploads (no build plugin)
+Place blob files under `.netlify/blobs/deploy/` in the site's base directory; Netlify uploads them to deploy-specific stores (preserving directory structure) after build, before deploy.
 
-If a `get`/`set` call throws in a deployed function, don't guess at a fix or route around it — the exact error is in the **function logs**, and it almost always names the cause. Read it first. Common causes: the store isn't reachable from the calling context, a missing or mismatched store `name`, or a read-after-write timing gap (an immediate read of a just-written key — use `consistency: "strong"` when you need read-your-writes).
+- Attach metadata with a sibling JSON file prefixed with `$`: `$mouse.jpg.json` for `mouse.jpg`, `dogs/$good-boy.jpg.json` for `dogs/good-boy.jpg`.
+- Metadata files must be valid JSON or **the deploy fails**.
+- `.netlify/blobs/deploy` is **wiped before each build** — files must be created DURING the build (build command or plugin). Files committed to the repo beforehand are NOT uploaded.
+- Requires continuous deployment or CLI deploys.
 
-The store exposes only the documented methods above; there is no lower-level REST endpoint to fall back on. If the logs don't resolve it, report the exact error plus the affected site/deploy to the user and stop. Reaching around a failing store — direct `https://api.netlify.com/...` calls, reading auth tokens off disk, or inventing endpoints — can't work (those aren't supported surfaces) and risks corrupting or losing the very data you're trying to save.
+## Constraints & gotchas
+
+- **Store names:** no `/`, no `:`, max 64 bytes.
+- **Keys:** non-empty, cannot start with `/`, max 600 bytes, any Unicode. (UTF-8: most chars 1 byte, some more, e.g. `à` = 2 bytes.)
+- **Sizes:** object ≤ 5 GB; metadata ≤ 2 KB.
+- **Pagination pages:** `list` and `listStores` cap pages at 1,000 entries/stores.
+- **Last write wins** — no concurrency control beyond `onlyIfMatch` / `onlyIfNew`.
+- **Go Functions cannot access Blobs.**
+- **Local dev (Netlify Dev)** uses a sandboxed local store: no file-based uploads, and you cannot read production data.
+- **Not supported** under Netlify's HIPAA-compliant hosting.
+- Deploy deletion cleans up deploy-specific stores only; other stores need manual deletion or your own expiration logic.
+- Downloading a deploy does NOT include deploy-specific blobs; locking a published deploy does NOT prevent writes to its deploy-specific stores.
+- Encrypted at rest and in transit; blobs are reachable only through your own site.
+
+## When something fails
+Surface the error and read the function logs. Do not invent REST endpoints or side-channel APIs to retry a failed store operation.
+
+## CLI & migration
+Inspect blobs with `netlify blobs:list` / `:get` / `:set` / `:delete` — reference: https://cli.netlify.com/commands/blobs/
+
+If you wrote to site-wide stores with `@netlify/blobs` ≤ 6.5.0, data becomes inaccessible after upgrading (namespacing change). Migrate with the latest CLI, which makes the store accessible on 7.0.0+:
+
+```sh
+netlify recipes blobs-migrate YOUR_STORE_NAME
+```
+
+<!-- system: agent-context/blobs/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (blobs)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Blobs is not a database. For dynamic, per-user, or transactional data,
+   use Netlify DB — Blobs is for objects, files, and cache-like state.
+2. When a store operation fails, surface the error and read the function
+   logs — do not invent REST endpoints or side-channel APIs to retry.
+3. `netlify blobs:list/get/set/delete` exist for inspection; the CLI
+   reference is their source of truth — link, don't restate.
+4. Blobs have no built-in access control — the serving function is the gate.
+   When in doubt, default to private: gate reads behind an authenticated
+   function rather than exposing blobs publicly.
+5. Site-scoped stores are shared across ALL deploy contexts — code on a
+   deploy preview reads, overwrites, and deletes production data. Never run
+   destructive tests or seed throwaway data from previews; use
+   `getDeployStore()` or a context-specific store name for isolation.
+6. Don't build counters, balances, or read-modify-write logic on a blob key —
+   even with `onlyIfMatch` retries. That's transactional data; use Netlify DB.
+7. Build plugins: state BOTH halves — they can read from any of the site's
+   stores, but write only to deploy-specific stores (`getDeployStore`).

--- a/codex/skills/netlify-caching/SKILL.md
+++ b/codex/skills/netlify-caching/SKILL.md
@@ -1,186 +1,311 @@
 ---
 name: netlify-caching
-description: Guide for controlling caching on Netlify's CDN. Use when configuring cache headers, setting up stale-while-revalidate, implementing on-demand cache purge, or understanding Netlify's CDN caching behavior. Covers Cache-Control, Netlify-CDN-Cache-Control, cache tags, durable cache, and framework-specific caching patterns.
+description: Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add caching or cache-control headers to a function response, tune cache TTL or stale-while-revalidate, set up the durable cache, vary a cache key by query/header/cookie/country/language, purge or invalidate the cache by site or cache tag, use the programmatic Cache API (caches.open/match/put) or @netlify/cache helpers (fetchWithCache/cacheHeaders/getCacheStatus), speed up an expensive API call, add ISR or on-demand revalidation, or debug why a response is or isn't cached via the Cache-Status header.
 ---
 
-# Caching on Netlify
+# Netlify caching
 
-## Default Behavior
+## Cache-control header to reach for
 
-**Static assets** are cached automatically:
-- CDN: cached for 1 year, invalidated on every deploy
-- Browser: always revalidates (`max-age=0, must-revalidate`)
-- No configuration needed
+Dynamic responses (Functions, Edge Functions, proxies) are **NOT cached by default** — you must opt in. Set `Netlify-CDN-Cache-Control` on the response:
 
-**Dynamic responses** (functions, edge functions, proxied) are **not cached by default**. Add cache headers explicitly.
+```ts
+import type { Context } from "@netlify/functions";
 
-**Only `GET` requests are cached.** Netlify's CDN caches responses to `GET` requests only. Responses to `POST`, `PUT`, `PATCH`, `DELETE`, and other non-`GET` methods are never cached, no matter what cache headers you set on them. If a response needs to be CDN-cacheable, expose it on a `GET` route (put the inputs in the URL/query string) — you cannot make the CDN cache a mutating `POST` endpoint by adding cache headers.
-
-## Cache-Control Headers
-
-Three headers control caching, from most to least specific:
-
-| Header | Who sees it | Use case |
-|---|---|---|
-| `Netlify-CDN-Cache-Control` | Netlify CDN only (stripped before browser) | CDN-only caching |
-| `CDN-Cache-Control` | All CDN caches (stripped before browser) | Multi-CDN setups |
-| `Cache-Control` | Browser and all caches | General caching |
-
-### Common Patterns
-
-```typescript
-// Cache at CDN for 1 hour, browser always revalidates
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, s-maxage=3600, must-revalidate",
-    "Cache-Control": "public, max-age=0, must-revalidate",
-  },
-});
-
-// Stale-while-revalidate (serve stale for 2 min while refreshing)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=120",
-  },
-});
-
-// Durable cache (shared across edge nodes, serverless functions only)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, durable, max-age=60, stale-while-revalidate=120",
-  },
-});
-```
-
-### Immutable Assets
-
-For fingerprinted files (hash in filename):
-
-```toml
-# netlify.toml
-[[headers]]
-for = "/assets/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-```
-
-## Cache Tags and On-Demand Purge
-
-Tag responses for selective cache invalidation:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-Tag": "product,listing",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
-```
-
-Purge by tag:
-
-```typescript
-import { purgeCache } from "@netlify/functions";
-
-export default async () => {
-  await purgeCache({ tags: ["product"] });
-  return new Response("Purged", { status: 202 });
+export default async (req: Request, context: Context) => {
+  return new Response("Hello world", {
+    headers: {
+      'Netlify-CDN-Cache-Control': 'public, durable, max-age=60, stale-while-revalidate=120'
+    }
+  });
 };
 ```
 
-Purge entire site:
+Header choice (most specific wins; `CDN-Cache-Control`/`Cache-Control` always pass downstream):
+- `Netlify-CDN-Cache-Control` — Netlify CDN only. **Reach for this.**
+- `CDN-Cache-Control` — all CDNs that support it.
+- `Cache-Control` — any CDN or the browser.
 
-```typescript
-await purgeCache();
+**Legacy path to avoid:** On-demand Builders do **not** support these headers or `Netlify-Vary` — they use a TTL pattern and key on URL path only. Don't reach for ODBs in new code.
+
+## Footguns (read first)
+
+- **Only `GET` is cached.** POST/PUT/etc. are never cached regardless of headers — expose cacheable data on a GET route (inputs in the URL or query string).
+- **`netlify dev` does not emulate the CDN cache.** A local cache miss every time is expected. Verify caching on a deployed URL (Deploy Preview or production) via its `Cache-Status` header.
+- **Without `Netlify-Vary: query=...`, the full query string is the cache key** — every distinct query string (`utm_*`, `fbclid`, …) is a separate cache entry. Enumerate only the params that change the response.
+- **Static assets are fresh for up to a year** — a shorter `max-age` is ignored. They change only on a new deploy or manual purge.
+- **basic-auth on ANY page disables caching for the ENTIRE site.**
+- **`durable` is serverless-only** — it has no effect on Edge Function responses.
+- Never opt sensitive content out of automatic invalidation — it can stay publicly cached after deploys/firewall changes.
+
+## Directives
+
+- `public` cache it / `private` browser-only, not Netlify's shared cache / `no-store` don't cache.
+- `s-maxage=N` seconds in Netlify's shared cache (overrides `max-age` there).
+- `max-age=N` seconds in any cache.
+- `stale-while-revalidate=N` serve stale for N seconds after expiry while revalidating in background.
+- `durable` (serverless only) store in Netlify's durable cache so other edge nodes reuse it instead of re-invoking the function.
+
+Defaults when no header is set — static: `Netlify-CDN-Cache-Control: public, s-maxage=31536000, must-revalidate`; dynamic: `Cache-Control: public, max-age=0, must-revalidate`.
+
+## Cache key variation — `Netlify-Vary`
+
+Comma-delimited instructions on the response; pipe-delimited value lists:
+
+```
+Netlify-Vary: query=item_id|page, country=es+de|us, cookie=ab_test|is_logged_in
 ```
 
-`purgeCache()` picks up the site ID and credentials automatically **only when it runs inside a deployed Netlify Function**. Called from anywhere else — a local script, a CI job, a build step, or any code outside the Netlify Functions runtime — it has no ambient credentials, and you must pass a Netlify personal access token (and the site ID). Read the token from an environment variable; never hardcode it:
+- `query=a|b` subset, or bare `query` for all params. Keys case-sensitive; param order irrelevant.
+- `header=Device-Type|App-Version` — custom + most standard headers.
+- `language=en|es+pt` — `+` groups; checked against `Accept-Language` with quality weighting.
+- `country=us|es+pt` — GeoIP, ISO 3166-1 two-letter codes; `+` groups.
+- `cookie=ab_test|is_logged_in` — target specific keys, not the whole `Cookie` header.
 
-```typescript
-await purgeCache({
-  token: process.env.NETLIFY_PURGE_TOKEN, // a Netlify personal access token, from env
-  siteID: process.env.NETLIFY_SITE_ID,
-  tags: ["product"],
-});
+**Cannot vary by header on:** `Accept*`, `Cache-Control`, `Connection`, `Content-Length`, `Cookie`, `Host`, `If-*`, `Range`, `Referer`, `Upgrade`, `User-Agent`. For language/cookie/format use `Vary: Accept-Language`/`Vary: Cookie` or the specific `Netlify-Vary` instruction.
+
+**Consistency rule:** a URL must return the same `Netlify-Vary` on every response — the first cached response's instructions win and later ones are ignored. `Netlify-Vary` + standard `Vary` are both respected (use `Vary` for format/encoding, and to pass instructions to an upstream CDN like Cloudflare).
+
+## Cache tags & opt-out
+
+Tag responses for taggable purging:
+
+```
+Netlify-Cache-Tag: tag1,tag2,tag3
 ```
 
-`Netlify-Cache-Tag` is **purge-only**: tagged responses are still cleared by automatic deploy-based invalidation like everything else. The tag only lets you purge them on demand between deploys.
+- `Netlify-Cache-Tag` (Netlify CDN) wins over `Cache-Tag` (passed downstream). Some providers strip `Cache-Tag` — set both when proxying through them.
+- Constraints: case-insensitive, UTF-8 only, ≤1024 chars/tag, ≤500 tags/response.
 
-### Surviving deploys with `Netlify-Cache-ID`
+Opt a response out of automatic atomic-deploy invalidation with `Netlify-Cache-ID` (comma-separated; auto-registered as cache tags for purging; separate 500-ID limit):
 
-To keep a cached response *across* deploys, set a `Netlify-Cache-ID` header. A response carrying it is **excluded from automatic deploy-based invalidation** — it persists across deploys and clears only on explicit purge. The `Netlify-Cache-ID` value also auto-registers as a purge tag, so you purge it by that same id:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-ID": "catalog",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
+```
+Netlify-Cache-ID: cms-proxy,product,image
 ```
 
-```typescript
+After opting out, purge on-demand after relevant changes (e.g. redirect/proxy or function changes behind a `Netlify-Cache-ID`).
+
+## On-demand invalidation (purge)
+
+Purge from a **deployed function** with `purgeCache` (site ID is passed automatically):
+
+```ts
 import { purgeCache } from "@netlify/functions";
 
-// Purge by the same id — it doubles as a purge tag.
-await purgeCache({ tags: ["catalog"] });
+export default async () => {
+  await purgeCache(); // no args = purge everything for the site
+  return new Response("Purged!", { status: 202 });
+};
 ```
 
-## Cache Key Variation
+Purge by tag, optionally targeting a deploy/subdomain:
 
-`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
+```ts
+import { purgeCache } from "@netlify/functions";
 
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Vary": "cookie=ab_test|is_logged_in",
-  },
+export default async (req: Request) => {
+  const cacheTag = new URL(req.url).searchParams.get("tag");
+  if (!cacheTag) return;
+  await purgeCache({
+    tags: [cacheTag],
+    deployAlias: "deploy-preview-11",
+    domain: "early-access.company.com",
+  });
+  return new Response("Purged!", { status: 202 });
+};
+```
+
+**Ambient credentials only work inside a deployed function.** From CI, local scripts, or the build, pass `token` (a personal access token read from an env var — never hardcoded) and `siteID`.
+
+**Lambda-compatible functions** use the legacy `module.exports.handler = async (event, context) => {…}` signature and must pass `context.clientContext.custom.purge_api_token`:
+
+```ts
+import { purgeCache } from "@netlify/functions";
+
+module.exports.handler = async (event, context) => {
+  const token = context.clientContext.custom.purge_api_token;
+  await purgeCache({ tags: ["tag1", "tag2"], token });
+  return { body: "Purged!", statusCode: 202 };
+};
+```
+
+Direct API (from outside a function) — `POST https://api.netlify.com/api/v1/purge` with `Authorization: Bearer <personal_access_token>` and `Content-Type: application/json`:
+
+```sh
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <personal_access_token>" \
+  --data '{"site_slug": "mysitename", "cache_tags": ["news"], "deploy_alias": "deploy-preview-11", "domain": "early-access.company.com"}' \
+  'https://api.netlify.com/api/v1/purge'
+```
+
+- Purge by site: `site_id` or `site_slug`. By tag: `cache_tags` + site. Omitting `cache_tags` purges the whole site; an **empty** `cache_tags` list purges NOTHING.
+- Identifier mapping: in the UI (Project configuration > General > Project details), **Project ID** = `site_id`, **Project name** = `site_slug`. See https://docs.netlify.com/api-and-cli-guides/api-guides/get-started-with-api#get-site.
+- **Rate limit:** each tag or site can be purged only twice per 5s — exceeding returns `429`.
+
+## Cache API (`caches` global)
+
+Programmatic read/write of HTTP responses from Functions/Edge Functions. Use for caching individual components of a route or arbitrary fetches, alongside header-based route caching.
+
+**Scope rule:** `caches.open()` anywhere, but `match`/`put`/`delete` **only inside the request handler** — doing them at module/global scope throws.
+
+```ts
+import type { Config, Context } from "@netlify/functions";
+
+const cache = await caches.open("my-cache"); // ok in global scope
+
+export default async (req: Request, context: Context) => {
+  const request = new Request("https://example.com/expensive-api");
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const fresh = await fetch(request);
+  if (fresh.ok) {
+    cache.put(request, fresh.clone()).catch((error) => {
+      console.error("Failed to add to the cache:", error);
+    });
+  }
+  return fresh;
+};
+
+export const config: Config = { path: "/cache-api-example" };
+```
+
+`CacheStorage` subset:
+- `caches.match(request)` → `Response` from any cache, or `undefined`.
+- `caches.open(name)` → `Cache`. Distinct names fragment the cache and lower hit ratio — use few, meaningful names.
+
+`Cache` methods (all require `caches.open()`):
+- `cache.match(request)` → `Response` | `undefined`.
+- `cache.put(request, response)` → adds a response.
+- `cache.add(request)` / `cache.addAll(requests)` → fetch + store.
+- `cache.delete(request)` → `true`.
+- `keys()` is **not implemented** — no way to list contents.
+
+Consistency: reads/writes strongly consistent; **deletes eventually consistent** (a deleted entry may still return briefly).
+
+**Cannot cache:** partial responses (206), `Vary: *`, or non-`GET` methods. Responses need a cache-control header with `max-age`/`s-maxage` ≥ 1s, `public` (not `private`/`no-cache`/`no-store`), and a 2xx status — otherwise storage errors. For responses you don't control, rewrite headers with `fetchWithCache`.
+
+**Limits per invocation:** 100 lookups, 20 insertions/deletions. Exceeding: further lookups return nothing; writes/deletes no-op. Limits are shared across edge functions in a request but separate between serverless and edge functions. Cache data is per-region (not replicated), auto-invalidated on redeploy and on `max-age`/`s-maxage` expiry.
+
+## `@netlify/cache` module
+
+Install to get helpers, time constants (`MINUTE`/`HOUR`/`DAY`), and a `caches` export for local dev:
+
+```
+npm install @netlify/cache
+```
+
+**Local-dev workaround:** the `caches` global isn't part of Node.js. Netlify provides it in its Functions/Edge runtimes (live and under `netlify dev`), but if you run your framework's own dev server the global is undefined and throws — import it instead:
+
+```ts
+import { caches } from "@netlify/cache";
+const cache = await caches.open("my-cache");
+```
+
+Requires Netlify CLI 20.0.3+; nothing persists locally (lookups return nothing, writes/deletes don't mutate). No functional change from the global.
+
+### `cacheHeaders(settings)` → header object
+
+```ts
+import { cacheHeaders, DAY } from "@netlify/cache";
+
+const headers = {
+  "x-custom-header": "some value",
+  ...cacheHeaders({
+    ttl: 2 * DAY,          // s-maxage
+    swr: HOUR,             // stale-while-revalidate
+    durable: true,
+    tags: ["product", "sale"],
+    overrideDeployRevalidation: ["tag"], // opt out of atomic-deploy invalidation
+    vary: {
+      cookie: ["ab_test_name", "ab_test_bucket"],
+      query: ["item_id", "page"], // or true for all
+      country: ["us", ["es", "pt"]], // nested = OR
+      language: ["en"],
+      header: ["Device-Type"],
+    },
+  }),
+};
+```
+
+For only generic (non-Netlify) headers, use the `cdn-cache-control` npm module instead.
+
+### `fetchWithCache(resource, options?, cacheSettings?)`
+
+Drop-in `fetch` that returns a cached response or fetches, stores, and returns. `cacheSettings` override conflicting response headers; with `swr`, background revalidation is handled automatically.
+
+```ts
+import { fetchWithCache, DAY } from "@netlify/cache";
+
+const response = await fetchWithCache("https://example.com/expensive-api", {
+  ttl: 2 * DAY,
+  tags: ["product", "sale"],
+  vary: { cookie: ["ab_test_name"], query: ["item_id", "page"] },
 });
 ```
 
-- `query=param1|param2` — key on the named query parameters
-- `header=X-Custom` — key on the named request header
-- `cookie=ab_test|is_logged_in` — key on the named cookies
-- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
-- `language=en|fr` — key on the listed `Accept-Language` values
+### `getCacheStatus(response | headers | headerString)`
 
-Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
+Returns `{ hit, caches: { durable: { hit, stale, stored, ttl }, edge: { hit, stale } } }`.
 
-## Framework-Specific Caching
-
-### Next.js
-ISR uses Netlify's durable cache automatically (runtime 5.5.0+). `revalidatePath` and `revalidateTag` trigger cache purge.
-
-### Astro / Remix
-Full control over cache headers in server routes. Set `Netlify-CDN-Cache-Control` in responses for CDN caching.
-
-### Nuxt
-Default Nitro preset handles caching. ISR-style patterns use `routeRules` with `swr` or `isr` options.
-
-### Vite SPA
-Static assets are cached by default. API responses from Netlify Functions need explicit cache headers.
-
-**The full query string is part of the cache key by default.** With no `Netlify-Vary: query=` directive, every distinct query string is cached as a separate entry — so appending tracking or marketing params (`?utm_source=…`, `fbclid`, and the like) silently fragments the cache into many near-duplicate entries and lowers the hit rate, even when those params don't change the response. Add `Netlify-Vary: query=<names>` listing only the parameters that actually affect the output; the CDN then keys on just those and ignores all other query params, collapsing the variants onto one cache entry.
-
-## Local Development
-
-`netlify dev` does not emulate the CDN cache. Header-based CDN caching is only observable on a deployed site: locally, cache headers pass through untouched, nothing is stored in or served from the CDN cache, Cache-API reads return no persisted entries, and the `Cache-Status` response header is absent. A "cache miss every time" on `localhost` is expected, not a bug — you cannot validate `Netlify-Vary` keying, cache tags, durable cache, or purge behavior locally. Verify caching on a deployed URL instead (a Deploy Preview or production) and read its `Cache-Status` header.
-
-## Debugging
-
-Check the `Cache-Status` response header. Netlify emits it in the RFC 9211 format — one entry per named cache layer the request passed through, not a bare `HIT`/`MISS`:
-
-```
-Cache-Status: "Netlify Edge"; fwd=miss, "Netlify Durable"; hit; ttl=3600
+```ts
+const { hit, edge, durable } = getCacheStatus(response);
 ```
 
-- A named layer (`"Netlify Edge"`, `"Netlify Durable"`) with `hit` — served from that cache
-- `fwd=miss` — the entry was not in that layer, so the request was forwarded onward
-- `ttl=…` — remaining freshness (seconds) for a hit
+### `needsRevalidation(response)` → boolean
 
-## Constraints
+Only needed when calling `cache.match`/`cache.put` directly (not with `fetchWithCache`+`swr`). True when a Cache-API response is stale within its SWR window — return it, then revalidate in `context.waitUntil` and `cache.put` the fresh copy:
 
-- Basic auth disables caching for the entire site
-- Durable cache is serverless functions only (not edge functions)
-- Same URL must return identical `Netlify-Vary` headers across responses
-- Deploy invalidation is scoped to deploy context (production vs preview)
+```ts
+if (cached) {
+  if (needsRevalidation(cached)) {
+    context.waitUntil(
+      fetch(request).then((fresh) => {
+        const response = new Response(fresh.body, {
+          headers: { ...Object.fromEntries(fresh.headers), ...cacheHeaders({ ttl: MINUTE, swr: HOUR }) },
+        });
+        return cache.put(request, response);
+      })
+    );
+  }
+  return cached;
+}
+```
+
+## Durable cache
+
+Add `durable` (serverless only) so edge nodes lacking a local copy check the shared durable cache before invoking the function — fewer invocations, better cache-miss latency. Eventually consistent, so multiple regions may still invoke the function a few times per version. Co-located with the site's functions region. Works with `Netlify-Vary`, SWR, and on-demand invalidation. **Next.js:** Next Runtime 5.5.0+ uses the durable cache automatically.
+
+## Debugging with `Cache-Status`
+
+Netlify sets `Cache-Status` (RFC 9211) on all responses. Check it on a **deployed** URL. Look for values starting `"Netlify Edge"` or `"Netlify Durable"`:
+
+- `"Netlify Edge"; fwd=miss` — nothing cached.
+- `"Netlify Edge"; hit` — served from cache.
+- `"Netlify Edge"; hit; fwd=stale` — stale served while revalidating (SWR).
+- Durable stored on miss: `"Netlify Durable"; fwd=uri-miss; stored=true; ttl=3600`.
+- Durable hit: `"Netlify Durable"; hit; ttl=1234`.
+
+`ttl` negative = seconds since expiry. Each request may hit a different cache instance — without production traffic or `durable`, expect several empty caches before a hit; repeat requests to warm one.
+
+<!-- Gaps: package/method inconsistency in @netlify/cache local-dev docs (caches import shown with cache.set, not the documented cache.put) resolved to cache.put per Cache API surface. -->
+
+<!-- system: agent-context/caching/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (caching)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Only `GET` responses are cached by the CDN. `POST`/`PUT`/etc. are never
+   cached regardless of headers — expose cacheable data on a `GET` route
+   (put the inputs in the URL or query string).
+2. Without `Netlify-Vary: query=...`, the full query string is the cache key —
+   every distinct query string (`utm_*`, `fbclid`, ...) is a separate cache
+   entry. Enumerate only the params that actually change the response.
+3. `netlify dev` does not emulate the CDN cache — a cache miss every time
+   locally is expected, not a bug. Verify caching behavior on a deployed URL
+   (Deploy Preview or production) via its `Cache-Status` header.
+4. `purgeCache()` has ambient credentials only inside a deployed function.
+   From CI, local scripts, or the build, pass `token` (a personal access
+   token read from an env var, never hardcoded) and `siteID`.

--- a/codex/skills/netlify-config/SKILL.md
+++ b/codex/skills/netlify-config/SKILL.md
@@ -1,228 +1,302 @@
 ---
 name: netlify-config
-description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, the `[dev]` block that controls `netlify dev` (command, port, targetPort, framework), or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, edge functions config, and the `[dev]` block (including when `framework` must be `"#custom"` — required when both a custom `command` and `targetPort` are set).
+description: Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy contexts alongside environment variables/scopes and the Secrets Controller plus redirect/rewrite/proxy and custom-header rules. Use when setting a build command or publish directory, adding redirect or rewrite or proxy rules, configuring custom headers or basic auth, setting or scoping environment variables and secrets, wiring up a monorepo or SPA fallback, or skipping unnecessary builds. Reach for this whenever you touch netlify.toml or ask "why is my env var undefined in a function" or "how do I redirect this path".
 ---
 
-# Netlify Configuration (netlify.toml)
+# Netlify configuration
 
-Place `netlify.toml` at the repository root. In a monorepo, Netlify searches for the config and uses the **first** one it finds: the package directory (the subdirectory containing the site), then the base directory, then the repository root — so put a site-specific `netlify.toml` in the package directory to take precedence over root-level config (see the **netlify-deploy** skill's monorepo notes).
+`netlify.toml` lives at the repo root (or set `base`/package directory for monorepos). Settings in `netlify.toml` **override** the Netlify UI on conflict. `_headers` and `_redirects` are extensionless plain-text files in the **publish directory**, processed **before** `netlify.toml` rules.
 
-**`netlify.toml` takes precedence over the Netlify UI.** When the same property (build command, publish directory, an environment variable, a redirect, a header) is configured in both places, the value in `netlify.toml` wins and silently overrides the corresponding Netlify UI setting — the dashboard field still shows its old value but is inert. Once a `netlify.toml` is present, treat it as the source of truth and change settings there, not in the UI.
+## Footguns (read first)
 
-## Build Settings
+- **Env vars in `netlify.toml` are NOT available to functions or edge functions at runtime** — reading them there returns `undefined`. Vars declared in `netlify.toml` only get the **Builds** and **Post processing** scopes. Set runtime vars in the UI or with `netlify env:set`.
+- **Never put secrets in client-prefixed vars** (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, …) — they are inlined into the client bundle. `--secret` does not protect them.
+- **`.env` is not read by the Netlify build system** — import variables into Netlify first (`netlify env:import`). The CLI reads `.env` only for local builds.
+- **Direct env injection into `netlify.toml` (`key = "$VAR"`) is unsupported** — except signed proxy redirects. Use a build plugin or `sed` in the build command.
+- **`[[redirects]]` and `[[headers]]` are global** — NOT context-aware, cannot be scoped to branches/contexts. Workaround: per-context build command copies a custom file into the publish directory.
+- **Proxy rewrites time out at 26 seconds.** HTTP `307` is unsupported — use `302`.
+
+## `netlify.toml` — core structure
 
 ```toml
 [build]
-  base = "project/"          # Base directory (default: root)
-  command = "npm run build"  # Build command
-  publish = "dist/"          # Output directory
+  base = "project/"          # base directory
+  publish = "build-output/"  # relative to base, default /
+  command = "npm run build"  # runs in Bash shell
+  [build.environment]
+    NODE_VERSION = "18"
+
+[context.production]         # production branch deploy
+  command = "make publish"
+  environment = { NODE_VERSION = "14.15.3" }
+[context.deploy-preview]     # PR/MR previews
+  publish = "dist/"
+[context.branch-deploy]      # non-production branches
+  command = "echo branch"
+[context.dev.environment]    # local dev env vars ONLY
+  NODE_ENV = "development"
+[context.staging]            # a specific branch name
+  command = "echo staging"
+[context."feat/branch"]      # quote branches with special chars
+  command = "echo special"
 ```
 
-## Redirects
+Context precedence (least → most specific): UI settings < base context-aware key < `[context.production|deploy-preview|branch-deploy|dev]` < `[context.branchname]`. Only `[build]` and `[[plugins]]` are context-aware. All paths are absolute relative to the base directory (root `/` default).
 
-```toml
-# Basic redirect
-[[redirects]]
-from = "/old"
-to = "/new"
-status = 301              # 301 (default), 302, 200 (rewrite), 404
+Config file search order: package directory → base directory → root.
 
-# SPA catch-all
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
-
-# Splat (wildcard)
-[[redirects]]
-from = "/blog/*"
-to = "/news/:splat"
-
-# Path parameters
-[[redirects]]
-from = "/users/:id"
-to = "/api/users/:id"
-status = 200
-
-# Force (override existing files)
-[[redirects]]
-from = "/app/*"
-to = "/index.html"
-status = 200
-force = true
-
-# Proxy to external service
-[[redirects]]
-from = "/api/*"
-to = "https://api.example.com/:splat"
-status = 200
-[redirects.headers]
-  X-Custom = "value"
-
-# Country/language conditions
-[[redirects]]
-from = "/*"
-to = "/fr/:splat"
-status = 200
-conditions = { Country = ["FR"], Language = ["fr"] }
-```
-
-**Rule order matters** — Netlify processes the first matching rule. Place specific rules before general ones.
-
-Redirect rules can also live in a plain-text `_redirects` file in the publish directory. If both a `_redirects` file and `[[redirects]]` in `netlify.toml` exist, the `_redirects` file rules are processed **first**, then the `netlify.toml` rules, reading top to bottom — and the first matching rule wins. The same ordering applies to a `_headers` file versus `[[headers]]`. Because a `_redirects` rule can silently shadow a `netlify.toml` rule for the same path, keep overlapping rules in a single source.
-
-## Headers
-
-```toml
-[[headers]]
-for = "/*"
-[headers.values]
-  X-Frame-Options = "DENY"
-  X-Content-Type-Options = "nosniff"
-
-[[headers]]
-for = "/assets/*"
-[headers.values]
-  Cache-Control = "public, max-age=31536000, immutable"
-```
-
-Headers apply only to files served from Netlify's CDN (not to function or edge function responses — set those in code).
-
-## Deploy Contexts
-
-Override settings per deploy context:
-
-```toml
-[context.production]
-command = "npm run build"
-environment = { NODE_ENV = "production" }
-
-[context.deploy-preview]
-command = "npm run build:preview"
-
-[context.branch-deploy]
-command = "npm run build:staging"
-
-[context.dev]
-environment = { NODE_ENV = "development" }
-
-# Specific branch
-[context."staging"]
-command = "npm run build:staging"
-```
-
-**`[[redirects]]` and `[[headers]]` are global — they cannot be scoped to a deploy context.** Context tables like `[context.production]` work for keys such as `[build]`, `[build.environment]`, and `[[plugins]]`, but redirect and header rules apply to every context no matter where you place them in the file; there is no `[context.production.redirects]` or context-nested `[[redirects]]`. For context-specific redirects or headers, use the per-deploy escape hatch: generate a `_redirects` or `_headers` file during that context's build (those files ship per deploy), or gate the behavior on a runtime signal in an edge function.
-
-## Environment Variables
-
-```toml
-[build.environment]
-NODE_VERSION = "20"
-
-[context.production.environment]
-API_URL = "https://api.prod.com"
-
-[context.deploy-preview.environment]
-API_URL = "https://api.staging.com"
-```
-
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
-
-**Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
-
-### CLI Management
-
-```bash
-# Set
-netlify env:set API_KEY "value"
-netlify env:set API_KEY "value" --secret              # Hidden from logs
-netlify env:set API_KEY "value" --context production   # Context-specific
-
-# Get
-netlify env:get API_KEY
-
-# List
-netlify env:list
-netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
-
-# Import from file
-netlify env:import .env
-
-# Delete
-netlify env:unset API_KEY
-```
-
-**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
-
-### Context Scoping
-
-Variables set via the CLI can also be scoped to deploy contexts:
-
-```bash
-netlify env:set API_URL "https://api.prod.com" --context production
-netlify env:set API_URL "https://api.staging.com" --context deploy-preview
-netlify env:set DEBUG "true" --context branch:feature-x
-```
-
-This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
-
-When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
-
-For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-frameworks** skill; for function-side details, see **netlify-functions**.
-
-## Functions Configuration
+## Functions config
 
 ```toml
 [functions]
-directory = "netlify/functions"   # Default
-node_bundler = "esbuild"
+  directory = "functions/"           # default: YOUR_BASE_DIR/netlify/functions
+  node_bundler = "esbuild"           # prefer esbuild; zisi is the JS default
+  external_node_modules = ["package-1"]
+  included_files = ["files/*.md", "!files/skip.md"]
 
-# Scheduled function
-[functions."cleanup"]
-schedule = "@daily"
+[functions."api_*"]                  # glob filter; values CONCATENATE across matches
+  external_node_modules = ["package-2"]
 ```
 
-Use the single-table `[functions]` form for global settings and `[functions."name-or-glob"]` for per-function overrides. There is **no** `[[functions]]` array-of-tables and no path-based function routing table in `netlify.toml` — functions are routed by file (served at `/.netlify/functions/{name}`) or by an in-code `path`/`config` export, not by config.
+- `esbuild` = smaller/faster artifacts; TypeScript functions **always** use `esbuild`.
+- `external_node_modules` applies only with `esbuild`. `included_files`: `*` wildcard, `!` excludes; paths absolute to base.
 
-## Edge Functions Configuration
+## Environment variables
+
+Set runtime/scoped vars via CLI/UI/API (not `netlify.toml`):
+
+```sh
+netlify env:set MY_KEY value --secret     # --secret marks an env var secret
+netlify env:import .env                    # site-level, all scopes, all contexts
+netlify env:list --plain --context production > .env
+netlify env:unset MY_KEY
+```
+
+**Keep any `.env` snapshot gitignored — never commit it.**
+
+**Types:** site vars (one site) vs shared vars (whole team; Pro/Enterprise; Team Owners only).
+
+**Scopes** (Pro/Enterprise; default = all): **Builds**, **Functions** (also Edge Functions + On-demand Builders), **Runtime** (forms, signed proxy redirects), **Post processing** (snippet injection). Vars from `netlify.toml` are locked to **Builds** + **Post processing**.
+
+**Scope precedence is independent per scope:** a site variable scoped only to Builds does NOT shadow a shared variable for the Functions scope — the shared value still applies there. Site beats shared only within the scopes the site variable actually carries.
+
+**Deploy-context values:** `Production`, `Deploy Previews`, `Branch deploys` (override per-branch with a `Branch` value, wildcard suffix `release/*`), `Preview server`, `Local development`.
+
+**Overrides:** `netlify.toml` vars override same-key UI/CLI/API vars. Site var beats shared var per its scopes/contexts.
+
+**Limits:** keys ≤ 255 chars, alphanumeric + underscore, first char a letter (`KEY1` ok; `1KEY`/`_KEY1` invalid). Values ≤ 5,000 chars (functions within AWS limits). Reserved read-only names can't be overridden.
+
+### Build variables
+
+Settable in `netlify.toml` `[build.environment]`: `NODE_VERSION`, `NODE_ENV`, `NPM_VERSION`, `NPM_FLAGS`, `NPM_TOKEN`, `YARN_VERSION`, `PNPM_FLAGS`, `BUN_VERSION`, `RUBY_VERSION`, `PHP_VERSION`, `PYTHON_VERSION`, `GO_VERSION`, `HUGO_VERSION`, `NETLIFY_USE_YARN`, `CI`, etc.
+
+**Set in UI/CLI only (NOT `netlify.toml`, which is read after clone):** `AWS_LAMBDA_JS_RUNTIME`, `GIT_LFS_ENABLED`, `GIT_LFS_FETCH_INCLUDE`, `NETLIFY_BUILD_DEBUG`.
+
+Read-only build metadata (examples): `NETLIFY`, `BUILD_ID`, `CONTEXT` (`production`/`deploy-preview`/`branch-deploy`/`dev`), `BRANCH`, `HEAD`, `COMMIT_REF`, `CACHED_COMMIT_REF`, `PULL_REQUEST`, `REVIEW_ID`, `URL`, `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `DEPLOY_ID`, `SITE_NAME`, `SITE_ID`, `ACCOUNT_ID`.
+
+Access: Bash `$VAR_NAME` in build/ignore commands; `process.env.VAR_NAME` in Node scripts and plugins. Scope must include **Builds**.
+
+### Inject env values into headers/redirects
 
 ```toml
-[[edge_functions]]
-path = "/admin/*"
-function = "auth"
-excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
-
-# Import map for Deno URL imports
-[functions]
-deno_import_map = "./import_map.json"
+[build]
+  command = "sed -i \"s|HEADER_PLACEHOLDER|${PROD_API_LOCATION}|g\" netlify.toml && yarn build"
 ```
 
-## Dev Server
+Substitution only reaches `[[headers]]`/`[[redirects]]` (read after build); NOT available to build plugins. Alternatively mutate `netlifyConfig` in a local build plugin.
+
+## Redirects & rewrites
+
+`_redirects` (one rule per line) or `[[redirects]]`. Rules process top-down; first match wins. `_redirects`/file rules run before `netlify.toml`.
+
+```
+/home            /                301
+/my-redirect     /                302
+/store id=:id    /blog/:id        301
+/news/*          /blog/:splat
+/*               /index.html      200          # SPA fallback
+```
 
 ```toml
-[dev]
-command = "npm start"       # Dev server command
-port = 8888                 # Netlify Dev port
-targetPort = 3000           # Your app's dev server port
-framework = "#auto"         # "#auto", "#static", "#custom"
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 302              # default 301
+  force = true             # default false; shadow an existing URL
+  query = { id = ":id" }
+  conditions = { Language = ["en"], Country = ["US"], Role = ["admin"] }
+  [redirects.headers]
+    X-From = "Netlify"
 ```
 
-**If you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`.** With `framework = "#auto"` (the default) Netlify Dev runs its own detector and ignores your custom `command`; `"#custom"` tells it to run your `command` as the app server and connect to `targetPort`. Setting `command` + `targetPort` while leaving `framework` at `#auto` (or omitting it) is a silent misconfiguration.
+- **Force/shadow:** you can't shadow an existing URL by default — append `!` in `_redirects` or `force = true` in toml.
+- **Splats** (`*`) only at the end of a path segment (`/jobs/*.html` won't work). Can't exclude a path from a splat — order a more specific rule first.
+- **Query:** `id=:id` matches URLs with *only* `id` and no other params. List optional-param variants most-general-last.
+- **Trailing slash:** URLs are normalized before rules run; you cannot add/remove a trailing slash via a redirect (infinite loop). Pretty URLs (on by default) handle standardization.
+- **Country/Language conditions:** no spaces (`Country=au,nz`). `Country` = ISO 3166-1 alpha-2; `Language` = browser/locale codes, matches the FIRST `Accept-Language` entry. `nf_country`/`nf_lang` cookies override.
+- **Domain redirects:** HTTP and HTTPS need separate rules unless forcing SSL; the domain must be assigned to the site.
+- Role-based redirects with external auth: Enterprise only. HTTP `307` unsupported → use `302`.
+- **10,000+ redirects:** favor wildcards/placeholders; serialization across `_redirects` + `netlify.toml` can fail the deploy if too large — consider Edge Functions.
 
-## Plugins
+### Rewrites & proxies (status 200)
+
+```
+/api/*            https://api.example.com/:splat        200
+/netlify-site/*   https://my-other-site.netlify.app/:splat  200
+```
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  headers = { X-From = "Netlify" }
+```
+
+- No cross-team rewrites between Netlify sites. Infinite-loop rules (from == to) are ignored.
+- Internal rewrites limited to one hop. Proxy timeout **26s** — use async for longer. Rewrites break relative-path assets — use absolute paths or `<base>`.
+- Proxy to another Netlify site: use its `.netlify.app` subdomain. Rewrites into a separate password-protected site are not allowed.
+
+### Signed proxy redirects (`netlify.toml` only)
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  signed = "API_SIGNATURE_TOKEN_PLACEHOLDER"
+```
+
+Must be in `netlify.toml`; env var scope must include **Runtime**; not supported proxying Netlify→Netlify. Netlify sends the JWS as HMAC HS256 in the `x-nf-sign` header. (This is the one place `$VAR`-style env injection is allowed.)
+
+## Custom headers
+
+```
+/*
+  X-Frame-Options: DENY
+  cache-control: max-age=0
+  cache-control: no-cache          # multi-value collapses comma-joined
+```
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Basic-Auth = "someuser:somepassword anotheruser:anotherpassword"
+    cache-control = '''
+    max-age=0,
+    no-cache,
+    no-store'''
+```
+
+- **Headers apply only to files Netlify serves from its own store** — proxied content, functions, and edge/SSR pages must return their own headers.
+- Reserved header names Netlify controls (ignored if you set them): `Content-Length`, `Content-Encoding`, `Location` (use redirects), `Set-Cookie` (may be overridden), `Server`, `Date`, `Age`, `Connection`, `Transfer-Encoding`, etc.
+- Basic-Auth headers: Pro/Enterprise. Cross-subdomain cookies impossible on `*.netlify.app` (Public Suffix List) — needs a custom domain.
+- Global only; per-branch via the build-command copy workaround.
+
+## Secrets Controller
+
+Mark a var secret via `--secret` (CLI), `is_secret: true` (API), or the UI. Enforced, non-customizable policy:
+
+- Values are **write-only** — no readable version after setting; the flag can't be removed to reveal a value.
+- Must be set to explicit deploy contexts and scopes; **cannot** have the `post processing` scope.
+- Only code on Netlify reads unmasked values; outside code gets masked. The `dev` context value is unmasked and exempt.
+- Secret scanning (smart detection: Personal/Pro/Enterprise) runs on the next build after marking a var secret. Resolve a detection by removing the value at the location in the deploy log, then redeploy. Safelist false positives via `SECRETS_SCAN_SMART_DETECTION_OMIT_VALUES` (comma-separated), then redeploy.
+
+**Sensitive variable policy (public repos only):** untrusted deploys (unrecognized authors) default to **Require approval**; alternatives are **Deploy without sensitive variables** or **Deploy without restrictions**. Not available for GitHub Enterprise Server / GitLab self-managed (treated as private).
+
+## Ignore builds
+
+```toml
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/blog"
+```
+
+- Exit `0` = no changes, **build stops**; exit `1` = changed, build continues.
+- Runs from base directory; uses fixed **Node.js 18** (not customizable); site `package.json` deps unavailable. Referenced file paths must start with `./`.
+- Won't cancel a build triggered by a build hook, regardless of exit code.
+
+Node.js variant:
+```js
+// ignore_build.js — build only non-debug branches
+process.exitCode = process.env.BRANCH.includes("debug") ? 0 : 1
+```
+
+## JavaScript SPAs
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"        # varies by framework
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200            # required for pushState routing to avoid 404s
+```
+
+Hashed/code-split filenames + atomic deploys can break asset refs (`Uncaught SyntaxError: Unexpected token`) — disable hashed filenames, use permalinks, or a service worker.
+
+## Monorepos
+
+Recommended: set the site's subdirectory as the **package directory** (keep `netlify.toml` there), leave base directory at repo root `/`, declare deps at the subdirectory level.
+
+- **Package directory is UI-only** (Build settings > Configure) — it cannot be set in `netlify.toml`. Base directory can be set in root-level `netlify.toml` (`[build] base`) and overrides the UI.
+- Use absolute paths relative to base: base `/frontend` + plugin at `/frontend/packages/my-app/plugins` → specify `/packages/my-app/plugins/...`.
+- Build only on subdirectory changes with an `ignore` command. CLI: `--filter <site>`. Netlify caches all `node_modules` regardless of where deps are declared.
+
+## Plugins, extensions, dev, templates
 
 ```toml
 [[plugins]]
-package = "@netlify/plugin-lighthouse"
-[plugins.inputs]
-  audits = ["performance", "accessibility"]
+  package = "@netlify/plugin-lighthouse"
+  [plugins.inputs]
+    breeds = ["pomeranian"]
+
+[[integrations]]           # extensions; install on team first
+  name = "abc-performance-extension"
+  [integrations.config]
+    output_path = "reports/perf.html"
+
+[dev]                      # Netlify Dev — NOT run in Bash; no `environment` key here
+  command = "yarn start"
+  targetPort = 3000        # if command + targetPort both set, framework must be "#custom"
+  port = 8888
+  publish = "dist"
+  [dev.https]
+    certFile = "cert.pem"
+    keyFile = "key.pem"
 ```
 
-## Image CDN
+`[dev]` has **no `environment` property** — set local env vars in `[context.dev.environment]` instead. `framework` values: `#auto` (default), `#static`, `#custom`.
 
+For Deploy-to-Netlify buttons use `[template]` / `[template.environment]`.
+
+Post-processing pretty URLs:
 ```toml
-[images]
-remote_images = ["https://example\\.com/.*"]
+[build.processing.html]
+  pretty_urls = true
 ```
 
-See the **netlify-image-cdn** skill for full Image CDN usage.
+<!-- TOML syntax reference: https://toml.io/en/ · Netlify config docs: https://docs.netlify.com/build/configure-builds/file-based-configuration.md -->
+
+<!-- system: agent-context/config/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (config)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Env vars set in `netlify.toml` are NOT available to functions or edge
+   functions at runtime — reading them there returns `undefined`. Set
+   runtime vars in the UI or with `netlify env:set`, not `netlify.toml`.
+2. Never put secrets in client-prefixed env vars (`VITE_`, `NEXT_PUBLIC_`,
+   `PUBLIC_`, ...) — they are inlined into the client bundle; `--secret`
+   does not protect them.
+3. When snapshotting env vars locally (`netlify env:list --plain > .env`),
+   keep `.env` gitignored — never commit it.
+4. State env-var scope interaction explicitly: a site variable scoped to
+   Builds does not shadow the shared variable for other scopes — precedence
+   resolves independently per scope (site beats shared only within the
+   scopes the site variable actually carries).

--- a/codex/skills/netlify-database/SKILL.md
+++ b/codex/skills/netlify-database/SKILL.md
@@ -1,286 +1,78 @@
 ---
 name: netlify-database
-description: Guide for using Netlify Database — the GA managed Postgres product built into Netlify. Use when a project needs any kind of dynamic, structured, or relational data. Covers provisioning via @netlify/database, Drizzle ORM (@beta) setup, migrations, preview branching, and safe production data handling. Blobs is only for file/asset storage — any dynamic data belongs in the database.
+description: Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing schema migrations, setting up Drizzle ORM, local dev with netlify dev, database branches for deploy previews, and migrating an existing Postgres project onto Netlify. Use when adding a database, building a contact form or CRUD API, writing SQL migrations, wiring up Drizzle, running netlify database commands, testing with a local Postgres, or switching from Neon/Supabase/RDS to Netlify Database.
 ---
 
 # Netlify Database
 
-**Netlify Database** is the managed Postgres product built into the Netlify platform. It is **GA** and is the default choice for any dynamic data in a Netlify project.
+Zero-config managed Postgres. Install `@netlify/database`, write migrations under `netlify/database/migrations/`, deploy — Netlify provisions the DB and applies migrations automatically. Queryable from Functions, Edge Functions, Builds, and Agent Runners.
 
-Install `@netlify/database` and Netlify auto-provisions a Postgres database for the site at deploy time. Each deploy preview gets its own isolated branch forked from production data. No Neon account, connection-string wiring, or claim flow — the database is a first-class Netlify primitive.
+## Modern client (reach for this)
 
-## Database vs Blobs
-
-Use **Netlify Database** for anything dynamic:
-
-- Any user-generated or app-generated records (posts, comments, orders, sessions, audit logs)
-- Structured data that will grow, be queried, or be joined
-- Key-value-style data read or written by application code at runtime
-
-Use **Netlify Blobs** only for **file and asset storage**: images, documents, exports, uploads, cached binary artifacts. Do not use Blobs as a dynamic data store — reach for Database instead. See `netlify-blobs/SKILL.md`.
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any database code — answers shape the schema, the seed data, and the query layer:
-
-- **What entities does the app need?** (Users, posts, orders, sessions — drives the schema in `db/schema.ts`.)
-- **Any seed data for the prototype?** (Test rows, default roles, sample content — these become a DML migration, not ad-hoc `INSERT`s against production.)
-- **Drizzle (recommended) or native driver?** (Drizzle for type-safe queries and generated migrations; native for raw SQL or a different query builder like Kysely.)
-
-**If you don't have preferences here, tell me roughly what the app does and I'll pick sensible defaults** — typically Drizzle with timestamp-prefix migrations and a starter schema for the entities the prompt implies.
-
-## CRITICAL: Install Drizzle from the `@beta` dist-tag
-
-The Netlify Database adapter for Drizzle ORM currently only exists on the `beta` release line of `drizzle-orm`. Install **both** `drizzle-orm` and `drizzle-kit` from the `@beta` dist-tag:
-
-```bash
-npm install drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-The default `latest` versions do not include the `drizzle-orm/netlify-db` adapter and will fail. If `drizzle-kit generate` errors about being outdated, or the `drizzle-orm/netlify-db` import fails to resolve, the install is missing `@beta`.
-
-The `@beta` tag only affects the installed version — imports are written as `drizzle-orm`, `drizzle-orm/pg-core`, and `drizzle-orm/netlify-db` without modification.
-
-## CRITICAL: Use the Netlify CLI for database operations
-
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`) that replaces hand-rolled scripts and direct API/UI work. Reach for these commands first before writing custom tooling. **Requires Netlify CLI 26.0.0+** — if a `netlify database` subcommand isn't recognized, run `npm install -g netlify-cli@latest`.
-
-The corollary: **never go around the CLI**, even for read-only work. Don't run `psql`/`pg_dump` or any raw Postgres client (use `netlify database connect --query "..."`), don't curl `https://api.netlify.com/...`, don't read auth tokens off disk for side-channel calls, and don't use `netlify api <method>` as a recovery hatch when provisioning fails — the supported recovery is under [If the first deploy fails to provision the database](#if-the-first-deploy-fails-to-provision-the-database).
-
-If the documented happy path doesn't work, [surface the failure and stop](#when-something-fails-surface-and-stop) — don't escalate to lower-level tools. Full command reference is in [Netlify CLI commands](#netlify-cli-commands-for-netlify-database) below.
-
-## When something fails, surface and stop
-
-When a `netlify` command fails, a deploy fails to provision the database, or any documented happy path errors out, the right action is to **report the failure to the user** with the deploy log URL, the exact error, and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools.
-
-Specific failure modes (like the first-deploy 401) get their own playbooks below. The general rule applies everywhere: a stuck agent surfacing context is far safer than one that wanders off.
-
-## CRITICAL: Never apply migrations to a Netlify-hosted database
-
-The only database you ever apply migrations to yourself is the **local development DB**. For any Netlify-hosted database — production or a deploy preview branch — **Netlify applies migrations automatically during the deploy**. Your job is to create migration files and commit them. The deploy does the rest.
-
-This means:
-
-- Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
-- Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
-- Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
-
-The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
-
-## Not the legacy "Netlify DB" extension
-
-The older **Netlify DB** extension (Beta) is **deprecated**. It is a separate product and must not be confused with Netlify Database. Do not recommend or install it for new projects.
-
-| | Netlify Database (GA, recommended) | Netlify DB extension (deprecated Beta) |
-|---|---|---|
-| Package | `@netlify/database` | `@netlify/neon` |
-| Env var | `NETLIFY_DB_URL` | `NETLIFY_DATABASE_URL` |
-| Setup | `netlify database init` or install the package — auto-provisioned at deploy | Historically `netlify db init` on older CLI versions, with a claim into the user's Neon account; that flow is no longer reachable from the current CLI |
-| Status | GA | Deprecated; new creation blocked as of April 2026 |
-
-If an existing project is already using the `@netlify/neon` extension, keep it working and encourage the user to switch. See `references/legacy-extension.md` for recognition and coexistence, and `references/migration-from-extension.md` for the full switching process (also covers switching from other external Postgres providers).
-
-## Provisioning
-
-The fastest path is `netlify database init` — an interactive setup that installs `@netlify/database`, lets the user pick Drizzle or raw SQL, writes `drizzle.config.ts` if needed, scaffolds a starter migration, applies it locally, and runs a sample query end-to-end:
-
-```bash
-netlify database init           # interactive
-netlify database init --yes     # accept defaults — for CI/agents
-```
-
-If you'd rather wire things up by hand, install the package directly:
-
-```bash
-npm install @netlify/database
-```
-
-Either way, the presence of `@netlify/database` in the dependency tree triggers provisioning on the next deploy. A database can also be created manually from the Netlify UI before first deploy, but the package + deploy path is the supported automation flow.
-
-### Provisioning workflow: preview-first
-
-The supported inner loop is **preview-first**, not `--prod`-first:
-
-1. **First deploy: `netlify deploy`** (no `--prod`). This provisions the database if needed, applies any pending migrations to the production branch, and produces a draft URL. Verify the deploy log shows `Netlify Database setup completed in <n>s` (and, if migrations exist, `Loading migrations from netlify/database/migrations directory`) before continuing.
-2. **User verifies on the draft URL** — and completes any dashboard-only setup along the way (e.g., enabling Identity if the project also uses it; see `netlify-identity/SKILL.md`).
-3. **Promote: `netlify deploy --prod`**.
-
-Why preview-first matters: the preview deploy provisions the database and applies migrations exactly the way the production deploy will, so a failure during preview is recoverable without prod ever entering a half-configured state. `--prod`-first works in the happy case but is harder to recover from when something goes wrong.
-
-### If the first deploy fails to provision the database
-
-**Symptom:** the build (or the Netlify Database setup extension inside the build) fails with a `401 Access Denied` on `createSiteDatabase`, typically on the very first deploy of a brand-new site. The deploy log shows the failure inside the extension's setup step.
-
-**If the failure happened on `netlify deploy --prod` as the very first deploy**, the first thing to try is the supported preview-first flow — run `netlify deploy` (no `--prod`). The failure has only been observed on `--prod`-first attempts on brand-new sites.
-
-**If a preview deploy also fails — or the original failure was already on a preview — report the failure to the user and stop.** Do not work around it. Specifically, do not:
-
-- Curl `https://api.netlify.com/...` directly
-- Run `netlify api createSiteDatabase` (or any other `netlify api` call to manually create what the platform was supposed to provision)
-- Pull auth tokens out of `~/Library/Preferences/netlify/config.json`
-- Connect via `psql` to "check on things"
-
-The recovery is to give the user the deploy log URL, the site URL, and the exact error, and let them decide what to do next (file a support issue, recreate the site, switch teams).
-
-## Drizzle ORM (recommended path)
-
-Drizzle is the recommended way to work with Netlify Database. Prefer Drizzle over writing raw SQL or hand-editing migration files — manual migrations are an edge case (see `references/migrations.md`).
-
-### Install
-
-```bash
-npm install @netlify/database drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-### Schema file
-
-Create `db/schema.ts`. Define all tables here using Drizzle's schema builder.
-
-```typescript
-// db/schema.ts
-import { boolean, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
-
-export const items = pgTable("items", {
-  id: serial().primaryKey(),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  isActive: boolean("is_active").notNull().default(true),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
-
-export type Item = typeof items.$inferSelect;
-export type NewItem = typeof items.$inferInsert;
-```
-
-Use snake_case strings for column names (`"is_active"`, `"created_at"`) to match Postgres conventions. Drizzle variable names can be camelCase.
-
-### Drizzle client
-
-Create `db/index.ts`. The adapter on `drizzle-orm/netlify-db` picks the right driver for the runtime automatically.
-
-```typescript
-// db/index.ts
-import { drizzle } from "drizzle-orm/netlify-db";
-import * as schema from "./schema";
-
-export const db = drizzle({ schema });
-```
-
-The connection is configured automatically — no connection string needed. If your project uses native ESM with `.js` extensions on relative imports (`from "./schema.js"`), keep that style consistent here.
-
-### Drizzle Kit config
-
-Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
-
-```typescript
-// drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  out: "netlify/database/migrations",
-});
-```
-
-No `migrations` block is needed: `drizzle-kit generate` (the `@beta` line this skill pins) already defaults to timestamp prefixes, which keep filenames unique when branches generate migrations in parallel. Setting `migrations: { prefix: "timestamp" }` explicitly is harmless but redundant — and forcing a sequential `prefix: "index"` is what causes the parallel-branch collisions, so don't.
-
-### Package scripts
-
-```json
-{
-  "scripts": {
-    "db:generate": "drizzle-kit generate",
-    "db:migrate": "netlify database migrations apply"
-  }
-}
-```
-
-- `db:generate` writes a new migration file under `netlify/database/migrations/` from the current schema.
-- `db:migrate` applies pending migrations to the **local development database only**, via the CLI. Hosted migrations (preview branches, production) are applied by the deploy — never by this script.
-
-### Schema-change workflow
-
-1. Edit `db/schema.ts`.
-2. `npm run db:generate` — writes a new file into `netlify/database/migrations/`.
-3. Review the SQL.
-4. `npm run db:migrate` — applies it to the local development DB for testing.
-5. Commit the schema change and migration file together and push. The deploy applies the migration to the preview branch, then to production on publish.
-
-### Query patterns
-
-```typescript
-import { db } from "./db";
-import { items } from "./db/schema";
-import { eq, desc } from "drizzle-orm";
-
-// Select all
-const all = await db.select().from(items);
-
-// Select with condition
-const [one] = await db.select().from(items).where(eq(items.id, id)).limit(1);
-
-// Ordering and limit
-const recent = await db.select().from(items).orderBy(desc(items.createdAt)).limit(10);
-
-// Insert
-const [created] = await db.insert(items).values({ title: "New" }).returning();
-
-// Update
-const [updated] = await db.update(items).set({ title: "Updated" }).where(eq(items.id, id)).returning();
-
-// Delete
-await db.delete(items).where(eq(items.id, id));
-```
-
-Full migration workflow, expand-and-contract for breaking schema changes, and production DML migrations are in `references/migrations.md`.
-
-## Native driver (when Drizzle isn't a fit)
-
-When a project wants raw SQL, uses a different query builder (Kysely, etc.), or has a library that needs a `pg.Pool`, use the native driver exposed by `@netlify/database`.
-
-```bash
-npm install @netlify/database
-```
-
-```typescript
+```ts
 import { getDatabase } from "@netlify/database";
 
-const db = getDatabase();
-
-// Tagged template — parameters are safely bound, not interpolated
-const users = await db.sql`SELECT * FROM users WHERE active = ${true}`;
-
-// Insert with RETURNING
-const [user] = await db.sql`
-  INSERT INTO users (name, email)
-  VALUES (${name}, ${email})
-  RETURNING *
-`;
-
-// Bulk insert
-const rows = db.sql.values([
-  ["Ada", "ada@example.com"],
-  ["Bob", "bob@example.com"],
-]);
-await db.sql`INSERT INTO users (name, email) VALUES ${rows}`;
+const db = getDatabase();               // auto-selects connection for the runtime
+const userId = 42;
+const users = await db.sql`SELECT * FROM users WHERE id = ${userId}`;  // auto-parameterized
 ```
 
-Transactions go through `db.pool` so `BEGIN`, the queries, and `COMMIT`/`ROLLBACK` all run on the same connection:
+Own driver / ORM instead:
+```ts
+import { getConnectionString } from "@netlify/database";
+const connectionString = getConnectionString();  // correct branch for this env
+```
 
-```typescript
-import { getDatabase } from "@netlify/database";
+**Legacy — do NOT use for new code:** `import { neon } from "@netlify/neon"`. Superseded by `@netlify/database`. Replace `neon()` calls with the Drizzle `netlify-db` adapter or a Postgres driver via `getConnectionString()`. The legacy env var `NETLIFY_DATABASE_URL` is replaced by `NETLIFY_DB_URL`.
 
+## Where things go
+
+| What | Location |
+|------|----------|
+| Migrations | `netlify/database/migrations/` (SQL files or subdirs with `migration.sql`) |
+| Query code | Functions (`netlify/functions/`), Edge Functions |
+| Drizzle schema | `db/schema.ts` (convention) |
+| Drizzle client | `db/index.ts` (convention) |
+| Connection string | `NETLIFY_DB_URL` env var, or `getConnectionString()` |
+
+## Querying
+
+`getDatabase(options?)` returns a client with `sql` and `pool`. `options.connectionString` overrides the auto-provisioned one; `options.debug` enables logging.
+
+```ts
 const db = getDatabase();
+const active = await db.sql`SELECT * FROM users WHERE active = ${true}`;
+await db.sql`INSERT INTO users (name, email) VALUES (${"Ada"}, ${"ada@example.com"})`;
+await db.sql`UPDATE users SET name = ${"Ada Lovelace"} WHERE id = ${1}`;
+await db.sql`DELETE FROM users WHERE id = ${1}`;
+
+// Type the rows
+interface User { id: number; name: string; email: string; }
+const typed = await db.sql<User>`SELECT * FROM users`;
+
+// Stream
+for await (const row of db.sql`SELECT * FROM users`.stream()) { /* ... */ }
+for await (const chunk of db.sql`SELECT * FROM users`.chunked(100)) { /* ... */ }
+```
+
+`SQLTemplate` methods: `execute()` → `Promise<T[]>`, `stream()` → `AsyncGenerator<T>`, `chunked(n)` → `AsyncGenerator<T[]>`, `toSQL()` → raw SQL + params without executing.
+
+`sql` helpers:
+- `sql.identifier(value)` — safe table/column name. String, string[], or `{ schema, table, column, as }`.
+- `sql.values(rows)` — bulk-insert values list from a 2D array.
+- `sql.default` — the SQL `DEFAULT` keyword.
+- `sql.raw(value)` — **injects unparameterized SQL; bypasses injection protection. Only for trusted constants (e.g. `"DESC"`), never user input.**
+- `sql.unsafe(query, params?, { rowMode })` — raw query string with `$1` params; `rowMode` is `"array"` or `"object"`.
+
+### Transactions — use `pool`
+
+`db.pool` is a [`pg.Pool`](https://node-postgres.com/apis/pool). `BEGIN`/queries/`COMMIT` must run on the same connection:
+```ts
 const client = await db.pool.connect();
 try {
   await client.query("BEGIN");
-  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", [name, email]);
-  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [id, title]);
+  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", ["Ada", "ada@example.com"]);
+  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [1, "First post"]);
   await client.query("COMMIT");
 } catch (e) {
   await client.query("ROLLBACK");
@@ -290,76 +82,307 @@ try {
 }
 ```
 
-For third-party tools that need a raw connection string, import `getConnectionString` from `@netlify/database` — but prefer `getDatabase()` for application code.
+Own drivers:
+```ts
+import { getConnectionString } from "@netlify/database";
+import pg from "pg";
+const pool = new pg.Pool({ connectionString: getConnectionString() });
 
-### Manual migrations
-
-With the native driver, scaffold migration files via the CLI:
-
-```bash
-netlify database migrations new -d "create users table"
+// or the `postgres` driver via env var
+import postgres from "postgres";
+const sql = postgres(process.env.NETLIFY_DB_URL);
 ```
 
-This creates `netlify/database/migrations/<prefix>_<slug>/migration.sql` and prompts for the numbering scheme if it can't be detected from existing files. Open the file and write the SQL. The CLI auto-detects an existing scheme; for new projects it'll ask — choose `timestamp` unless you have a reason not to.
+## Drizzle ORM
 
-You can also write the file by hand if you prefer. Two layouts are supported:
+**Install both packages from `@beta` — required.** `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail.
+```bash
+npm install @netlify/database drizzle-orm@beta
+npm install -D drizzle-kit@beta
+```
 
-- **Flat:** `netlify/database/migrations/<prefix>_<slug>.sql`
-- **Subdirectory:** `netlify/database/migrations/<prefix>_<slug>/migration.sql` (what `migrations new` produces)
+`drizzle.config.ts` — you **MUST** set `out` to the Netlify migrations directory or Netlify won't apply generated migrations:
+```ts title="drizzle.config.ts"
+import { defineConfig } from "drizzle-kit";
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./db/schema.ts",
+  out: "netlify/database/migrations",   // NOT the default "drizzle"
+});
+```
 
-In both, `<prefix>` is digits (timestamp like `20260417143022` or sequential like `0001`) and `<slug>` is lowercase letters, numbers, hyphens, or underscores. Files apply in lexicographic order. See `references/migrations.md`.
+```ts title="db/schema.ts"
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+export const users = pgTable("users", {
+  id: serial().primaryKey(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  createdAt: timestamp().defaultNow(),
+});
+```
 
-Once a migration has been applied to any database, never modify it — roll forward with a new migration instead.
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";  // native adapter, auto-configured
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
 
-## Connection — don't reach for the env var
+```ts title="netlify/functions/api.ts"
+import { desc } from "drizzle-orm";
+import type { Config, Context } from "@netlify/functions";
+import { db } from "../../db";
+import { users } from "../../db/schema";
 
-`NETLIFY_DB_URL` is set automatically across builds, functions, edge functions, and local dev. Use the `getDatabase()` / `getConnectionString()` helpers above rather than reading it directly — only reach for the raw env var for third-party tools that demand a bare string.
+export default async (req: Request, context: Context) => {
+  if (req.method === "GET") {
+    const allUsers = await db.select().from(users).orderBy(desc(users.createdAt));
+    return Response.json(allUsers);
+  }
+  if (req.method === "POST") {
+    const { name, email } = await req.json();
+    const [user] = await db.insert(users).values({ name, email }).returning();
+    return Response.json(user, { status: 201 });
+  }
+  return new Response("Method not allowed", { status: 405 });
+};
 
-`NETLIFY_DB_URL` is intentionally different from the legacy extension's `NETLIFY_DATABASE_URL`. The two coexist so a project mid-migration doesn't break. Don't rename between them.
+export const config: Config = { path: "/api/users" };
+```
 
-## Preview branching
+Generate migrations after editing the schema: `npx drizzle-kit generate`.
 
-Each deploy preview runs against its own database branch forked from production data — schema and data changes in a preview don't affect production until the branch is merged and published. Migrations run against the preview branch first (failures fail the preview, not production), and ad-hoc preview edits (UI data browser or a direct client) don't propagate to production — always express production changes as migrations.
+**Never run `drizzle-kit push` against a Netlify-hosted database, and never run `drizzle-kit migrate` against `NETLIFY_DB_URL`.** Schema reaches hosted DBs only as committed migration files applied by the deploy. `generate` writes files; the deploy applies them.
 
-## Changing existing data — production or preview?
+## Migrations
 
-A request to change existing data — "rename this category", "fix the broken row for user X" — is **ambiguous about where it should land**: production, or only the current preview branch. Resolve that fork *before* changing anything: if the prompt didn't say, ask. When acting on someone's behalf, default to **not** touching production unless they explicitly asked.
+Files live in `netlify/database/migrations/`. Two formats:
+```text
+netlify/database/migrations/20260301143000_create_users.sql          # single SQL file
+netlify/database/migrations/20260318091500_add_posts/migration.sql   # subdir form
+```
 
-Once it's production-bound, express it as a **DML migration**, never a direct write:
+Naming: `<number>_<slug>` — `number` is digits (timestamp or `0001`…) defining order; `slug` is lowercase letters/numbers/hyphens/underscores. Sorted **lexicographically**, applied in order. **Use timestamp prefixes** (`netlify database migrations new` handles this) to avoid out-of-order rejection.
 
-- **Don't run the `UPDATE`/`INSERT`/`DELETE` against production** (or ad-hoc in a preview). Generate a DML migration in `netlify/database/migrations/` (raw SQL or Drizzle-generated) and commit it — the deploy applies it, like a schema migration.
-- Tell the user you created a data migration; merging the branch applies it to production. Have them **verify in the deploy preview first** (it runs against a forked copy of production data).
+```sql title="netlify/database/migrations/20260425103000_create_comments.sql"
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id),
+  author_id INTEGER NOT NULL REFERENCES users(id),
+  body TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
 
-Covers seed data, backfills, cleanups, CSV imports, and single-row fixes. Full detail in `references/migrations.md`.
+**When applied:**
+- Production deploy: applied immediately before publish; a failure blocks publish. With auto-publish off, Netlify waits for manual publish before applying.
+- Deploy preview: applied on every deploy before it goes live; a failure fails the deploy.
+- Local: **not** automatic — run `netlify database migrations apply` yourself.
 
-## Netlify CLI commands for Netlify Database
+**Migration footguns (all detected as drift / rejected):**
+- **Never edit an applied migration** — checksum drift: `migration "<name>" has been modified after being applied`. Write a new corrective migration.
+- **Never remove an applied migration** — `... has been removed after being applied`. Restore it.
+- **Out-of-order:** a prefix ≤ the highest applied version is rejected. Timestamps avoid this.
+- Prefer backwards-compatible migrations. Breaking changes (rename/drop column) → expand-and-contract across multiple deploys. New table / nullable column → single migration is fine.
 
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`). Requires CLI 26.0.0+. Most commands accept `--json` for machine-readable output — useful when scripting or reading results from an agent.
+Bring-your-own migration system: pick a directory **other than** `netlify/database/migrations` to avoid automatic detection, and you own applying to preview branches and production.
 
-Full per-command reference — `init`, `status`, `connect`, `migrations new` / `apply` / `pull` / `reset`, and `reset` — is in `references/cli-commands.md`. The one rule that applies across all of them: **never run DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`) through `connect`, `psql`, or any direct connection** — schema changes go through migration files.
-
-## Iterating on migrations
-
-When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
-
-- **Already applied** to any database (local dev DB, a preview branch, or production) → treat as immutable. Roll forward with a new migration that applies the correction.
-- **Only on disk** (not yet applied anywhere) → don't edit the SQL or snapshot files by hand. Run `netlify database migrations reset`, update `db/schema.ts`, then re-run `npm run db:generate`. Hand-editing desyncs Drizzle Kit's internal state and tends to produce broken migrations on the next generate.
+See `references/migrations.md`.
 
 ## Local development
 
-`netlify dev` runs against a local Postgres-compatible database — no remote connection, no risk to production. The local DB is the only one you migrate yourself (`netlify database migrations apply`).
+Local is **one** database that all code targets — branches are a deploy-time concept and don't exist locally. It's a real Postgres-compatible engine mirroring production, but single-process (not for load testing); auto-scale/sleep settings don't apply.
 
-## Common mistakes
+Start it — either path, state is interchangeable:
+```bash
+netlify dev                                    # CLI starts + tears down the local DB
+```
+Or the Vite plugin:
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import netlify from "@netlify/vite-plugin";
+export default defineConfig({ plugins: [netlify()] });
+```
 
-1. **Missing `@beta`** — `drizzle-orm`/`drizzle-kit` must be `@beta`; `latest` lacks the `drizzle-orm/netlify-db` adapter.
-2. **Wrong output dir** — set `out: "netlify/database/migrations"` in `drizzle.config.ts`; migrations elsewhere aren't applied by the deploy.
-3. **Self-applying hosted migrations** — never `drizzle-kit migrate`/`push` or DDL via `connect` against production/preview; commit migration files and let the deploy apply them.
+Common commands (while local DB is running):
+```bash
+netlify database migrations apply                        # apply pending locally
+netlify database migrations new -d "add users table"     # scaffold new migration
+netlify database migrations pull                          # overwrite local migrations from remote
+netlify database status                                   # enabled? installed? applied/pending migrations
+netlify database connect                                  # interactive SQL REPL
+netlify database connect --query "SELECT * FROM users LIMIT 10"
+netlify database reset                                    # drop all schemas/tables — LOCAL ONLY
+netlify database migrations reset                         # delete unapplied local migration files
+```
 
-## References
+External tools (works while `netlify dev` runs):
+```bash
+psql "$(netlify database connect --json | jq -r .connection_string)"
+```
 
-- [Migrations](references/migrations.md) — full migration workflow, expand-and-contract for breaking changes, and production DML
-- [CLI commands](references/cli-commands.md) — `init`, `status`, `connect`, and `migrations new` / `apply` / `pull` / `reset`
-- [Local development](references/local-dev.md) — running against a local Postgres-compatible database with `netlify dev`
-- [Operational footguns](references/operational-footguns.md) — client reuse, cold starts, preview-data (PII) exposure, legacy-extension deletion
-- [Legacy `@netlify/neon` extension](references/legacy-extension.md) — recognizing and coexisting with the older extension
-- [Migrating from the extension](references/migration-from-extension.md) — switching from `@netlify/neon` or other external Postgres, including the one-time data import
+See `references/local-dev.md`.
+
+## Setup
+
+New project: describe your app to Agent Runners at https://app.netlify.com/start, or `netlify create "<description>"` locally.
+
+Existing project:
+```bash
+netlify database init      # installs @netlify/database, picks Drizzle or raw SQL, scaffolds a migration
+netlify database init --yes # non-interactive (CI / agents)
+netlify dev
+```
+Manual: `npm install @netlify/database`, write a migration under `netlify/database/migrations/`, write a function, `netlify dev`, deploy.
+
+**If `@netlify/database` is NOT installed, Netlify will NOT auto-provision a database** — you'd have to create one manually from the UI **Database** menu. Install the package.
+
+## CLI reference (`netlify database`)
+
+Prereqs: Node ≥ 20.12.2, Netlify CLI ≥ 26.0.0 (`npm install -g netlify-cli`). All commands support `--json`.
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `init` | Set up DB in project | `-y, --yes` |
+| `status` | State: enabled, installed, connection string, applied/pending migrations | `-b, --branch`, `--show-credentials` |
+| `connect` | SQL REPL, or `--query` one-shot | `-q, --query`, `--json` |
+| `migrations apply` | Apply pending to local DB | `--to <name>` |
+| `migrations new` | Scaffold a migration | `-d, --description`, `-s, --scheme sequential\|timestamp` |
+| `migrations pull` | Overwrite local files from a branch | `-b, --branch`, `--force` |
+| `migrations reset` | Delete unapplied local migration files | `-b, --branch` |
+| `reset` | Drop all data/tables — **local only** | — |
+
+See `references/cli-commands.md`.
+
+## REST API
+
+Scoped to a site, rooted at `https://api.netlify.com/api/v1`, OAuth 2. Full reference: https://open-api.netlify.com.
+
+| Method + path | Purpose |
+|---------------|---------|
+| `POST /sites/{site_id}/database` | Create DB (returns existing conn string if present); `region` optional |
+| `GET /sites/{site_id}/database` | Get connection string |
+| `POST /sites/{site_id}/database/branch` | Create branch; body `deploy_id` (req), `parent_branch_id` (opt, defaults to production) |
+| `GET /sites/{site_id}/database/branch/{deploy_id}` | Get branch conn string (404 if none) |
+| `DELETE /sites/{site_id}/database/branch/{deploy_id}` | Delete a deploy's branch |
+| `POST /sites/{site_id}/database/snapshot` | Snapshot a branch (defaults production) |
+| `GET /sites/{site_id}/database/snapshots` | List snapshots |
+| `DELETE /sites/{site_id}/database/snapshot/{snapshot_id}` | Delete a snapshot |
+| `POST /sites/{site_id}/database/snapshot/{snapshot_id}/restore` | Restore snapshot to a branch (defaults production) |
+
+**Branch delete and snapshot restore are destructive and require explicit user confirmation first.** Snapshot restore is not a routine production-rollback lever.
+
+## Testing
+
+Bare Postgres for unit/integration tests (no functions):
+```ts title="db.test.ts"
+import { NetlifyDB } from "@netlify/database-dev";  // npm i -D @netlify/database-dev
+import { Client } from "pg";
+import { afterAll, beforeAll, expect, test } from "vitest";
+
+let db: NetlifyDB, connectionString: string;
+beforeAll(async () => {
+  db = new NetlifyDB();
+  connectionString = await db.start();
+  await db.applyMigrations("./netlify/database/migrations");
+});
+afterAll(async () => { await db.stop(); });
+
+test("inserts and reads a user", async () => {
+  const client = new Client({ connectionString });
+  await client.connect();
+  await client.query("INSERT INTO users (name) VALUES ($1)", ["Ada"]);
+  const { rows } = await client.query("SELECT name FROM users");
+  expect(rows).toEqual([{ name: "Ada" }]);
+  await client.end();
+});
+```
+`NetlifyDB(options?)`: `directory` (persist to disk; omit = in-memory), `port` (default random), `logger`.
+
+Full Netlify environment (functions/edge functions read `NETLIFY_DB_URL` as in production):
+```ts
+import { NetlifyDev } from "@netlify/dev";  // npm i -D @netlify/dev
+const netlifyDev = new NetlifyDev({ projectRoot: "./fixtures/my-project" });
+await netlifyDev.start();  // sets NETLIFY_DB_URL in the runtime
+// ...tests...
+await netlifyDev.stop();
+```
+
+## Database branches (deploy-time)
+
+Production deploys are the only deploys that touch the production database. Each deploy preview gets its own branch, seeded with a copy of production data at preview-creation time; schema/data changes there never affect production. Wired up automatically, no code changes.
+
+**Preview branches can contain production data, including PII — and preview deploy links are public. Warn the user before sharing a preview link.**
+
+## Runtime gotchas
+
+- **`Environment not configured`** (`getDatabase()` can't resolve a connection string): running outside Netlify, on **Functions in Lambda compatibility mode**, or an outdated CLI. Fix: pass `connectionString` explicitly.
+  ```ts
+  const db = getDatabase({ connectionString: "postgres://..." });
+  ```
+  Lambda compatibility mode is the one primitive where you must pass `connectionString` yourself.
+- **`database feature not available for this account`** — requires a Credit-based plan.
+- **`compute customization requires a Pro or higher plan`** — auto-scale / sleep settings need Pro+; Free/Personal use defaults.
+- **`branch limit reached: maximum <N> branches...`** — each active deploy preview consumes a branch; delete unneeded branches or upgrade.
+- **`database not found`** — no DB provisioned; run `netlify database init`.
+- **`cannot reset the production branch`** — reset is non-production only.
+
+## Constraints
+
+- **Plan:** Netlify Database is available on Credit-based plans only; active DBs consume credits for compute and bandwidth. Storage is free until July 1, 2026.
+- **Permissions:** only a Team Owner can delete a database; only Team Owners and Developers can view connection strings (`Access Denied` = insufficient role).
+- **Secrets:** connection strings contain username + password. Never commit them; store in a secret manager / env var provider.
+
+## Switch an existing Postgres project to Netlify Database
+
+Three phases: provision (baseline schema on a branch), rehearse (swap code, copy data into a preview branch, validate), cut over (import data into production, merge). Works from any Postgres source (Neon, Supabase, RDS, self-managed, legacy `@netlify/neon`). Uses `pg_dump`/`pg_restore` (versions matching the source). There is a brief data-loss window — writes to the source between final export and production deploy don't cross over.
+
+Phase 2/3 code swap (Drizzle):
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
+
+Full step-by-step (dump flags, rollback, cleanup): `references/migration-from-extension.md` and `references/legacy-extension.md`.
+
+<!-- Gaps: plan-tier naming (Credit-based vs Free/Personal/Pro) not reconciled in source; exact plan limits, permission tables, and snapshot UI flows live on pages outside this grouping. -->
+
+<!-- system: agent-context/database/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (database)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Production data changes are expressed as DML migrations — agents never
+   edit rows directly (UI row editing exists for humans; it is not an agent
+   surface).
+2. Preview branches can contain production data, including PII — and preview
+   deploy links are public. Warn before sharing.
+3. Use only documented surfaces: no raw psql against internal endpoints, no
+   `netlify api` scraping, no reading tokens from local CLI config files.
+4. Deep guides live in this skill: `references/operational-footguns.md`,
+   `references/migrations.md`, `references/local-dev.md`,
+   `references/cli-commands.md`, `references/migration-from-extension.md`,
+   `references/legacy-extension.md`.
+5. Schema changes reach hosted databases only as committed migration files
+   applied by the deploy. Never run `drizzle-kit push` in any form against a
+   Netlify-hosted database, never run `drizzle-kit migrate` against
+   `NETLIFY_DB_URL`, and never apply DDL via `netlify database connect` or
+   any direct connection.
+6. When a `netlify` command or a deploy fails, surface the exact error, the
+   deploy log URL, and the affected site/branch to the user and stop — do
+   not invent recovery commands or escalate to lower-level tools.
+7. First-deploy `401 Access Denied` on `createSiteDatabase`: if it happened
+   on a `--prod`-first deploy, retry preview-first (`netlify deploy`, no
+   `--prod`); if a preview also fails, report and stop. Never curl
+   `api.netlify.com`, run `netlify api createSiteDatabase`, or pull tokens
+   from local CLI config to work around it.
+8. A request to change existing data is ambiguous between production and the
+   preview branch — if the prompt didn't say, ask. When acting on someone's
+   behalf, default to not touching production.
+9. Destructive database operations — REST branch delete, snapshot restore,
+   any reset — require explicit user confirmation first. The body must not
+   present snapshot restore as a routine production-rollback lever.
+10. Pin: `drizzle-orm` and `drizzle-kit` must be installed from `@beta` —
+    `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail. The
+    body may not soften this to a recommendation.

--- a/codex/skills/netlify-deploy/SKILL.md
+++ b/codex/skills/netlify-deploy/SKILL.md
@@ -1,153 +1,186 @@
 ---
 name: netlify-deploy
-description: Deploy, host, and publish web projects on Netlify with the Netlify CLI. Use when the user wants to deploy a site or repository to Netlify, link a local project to a Netlify site, ship a production or preview/draft deploy, set up Git-based continuous deployment, run a manual or local deploy, configure CI deploys, or troubleshoot a failed or misconfigured deploy. Also use to view or tail a deployed site's runtime logs — function and edge-function output, deploy logs — via `netlify logs` when debugging what a live site is doing (recent errors, recent activity, streaming output).
+description: Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons, drag-and-drop, and per-context netlify.toml build settings. Use when linking a repo, deploying from the CLI, setting up Deploy Previews or branch deploys, configuring deploy contexts, adding skew protection, fixing a failed or secrets-flagged deploy, or wiring build hooks and Deploy to Netlify buttons.
 ---
 
-# Netlify Deployment
+# Netlify deploy
 
-Install the CLI, link a project to a Netlify site, and deploy it — either through Git-based continuous deployment (the primary path) or a manual CLI upload (for prototypes and CI). Environment-variable management lives in the **netlify-config** skill; local development lives in the **netlify-frameworks** skill.
+## Deploy context config (netlify.toml, current form)
 
-## Installation
+Configure per-context build settings in `netlify.toml` at the repo root. Five predefined contexts: `production`, `deploy-preview`, `branch-deploy`, `preview-server`, `dev`. Branch names also work as custom contexts (a `staging` branch matches a `staging` context).
 
-```bash
-npm install -g netlify-cli    # Global (for local dev)
-npm install netlify-cli -D    # Local (for CI)
+```toml
+[context.production]
+  command = "make production"
+  [context.production.environment]
+    ACCESS_TOKEN = "super secret"
+  # Plugins context REQUIRES double brackets:
+  [[context.production.plugins]]
+    package = "@netlify/plugin-sitemap"
+
+[context.deploy-preview.environment]
+  ACCESS_TOKEN = "not so secret"
+
+[context.branch-deploy]
+  command = "make staging"
+
+[context.dev.environment]
+  NODE_ENV = "development"
+
+# Specific-branch context (overrides branch-deploy):
+[context.feature]
+  command = "make feature"
+
+[context."features/branch"]
+  command = "gulp"
 ```
 
-Requires Node.js 18.14.0+. You can also invoke the CLI without installing it using `npx netlify <command>`.
+Precedence: site globals < context overrides; production overrides globals when building production; more specific contexts (a named branch) override general ones (`branch-deploy`). Only explicitly-set options are overridden. File-based config overrides UI settings.
 
-## Authentication
+**Footgun — secrets in netlify.toml:** `netlify.toml` is committed to your repo. Do not put sensitive env values here, especially for public repos. Set secrets via the Netlify UI/CLI/API instead. Also: env vars declared in `netlify.toml` are NOT available to the deploy environment (Functions/Runtime/Post-processing scopes) — only UI/CLI/API-created vars are.
 
-```bash
-netlify login       # Opens browser for OAuth
-```
-
-For CI, set the `NETLIFY_AUTH_TOKEN` environment variable instead of logging in interactively. Generate a token from **User settings → Applications → Personal access tokens** in the Netlify UI.
-
-**CI also needs a site to target.** `NETLIFY_AUTH_TOKEN` only authenticates you — it does **not** select which site a deploy publishes to. In CI there is no linked `.netlify/state.json`, so also set `NETLIFY_SITE_ID` (the site's API/Project ID, shown as **Project ID** in the site's configuration) as an environment variable so `netlify deploy` knows where to publish. Without it, a CI deploy has no site to target and fails or tries to prompt. Locally this is handled by `netlify link`, which writes the site ID into `.netlify/state.json`; CI has no such file.
-
-Don't pre-check auth as a separate step. Run the real operation (`netlify deploy`, `netlify link`) directly; only if it fails with an authentication error do you surface `netlify login` (or setting `NETLIFY_AUTH_TOKEN`) as the fix.
-
-## Linking a Site
-
-Linking connects the local directory to a Netlify site and writes the site ID into `.netlify/state.json`.
+## CLI deploys
 
 ```bash
-# Interactive — pick an existing site
-netlify link
-
-# By Git remote (if the project has one)
-netlify link --git-remote-url https://github.com/org/repo
-
-# Create a new site
-netlify init           # With Git CI/CD setup
-netlify init --manual  # Without Git CI/CD
+netlify create              # new project from a natural-language prompt
+netlify deploy              # manual deploy, no continuous deployment
+netlify deploy --prod       # deploy directly to production
+netlify deploy --allow-anonymous   # temp deploy, claim within 1 hour
+npm update -g netlify-cli   # skew protection needs CLI v23.11.0+
 ```
 
-Run `netlify link` directly rather than pre-checking link status. If the command reports the project isn't linked to any site (or the site can't be found), that failure is the signal to link or create one with `netlify link` / `netlify init`.
+Manual deploys do NOT run a build command (exception: Netlify Drop builds for you when logged in). Anonymous deploys create a temporary project claimable within one hour; on claim it adopts the team's default visibility.
 
-**Always add `.netlify` to `.gitignore`** — every linking path (`netlify link`, `netlify init`, `netlify init --manual`) writes site state to `.netlify/state.json`, which shouldn't be committed. Mention this whenever you link or create a site.
+**Footgun — link writes `.netlify/state.json`:** every linking/create path writes `.netlify/state.json`. Add `.netlify` to `.gitignore` so it is never committed.
 
-## Deploying
+**Footgun — manual `--prod` on a Git-connected site:** the next push to the production branch silently replaces your hand-shipped deploy. Warn the user before running it; if the deploy must stay live, lock the published deploy.
 
-### Git-Based Deploys (Continuous Deployment) — primary path
+## Git continuous deployment
 
-The standard way to deploy on Netlify is to connect the site to a Git repository (set up with `netlify init`, or in the UI). Netlify then builds and deploys automatically on every push:
+Connect a Git repo (Git provider OAuth2 or the Netlify GitHub App). Netlify runs your build command and deploys on every push. Production deploys are triggered by pushes to the production branch (default `main`); Deploy Previews are built for pull/merge requests and agent runs.
 
-- **Push to the production branch → production deploy.**
-- **Open a pull request → deploy preview** with its own unique URL.
-- **Push to other branches → branch deploy**, but **only if branch deploys are enabled** — they are off by default. Turn them on (per branch or for all branches) in the site's build & deploy settings.
+## Deploy Previews & branch deploys
 
-The build runs on Netlify's servers, not your machine. Configure build settings (command, publish directory, base directory) in `netlify.toml` — see the **netlify-config** skill for the full configuration reference.
+- Deploy Previews build by default for PRs/MRs and agent runs. Base branch of a Deploy Preview must be a production branch or a branch with branch deploys enabled.
+- Branch deploys are OFF by default — a Developer/Owner must enable them: Project configuration > Build & deploy > Continuous Deployment > Branches and deploy contexts > Configure. Add individual branches, use a `features/*` prefix wildcard, or select **All**.
+- URL prefixes: branch deploys `<branch>--`; PR/MR previews `deploy-preview-<number>--`; agent previews `agent-<runID>--`; permalinks `<deployID>--`.
+- While the initial Deploy Preview builds, its URL returns `Not Found`.
 
-**`netlify.toml` overrides the UI.** File-based configuration in `netlify.toml` takes precedence over the equivalent build settings configured in the Netlify UI. When the same option is set in both places, the committed `netlify.toml` wins — editing that setting in the dashboard has no effect until you change the file and redeploy. This surprises people who tweak the build command, publish directory, or base directory in the UI and watch the old committed value keep applying on every deploy.
+**Deploy Preview entry path** — set in the PR/MR description (updates the PR comment link):
+```markdown
+@netlify /start/choose-your-path
+```
+Push a new (or empty) commit to regenerate the link. Once set in the PR/MR, you cannot override the entry path in the Netlify Drawer.
 
-**Monorepo config discovery order.** In a monorepo, Netlify searches for the `netlify.toml` in this order and uses the **first** one it finds: (1) the package directory, then (2) the base directory, then (3) the repository root. Put a site-specific `netlify.toml` in the package directory (the subdirectory that contains that site) so it takes precedence over any root-level config. A base directory set in a root-level `netlify.toml` also overrides the base directory configured in the UI.
+## Skip a deploy
 
-**The publish directory is resolved relative to the base directory.** When a `base` directory is configured, the publish directory is interpreted relative to that base, **not** the repository root. A top-level `publish = "dist"` combined with `base = "apps/web"` publishes `apps/web/dist`, not `dist` at the repo root. Set `publish` relative to the base so the built output is found.
+Add `[skip ci]` or `[skip netlify]` to a PR/MR title (skips the Deploy Preview) or anywhere in a commit message (skips branch/production deploy). For a multi-commit push, put it in the most recent commit. The next commit without the token deploys all skipped changes.
 
-### Manual / Local Deploys (No Git Required) — secondary path
+## Deploy to Netlify button
 
-Build the site, then upload the output directly with the CLI. This bypasses Netlify's build servers and is the right tool for prototypes, local-only projects with no Git remote, or a CI pipeline that builds elsewhere and uploads the artifact.
+Template code must be in a **public** GitHub.com or GitLab.com repo.
 
-```bash
-netlify deploy             # Draft deploy (preview URL)
-netlify deploy --prod      # Production deploy
-netlify deploy --dir=dist  # Specify the directory to upload
+```md title="Markdown"
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
 ```
 
-For sites with Git continuous deployment connected, prefer pushing to Git — a manual upload is the exception, not the default.
-
-**A manual `--prod` deploy is replaced by the next Git push.** If the same site also has Git continuous deployment connected, the next push to the production branch triggers a new build that auto-publishes and **replaces** your manually shipped `--prod` deploy — the hand-shipped build silently disappears from production. To keep a specific deploy live, **lock the published deploy** ("Stop auto publishing") from the site's Deploys list in the UI: while locked, new pushes still build but do not auto-publish until you unlock or manually publish. Mixing manual `--prod` deploys with Git CD on the same production branch is otherwise a race the next commit wins.
-
-### Deploy URLs are public by link
-
-Draft deploys (`netlify deploy`), Deploy Previews, branch deploys, and deploy permalinks each get a **unique URL that anyone with the link can open** — they are not private just because the URL is unguessable and unlisted. Don't treat a preview URL as a safe place for confidential or unreleased content on that basis alone. To actually restrict access, enable site protection in the UI (Password Protection, or Team/SSO protection). You can scope that protection to all deploys, or to non-production deploys only (Deploy Previews and branch deploys) while leaving production open. See the **netlify-access-control** skill for the full picture.
-
-## When a command fails, surface and stop
-
-When a `netlify` command or a deploy fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
-
-## Error Handling
-
-Common issues and what to do:
-
-**"Not logged in"**
-→ Run `netlify login` (or set `NETLIFY_AUTH_TOKEN` in CI).
-
-**"No site linked"**
-→ Run `netlify link` (existing site) or `netlify init` (new site).
-
-**"Build failed" / "Function bundling failed" / deploy marked failed**
-→ A failed deploy does **not** publish — the site keeps serving the last successful deploy, so it isn't down, and there's nothing to "roll back." The only way to get the new code live is to fix the failure and redeploy.
-→ Get the exact error from the deploy log (the CLI prints a log URL; the dashboard has the full build log), then address the actual cause — the build command or publish directory in `netlify.toml`, a missing dependency, or the function that failed to bundle — and re-run the deploy.
-→ Don't route around a failed build to force the site live: no `netlify api` publish/restore, no direct `https://api.netlify.com/...` calls, no reading auth tokens off disk, and don't ship a previous deploy in place of the failing one. If the log doesn't resolve it, report the exact error + log URL + affected site to the user and stop.
-→ Even if the user *asks* how to "roll back" or restore a previous deploy, correct the premise rather than complying: because the failed deploy never published, the previous deploy is still live and there is nothing to restore. Do **not** hand over `netlify api restoreSiteDeploy` / `publishDeploy` (or a dashboard rollback) as the answer — the fix is to resolve the build failure and redeploy.
-
-**"Secrets scanning found secrets" / deploy fails after a successful build**
-→ Netlify scans the build output and source for secret values (env-var values, known key formats) *after* the build succeeds and **fails the deploy** if it finds one — so an otherwise-green build can still fail here. Read the log: it names the offending key and where it appeared.
-→ If it's a real secret (an API/DB key that ended up in bundled or published output), that's a genuine leak — stop writing it into client/published files, and rotate the key if it was committed. Silencing the scanner over a real leak just ships the secret.
-→ If the flagged value is legitimately non-secret (e.g. a value that must ship to the browser), scope the exception narrowly with build environment variables: `SECRETS_SCAN_OMIT_KEYS` to exclude specific env-var keys, or `SECRETS_SCAN_OMIT_PATHS` to exclude specific paths. Prefer these over `SECRETS_SCAN_ENABLED=false`, which disables scanning across the entire build.
-
-**"Publish directory not found"**
-→ Run the build yourself (`netlify build`, which mimics the Netlify build environment, or the project's own build command) and look at which directory it actually emits — don't guess the output dir from the framework name, and don't just `ls` for a folder that isn't there.
-→ If the build itself **fails**, that's the real problem — surface the build error to the user and stop; don't change the `publish` path to paper over a broken build.
-→ Once the build succeeds, set the `publish` path (in `netlify.toml`, or `--dir`) to match that real output directory — remembering it's resolved relative to any configured `base` directory (see above).
-
-## Logs
-
-The simplest command is the right default: bare `netlify logs` shows recent logs from both the `functions` and `edge-functions` sources, covering roughly the last 10 minutes. Add flags only to scope or extend it:
-
-```bash
-netlify logs                                       # recent functions + edge-functions logs (~last 10m)
-netlify logs --follow                              # stream live
-netlify logs --source functions --function my-fn   # one function's logs
-netlify logs --source deploy --source functions    # include deploy logs (sources combine)
-netlify logs --since 24h                           # longer historical window
+URL parameters (query params; env vars go in the URL hash):
+```txt
+# require/set env vars via hash (values may be null; processed client-side, not logged)
+...?repository=REPO#SECRET_TOKEN=value&CUSTOM_LOGO=
+&fullConfiguration=true   # extra step to install SDK extensions + configure before deploy
+&base=blog                # alternate base dir for monorepos (repo still fully cloned)
+&create_from_path=examples/hello   # clone only this subdirectory
+&branch=beta-feature      # set production branch to this branch
 ```
 
-`--source` accepts `functions`, `edge-functions`, and `deploy`. This is the documented CLI logs surface — reach for it before the dashboard, and see [CLI commands](references/cli-commands.md) for more.
+File-based template config in root `netlify.toml` `[template]` section:
+```toml
+[template]
+  incoming-hooks = ["Contentful"]
+  required-extensions = ["supabase"]
+[template.environment]
+  SECRET_TOKEN = "change me for your secret token"   # label only; cannot set real values
+```
+`[template]` cannot set env var values (use the URL hash) or a base directory (use `base`). With an alternate `base`, the `netlify.toml` in the base directory wins over root config for that site's builds. `USAGE.md` at repo root shows extra instructions during the `fullConfiguration` flow.
 
-## Useful Commands
+## Drag and drop (Netlify Drop)
 
-| Command | Description |
-|---|---|
-| `netlify build` | Run the build locally (mimics the Netlify build environment) |
-| `netlify deploy` | Draft deploy (preview URL) |
-| `netlify deploy --prod` | Production deploy |
-| `netlify deploy --dir=<dir>` | Deploy a specific directory |
-| `netlify clone org/repo` | Clone, link, and set up in one step |
-| `netlify open` | Open the site in the Netlify dashboard |
-| `netlify logs` | Recent function + edge-function logs (see Logs above) |
+Drag a folder to https://app.netlify.com/drop. Logged in: Netlify detects the framework and builds before publishing (a pre-built output folder also works). Not logged in: files publish as-is. Update a drag-and-drop site by dropping the new output folder at the dropzone on the site's **Deploys** page (works for any non-Git site).
 
-## Related skills
+## Build hooks
 
-- **netlify-config** — `netlify.toml` (build settings, redirects, headers, deploy contexts) and environment-variable management (`env:set`, `env:get`, `env:list`, context scoping).
-- **netlify-frameworks** — framework adapter/plugin setup and local development (`netlify dev`, the Netlify Vite plugin).
-- **netlify-access-control** — restricting who can reach a site or its deploys.
+Build hooks give unique URLs to trigger builds/deploys. Builds from build hooks are treated as trusted and are NOT subject to the Deploy Request Policy.
 
-## References
+## Managing deploys
 
-- [CLI commands](references/cli-commands.md)
-- [Deployment patterns](references/deployment-patterns.md)
-- [netlify.toml guide](references/netlify-toml.md)
+- **Find:** Deploys tab; search by deploy ID or branch; filter by time frame, deploy context, and status.
+- **Lock (pause publishing):** on the Deploys list, **Lock to stop auto publishing**. New deploys still build but don't publish. **Unlock to start auto publishing** to resume. Use this to keep a specific deploy live.
+- **Cancel:** on the in-progress deploy's detail page, **Cancel deploy**.
+- **Retry:** builds from the branch HEAD — if HEAD moved past the original deploy SHA, it still builds from HEAD.
+- **Download:** deploy detail page — single file via **Deploy file browser**, or all files as ZIP via header **Download**.
+- **Delete:** Developer/Team Owner only. You cannot delete the currently-published deploy or one in progress. Permanent; does not reduce cost or preserve build minutes.
+
+Netlify auto-deletes deploys older than 30 days (90 days on paid plans); failed/canceled deploys are cleaned up on the same schedule. It never auto-deletes the published deploy, the most recent successful production deploy, or the most recent successful branch deploy per branch.
+
+**Fix a failed deploy:** a failed deploy never publishes — the previously published deploy stays live, so there is nothing to restore. Fix forward: use the **"Why did it fail?"** diagnosis above the deploy log, revert the offending commit, and let CI redeploy. Retry (optionally clearing cache) rebuilds from branch HEAD.
+
+## Skew protection
+
+Available on all plans. Routes requests to the server version that matches each client, avoiding version skew across deploys. Requires Netlify CLI v23.11.0+ for CLI deploys.
+
+- **Production context only.** Branch deploys, Deploy Previews, and permalinks bypass skew protection and serve the latest deploy for that context.
+- Framework support: Astro 5.15.0+ (on by default via the Netlify adapter); Next.js (optional; older versions need a config change). Framework maintainers add support via `netlify/v1/skew-protection.json`.
+- **Password protection:** works only if you protect non-production deploys only. Protecting production deploys (or all deploys) disables/ignores skew protection.
+- Netlify discards skew signals on hard navigation (`Sec-Fetch-Mode: navigate`, or `Sec-Fetch-Site` present and not `same-origin`).
+
+## Secrets scanning failures
+
+If a deploy fails secrets scanning and the flagged value is a real secret, that is a leak: stop shipping it in client/published output and rotate it. Never disable the scanner over a real leak. For genuine non-secrets, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` / `SECRETS_SCAN_OMIT_PATHS` — never `SECRETS_SCAN_ENABLED=false`.
+
+## Constraints
+
+- **54,000 files per directory** max — any directory in your publish dir over this limit fails the deploy. No limit on total files.
+- Deploys are atomic: only changed files upload; nothing goes live until the whole deploy is ready.
+- Only the published production deploy and most recent branch deploys are indexable; other previews get `X-Robots-Tag: noindex`.
+- Deploy Request Policy: private-repo deploys build only for recognized authors (Owners, Developers, Git Contributors; Marketplace bots count). Non-team-member deploys land as **Pending approval** until a Team Owner approves/matches them. Build-hook builds are exempt.
+- Retention limit is adjustable only on Enterprise (up to 365 days). Lock/unlock event notifications: Pro and Enterprise.
+
+## More
+
+Deep guides in this skill: `references/netlify-toml.md`, `references/cli-commands.md`, `references/deployment-patterns.md`.
+
+<!-- Gap: deploy-overview states failed/canceled deploys are deleted at 6 months, contradicting the 30/90-day cleanup figure used above; the 30/90-day value is stated here as the documented default. -->
+
+<!-- system: agent-context/deploy/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (deploy)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Agents do not roll back deploys: never call `restoreSiteDeploy` or
+   `publishDeploy` to restore an older deploy. Fix forward — revert the
+   commit and let CI deploy it.
+2. A failed deploy never publishes; on failure there is nothing to roll
+   back.
+3. Deep guides live in this skill: `references/netlify-toml.md`,
+   `references/cli-commands.md`, `references/deployment-patterns.md`.
+4. The frontmatter description must never advertise rollback or restore as a
+   capability — no "roll back", "restore a deploy", or equivalent.
+5. When the user asks to roll back or restore a previous deploy, correct the
+   premise rather than complying: after a failed deploy the previous deploy
+   is still live and there is nothing to restore; for a bad published deploy,
+   fix forward per rule 1. Do not hand over `restoreSiteDeploy` /
+   `publishDeploy` or a dashboard rollback as the answer.
+6. Always add `.netlify` to `.gitignore` when linking or creating a site —
+   every linking path writes `.netlify/state.json`, which must not be
+   committed. Mention it whenever you link.
+7. Secrets-scanning deploy failures: if the flagged value is a real secret,
+   that is a leak — stop shipping it in client/published output and rotate
+   it; never silence the scanner over a real leak. For genuinely non-secret
+   values, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` /
+   `SECRETS_SCAN_OMIT_PATHS`, never `SECRETS_SCAN_ENABLED=false`.
+8. Before running a manual `netlify deploy --prod` on a site with Git CD
+   connected, warn the user that the next push to the production branch
+   silently replaces the hand-shipped deploy; suggest locking the published
+   deploy if it must stay live.

--- a/codex/skills/netlify-edge-functions/SKILL.md
+++ b/codex/skills/netlify-edge-functions/SKILL.md
@@ -1,180 +1,259 @@
 ---
 name: netlify-edge-functions
-description: Guide for writing Netlify Edge Functions. Use when building middleware, geolocation-based logic, request/response manipulation, authentication checks, A/B testing, or any low-latency edge compute. Covers Deno runtime, context.next() middleware pattern, geolocation, and when to choose edge vs serverless.
+description: Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use when adding request/response manipulation at the edge — auth middleware, geolocation redirects, A/B testing and personalization, content localization, redirects/rewrites, SSR at the edge, or transforming responses — or when configuring path routing, response caching, or edge error handling. Triggers on tasks like "add auth middleware", "geo-based redirect", "A/B testing at the edge", "rewrite requests", or editing files in netlify/edge-functions.
 ---
 
 # Netlify Edge Functions
 
-Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
+**Reach for this (modern):** default-export handler + inline `config` export with a narrowly-scoped `path`. Import types from `@netlify/edge-functions`.
 
-## Check the framework adapter first
+```ts
+import type { Config, Context } from "@netlify/edge-functions";
 
-For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+export default async (request: Request, context: Context) => {
+  // return Response | URL (rewrite) | undefined (continue chain)
+};
 
-## Syntax
+export const config: Config = { path: "/products/*" };
+```
 
-```typescript
+**Avoid:** import maps in `deno.json` (unsupported — use a separate file via `deno_import_map`). Do not hand-write a function your framework's adapter already generates (Next.js, Astro, Remix, SvelteKit, Nuxt, etc.) — check the framework adapter/reference first; duplicating adapter middleware causes conflicts.
+
+## File location
+
+- Default directory: `YOUR_BASE_DIRECTORY/netlify/edge-functions`.
+- Custom directory: `edge_functions` key under `[build]` in `netlify.toml`. Keep it **outside** the publish directory so source files aren't deployed.
+- `.js`/`.ts`/`.jsx`/`.tsx` all supported. If a `.ts` and `.js` file share a name, the `.ts` is ignored and the `.js` deploys.
+
+## ⚠️ A function without a route silently never runs
+
+Edge functions are **not** auto-assigned a URL. No `config` export and no `netlify.toml` declaration = deploys clean, no build error, no warning, never executes. If "my edge function does nothing," check the route first.
+
+## Request handling patterns
+
+Handler receives `(request: Request, context: Context)`. Return one of:
+- `Response` — respond directly (ends the chain; declared redirects for the path do not run)
+- `URL` — rewrite to a **same-site** URL with 200 status (address bar unchanged)
+- `undefined` / empty `return;` — bypass this function, continue the chain
+
+Netlify adds no headers to edge requests — use `context` for client info.
+
+### Redirect
+```ts
+export default async (req: Request, { cookies, geo }: Context) => {
+  if (geo.city === "Paris" && cookies.get("promo-code") === "15-for-followers") {
+    return Response.redirect(new URL("/subscriber-sale", req.url));
+  }
+};
+```
+
+### Rewrite (same-site only)
+```ts
+export default async (request: Request, { geo }: Context) => {
+  if (geo.city === "Paris") return new URL("/subscriber-sale", request.url);
+};
+```
+To reach another site or external content, use `fetch()` — rewrite via `URL` is same-site only.
+
+### Middleware transform
+```ts
+import type { Context } from "@netlify/edge-functions";
+
+export default async (request: Request, context: Context) => {
+  const response = await context.next();
+  const text = await response.text();
+  return new Response(text.toUpperCase(), response);
+};
+```
+`context.next()` runs the rest of the chain and returns the origin `Response`. Only call it if you need the response body (it costs latency otherwise).
+
+To transform a **different** path, use `fetch()` — but this starts a **new** request chain and re-runs any edge functions matching that path. Use `context.next()` to hit a static asset/serverless function at the same internal path without re-running edge functions.
+
+### Read the request body
+A body can only be read once. If you read it, pass a fresh request to `next()`:
+```ts
+export default async (req: Request, context: Context) => {
+  const body = await req.json();
+  if (!isValid(body.access_token)) return new Response("forbidden", { status: 403 });
+  return context.next(new Request(req, { body: JSON.stringify(body) }));
+};
+```
+
+### Conditional requests
+`next()` normally forces a full response. For client caching control:
+```ts
+const res = await next({ sendConditionalRequest: true });
+if (res.status === 304) return res;
+```
+
+## `Context` object
+
+- **`geo`** — `city`, `country {code,name}`, `subdivision {code,name}`, `latitude`, `longitude`, `timezone`, `postalCode`.
+- **`cookies`** — `get(name)`, `set(options)`, `delete(name|options)` (CookieStore web standard). ⚠️ Cross-subdomain cookies require a **custom domain** — `netlify.app` is on the Public Suffix List.
+- **`next(options?)` / `next(request, options?)`** — continue the chain; `options.sendConditionalRequest`.
+- **`params`** — path params, e.g. `/pets/:name` → `{ name: "winter" }`. Query string: use `request.url`.
+- **`ip`**, **`requestId`**, **`server.region`**.
+- **`site`** — `id`, `name`, `url`. **`account.id`**. **`deploy`** — `context`, `id`, `published`, `skewProtectionToken`.
+- **`waitUntil(promise)`** — run work after the response is sent (analytics, logs) without blocking it. Still subject to the CPU time limit.
+
+`Netlify.context` gives the same context inside the handler (`null` outside it).
+
+## Environment variables
+
+Access via `Netlify.env.get(name)` (also `has`, `set`, `delete`, `toObject`). `set`/`delete` are invocation-scoped only — they do **not** persist; use the Netlify env API to update.
+
+```ts
+const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
+```
+
+⚠️ **Gotchas:**
+- Variables in `netlify.toml` are **NOT** available to edge functions.
+- Scope must include **Functions** to reach runtime. **Build**-scoped vars are build-only — embed them at build time if needed.
+- Values are frozen at deploy time. Change a var → new deploy required. Deploy Previews/branch deploys use their deploy-time values.
+
+## Configuration / routing
+
+Config via inline `config` export or `netlify.toml`. Properties:
+- **`path`** — `URLPattern` string or array; must start with `/`. e.g. `["/", "/products/*"]`.
+- **`excludedPath`** — exclude routes from `path`; must start with `/`. e.g. `["/*.css", "/*.js"]`.
+- **`pattern`** / **`excludedPattern`** — regex alternatives to `path`/`excludedPath`.
+- **`method`** — string or array of HTTP methods (inline only).
+- **`header`** — object of header conditions: `true` (present), `false` (absent), or a regex string on the value. Names case-insensitive; multiple same-name values matched as comma-joined list.
+- **`cache`** — `"manual"` to opt into caching.
+- **`onError`** — error handling (see below).
+
+### ⚠️ Scope `path` narrowly
+
+`path: "/*"` intercepts **every** request including static assets — adds latency to each and **bills an edge invocation** for each. Match only the paths you need.
+
+### netlify.toml (for ordering / multiple functions on a path)
+```toml
+[[edge_functions]]
+  path = "/admin"
+  function = "auth"
+
+[[edge_functions]]
+  path = "/admin"
+  function = "injector"
+  cache = "manual"
+```
+Header matching uses an `[edge_functions.header]` sub-table.
+
+### Execution order
+Config-file declarations run before inline; framework-generated before user; non-cached before cached. Within `netlify.toml`: top-to-bottom. Within inline: **alphabetical by file name**. To control order, prefer `netlify.toml`. If the same function is declared both inline and in toml, they merge and inline fields win.
+
+Caveats: a function on the **target** of a static rewrite does **not** run for rewritten requests. If a function returns a `Response`, redirects for that path are skipped.
+
+## Response caching (opt-in)
+
+### ⚠️ Both parts or neither
+Cache headers on the `Response` do **nothing** without `cache: "manual"` in config — and `cache: "manual"` without headers still caches nothing. You need **both**:
+
+```ts
 import type { Config, Context } from "@netlify/edge-functions";
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello from the edge!");
+  return new Response("Hello world", {
+    headers: { "cache-control": "public, s-maxage=3600" },
+  });
 };
 
-export const config: Config = {
-  path: "/hello",
-};
+export const config: Config = { cache: "manual", path: "/hello" };
 ```
 
-Place files in `netlify/edge-functions/`. Uses `.ts`, `.js`, `.tsx`, or `.jsx` extensions.
+- Use caching only for endpoint-style responses reusable across clients (e.g. shared SSR HTML). **Never** for middleware, routing, or per-client personalization.
+- Cached responses do **not** count toward invocations.
+- ⚠️ A cached function **shadows real static files**: `cache:"manual"` on `/*` makes `/cat.png` serve the function, not the static file.
+- Supported headers: `Cache-Control`, `CDN-Cache-Control`, `Netlify-CDN-Cache-Control`, `Expires`, `Vary`, `Netlify-Vary`. Headers must be set inline in code.
+- New deploy in the same context voids `s-maxage`/`max-age`/`Expires` (atomic deploys).
+- No local caching — cache headers are ignored under `netlify dev`.
 
-## Config Object
+## Error handling (`onError`, inline only)
 
-```typescript
-export const config: Config = {
-  path: "/api/*",                    // URLPattern path(s)
-  excludedPath: "/api/public/*",     // Exclusions
-  method: ["GET", "POST"],           // HTTP methods
-  onError: "bypass",                 // "fail" (default), "bypass", or "/error-page"
-  cache: "manual",                   // Enable response caching
-};
+- **`"fail"`** (default) — generic error page, stops the chain.
+- **`"/custom-path"`** — rewrite to a same-site path (starts with `/`), served without invoking that path's edge functions.
+- **`"bypass"`** — skip the erroring function, continue the chain.
+
+Guidance: fail **closed** for critical logic (auth); fail **open** for progressive enhancement (localization → `bypass`).
+
+## Runtime & modules
+
+Deno runtime with many standard Web APIs (`fetch`/`Request`/`Response`/`URL`, `console`, `atob`/`btoa`, `TextEncoder`/`Decoder`(`Stream`), Web Crypto `crypto.randomUUID/getRandomValues/subtle`, `WebSocket`, timers, Streams API, `URLPattern`, `Performance`).
+
+- **Node built-ins:** `import { randomBytes } from "node:crypto"` (`node:` prefix).
+- **Deno modules:** URL import, e.g. `import React from "https://esm.sh/react"`.
+- **npm packages (beta):** `npm install` then import by name. ⚠️ Packages needing native binaries (Prisma) or runtime dynamic imports (cowsay) may fail — prefer `node:` built-ins / Deno URLs.
+- **Import maps:** separate file only (not `deno.json`), declared via `deno_import_map` in `[functions]`.
+
+### SSR at the edge (.tsx)
+```tsx
+import React from "https://esm.sh/react";
+import { renderToReadableStream } from "https://esm.sh/react-dom/server";
+import type { Config, Context } from "@netlify/edge-functions";
+
+export default async function handler(req: Request, context: Context) {
+  const stream = await renderToReadableStream(
+    <html><body><h1>Hello {context.geo.country?.name}</h1></body></html>
+  );
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/html" } });
+}
+
+export const config: Config = { path: "/hello" };
 ```
 
-**Scope `path` narrowly — `path: "/*"` intercepts every request, including static assets.** A `/*` match runs the edge function on every CSS, JS, image, and font request, not just your HTML pages — adding latency to each asset and billing an edge invocation for it. Match only the routes you need (e.g. `path: "/"`, `path: "/app/*"`), or keep a broad path but exclude static assets with `excludedPath` (e.g. `excludedPath: ["/*.css", "/*.js", "/*.png", "/*.woff2"]`).
+## Edge vs serverless
 
-**Cache headers on an edge response do nothing without `cache: "manual"`.** Setting `Cache-Control` (or any cache header) on the `Response` an edge function returns has no effect unless the function also opts in with `config.cache = "manual"`. It's both or neither: without the flag the response is never cached, no matter what headers you set.
-
-## Declaring edge functions: inline config vs netlify.toml
-
-An edge function runs only if it is bound to a path. Bind it either with an inline `export const config = { path: ... }` in the function file (shown above), or with an `[[edge_functions]]` entry in `netlify.toml` that names the file:
-
-```toml
-[[edge_functions]]
-  path = "/admin/*"
-  function = "auth"        # runs netlify/edge-functions/auth.ts
-```
-
-**A file in `netlify/edge-functions/` with no path binding still deploys, but silently never runs.** There is no build error and no warning — nothing routes a request to it, so it is never invoked. If an edge function "isn't doing anything," first confirm it declares a `path` inline or has a matching `[[edge_functions]]` entry.
-
-### Chaining multiple edge functions on one path
-
-When several edge functions match the same path, they run as a chain in this order:
-
-1. Functions declared in `netlify.toml` run first, **in the order they appear** in the file (top to bottom).
-2. Functions declared inline (via `export const config`) run next, **in alphabetical order by filename**.
-3. Functions configured for caching (`cache: "manual"`) always run after non-caching ones.
-
-To guarantee a specific order (e.g. an auth gate that must run before a personalization rewrite), declare the functions in `netlify.toml` in the order you want — don't depend on inline config, whose order is alphabetical by filename and easy to get wrong. Declaring the same function both inline and in `netlify.toml` merges them into an inline declaration (inline config wins), which forfeits the deterministic `netlify.toml` ordering.
-
-## Edge functions run before redirects
-
-In Netlify's request chain, edge functions execute **before** redirect and rewrite rules (`[[redirects]]`, `_redirects`). Two consequences bite often:
-
-- An edge function is matched against the **original** requested URL, not a redirect/rewrite destination. Scope its `path` to the URL the client actually requests — an edge function declared on the *target* of a rewrite will not fire for requests that only reach that target via the rewrite.
-- If an edge function returns a `Response`, the request chain stops there and redirect rules for that path **never run**. Return `context.next()` (or `undefined`) if you want redirects to still apply.
-
-## Middleware Pattern
-
-Use `context.next()` to invoke the next handler in the chain and optionally modify the response:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  // Before: modify request or short-circuit
-  if (!isAuthenticated(req)) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  // Continue to origin/next function
-  const response = await context.next();
-
-  // After: modify response
-  response.headers.set("x-custom-header", "value");
-  return response;
-};
-```
-
-Return `undefined` to pass through without modification:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  if (!shouldHandle(req)) return; // continues to next handler
-  return new Response("Handled");
-};
-```
-
-## Geolocation and IP
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const { city, country, subdivision, timezone } = context.geo;
-  const ip = context.ip;
-
-  if (country?.code === "DE") {
-    return Response.redirect(new URL("/de", req.url));
-  }
-};
-```
-
-Local dev with mocked geo: `netlify dev --geo=mock --country=US`
-
-## Cookies
-
-Read and write cookies through the `context.cookies` helper instead of hand-parsing the `Cookie` header or building `Set-Cookie` strings:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const bucket = context.cookies.get("bucket");            // read from the request
-  context.cookies.set({ name: "bucket", value: "a" });     // set on the response
-  context.cookies.delete("legacy_session");                // tell the client to delete it
-  return context.next();
-};
-```
-
-- `cookies.get(name)` — reads a named cookie from the incoming request.
-- `cookies.set(options)` — sets a cookie on the outgoing response (same option shape as the web `CookieStore.set` standard).
-- `cookies.delete(name)` — instructs the client to delete the cookie.
-
-## Environment Variables
-
-Use `Netlify.env` (not `process.env` or `Deno.env`):
-
-```typescript
-const secret = Netlify.env.get("API_SECRET");
-```
-
-## Module Support
-
-- **Node.js builtins**: `import { randomBytes } from "node:crypto";`
-- **npm packages**: Install via npm and import by name
-- **Deno modules**: URL imports (e.g., `import X from "https://esm.sh/package"`)
-
-For URL imports, use an import map:
-
-```json
-// import_map.json
-{ "imports": { "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts" } }
-```
-
-```toml
-# netlify.toml
-[functions]
-  deno_import_map = "./import_map.json"
-```
-
-## When to Use Edge vs Serverless
-
-| Use Edge Functions for | Use Serverless Functions for |
-|---|---|
-| Low-latency responses | Long-running operations (up to 15 min) |
-| Request/response manipulation | Complex Node.js dependencies |
-| Geolocation-based logic | Database-heavy operations |
-| Auth checks and redirects | Background/scheduled tasks |
-| A/B testing, personalization | Tasks needing > 512 MB memory |
+Edge for low-latency request/response manipulation, geolocation, auth checks/redirects, A/B personalization. Serverless for long-running work (up to 15 min), heavy Node deps, database-heavy operations, background/scheduled tasks, or memory above 512 MB.
 
 ## Limits
 
-| Resource | Limit |
-|---|---|
-| CPU time | 50 ms per request |
-| Memory | 512 MB per deployed set |
-| Response header timeout | 40 seconds |
-| Code size | 20 MB compressed |
+- Code size: **20 MB** compressed (bundle).
+- Memory: **512 MB** per deployed set.
+- CPU execution: **50 ms** per request (excludes waiting on resources; `waitUntil` work still counts).
+- Response header timeout: **40 s**.
+- Invocations/month vary by plan; cached responses don't count.
+
+## Local dev, deploy, monitor
+
+```bash
+npm install netlify-cli -g
+netlify dev      # runs edge functions on local requests at :8888
+```
+- Geo mocking: `--geo=mock` (San Francisco) or `--geo=mock --country=XX`. Debug: `--edge-inspect` / `--edge-inspect-brk`.
+- Manual deploys require CLI **12.2.8+** (older versions error). Deploys are atomic.
+- Logs: **Logs & Metrics > Edge Functions** in the UI; each `console` log names the emitting function. Filter by name/path (glob) and time. Retention ≥24h (7 days on some plans).
+
+## Feature limitations
+
+- Split Testing enabled → edge functions do **not** run.
+- Custom Headers (incl. basic auth headers) do **not** apply to edge functions.
+- Prerendering does **not** apply to paths served by an edge function.
+- Multiple framework plugins generating edge functions may collide.
+- Not part of Netlify's HIPAA-compliant offering.
+
+<!-- system: agent-context/edge-functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (edge-functions)
+
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-edge-functions skill; owned
+by the skills maintainer.
+
+1. Check the framework's adapter/reference first: a custom edge function that
+   duplicates adapter-generated middleware causes conflicts. Only hand-write
+   an edge function when the framework doesn't already generate one for the
+   job.
+2. Scope `path` narrowly. `path: "/*"` intercepts every request — including
+   static assets — adding latency to each one and billing an edge invocation
+   for it.
+3. An edge function without a route (no config export, no netlify.toml
+   declaration) still deploys, but silently never runs: no build error, no
+   warning. When "my edge function does nothing", check the route first.
+4. Choose edge vs serverless by workload shape: edge functions for low-latency
+   request/response manipulation, geolocation logic, auth checks/redirects,
+   and A/B personalization; serverless functions for long-running work (up to
+   15 min), heavy Node.js dependencies, database-heavy operations,
+   background/scheduled tasks, or memory needs above 512 MB.
+5. Cache headers on an edge response do nothing without `cache: "manual"` in
+   config — it's both or neither. Setting `Cache-Control` on the returned
+   `Response` has no effect unless the function also opts in.

--- a/codex/skills/netlify-forms/SKILL.md
+++ b/codex/skills/netlify-forms/SKILL.md
@@ -1,195 +1,196 @@
 ---
 name: netlify-forms
-description: Guide for using Netlify Forms for HTML form handling. Use when adding contact forms, feedback forms, file upload forms, or any form that should be collected by Netlify. Covers the data-netlify attribute, spam filtering, AJAX submissions, file uploads, notifications, and the submissions API.
+description: Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam, and sends notifications. Use when adding a contact form, lead-capture form, file-upload form, or newsletter signup to a Netlify site; wiring AJAX form submission; setting up a custom thank-you page; adding a honeypot or reCAPTCHA to a form; getting forms working in Next.js, Nuxt, SvelteKit, Astro, or Gatsby; reading form submissions via the Netlify API; or debugging missing submissions and forms that silently fail to register.
 ---
 
 # Netlify Forms
 
-Netlify Forms collects HTML form submissions without server-side code. Form detection must be enabled in the Netlify UI (Forms section).
+Mark a form for detection with `data-netlify="true"` (or the bare `netlify` attribute — equivalent) on the `<form>` tag. Forms are detected by **parsing the final built HTML at deploy time** — there is no runtime API call or backend code. Client-side/JS-rendered/SSR forms are NOT in the built HTML and are never detected on their own; they require a static skeleton file (see below).
 
-> **Enabling detection only affects future deploys.** Netlify scans for forms at deploy time, so turning on (or re-enabling) form detection does **not** rescan your current live deploy. After enabling detection you must trigger a new deploy/build before an already-published form is registered and starts collecting submissions.
+Prerequisite: form detection must be enabled once in the Netlify UI (Forms > **Enable form detection**). Takes effect on the next deploy.
 
-## Basic Setup
-
-Add `data-netlify="true"` and a unique `name` to the form:
+## Static HTML form
 
 ```html
 <form name="contact" method="POST" data-netlify="true">
-  <label>Name: <input type="text" name="name" /></label>
-  <label>Email: <input type="email" name="email" /></label>
-  <label>Message: <textarea name="message"></textarea></label>
-  <button type="submit">Send</button>
+  <p><label>Your Name: <input type="text" name="name" /></label></p>
+  <p><label>Your Email: <input type="email" name="email" /></label></p>
+  <p><label>Message: <textarea name="message"></textarea></label></p>
+  <p><button type="submit">Send</button></p>
 </form>
 ```
 
-Netlify's build system detects the form and injects a hidden `form-name` input automatically. For a custom success page, add `action="/thank-you"` to the form tag. Use paths without `.html` extension — Netlify serves `thank-you.html` at `/thank-you` by default, and the `.html` path returns 404.
+- `name` sets the form name in the UI and **must be unique per site**.
+- At deploy, Netlify strips the `data-netlify`/`netlify` attribute and injects `<input type="hidden" name="form-name" value="contact" />`.
+- Add an `<input name="email">` so the notification email's `Reply-to` is set to the submitter.
 
-## JavaScript-Rendered Forms (React, Vue, SSR Frameworks)
+## JS-rendered / SSR / framework forms (Next.js, Nuxt, SvelteKit, Astro, Gatsby)
 
-For forms rendered by JavaScript frameworks (React, Vue, Astro, TanStack Start, Next.js, SvelteKit, Remix, Nuxt), Netlify's build parser cannot detect the form in static HTML. You MUST create a static HTML skeleton file for build-time form detection:
+Two required pieces:
 
-> **Form detection parses prerendered HTML only.** A `data-netlify` form is registered only if it appears in HTML produced at build time. On an Astro route that is server-rendered on demand (`export const prerender = false`, or an `output: "server"` route), the form is generated per request and is never scanned at build — so it is never registered. Put the form on a prerendered page, or add the static skeleton file below.
-
-Create a static HTML file in `public/` (e.g. `public/__forms.html`) containing a hidden copy of each form:
+**1. Static skeleton file `public/__forms.html`** — a hidden copy of each form with `data-netlify="true"`, a hidden `form-name` input, and every field the component submits, with names matching **exactly** (Netlify validates field names against the registered form). Without this file, submissions silently fail.
 
 ```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" />
-      <input type="email" name="email" />
-      <textarea name="message"></textarea>
-      <input name="bot-field" />
-    </form>
-  </body>
-</html>
+<!-- public/__forms.html -->
+<form name="pizzaOrder" data-netlify="true" hidden>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" />
+</form>
 ```
 
-**Rules:**
-- The form `name` must exactly match the `form-name` value used in your component's fetch call
-- Include every field your component submits — Netlify validates field names against the registered form
-- Without this file, Netlify cannot detect the form and submissions will silently fail
-
-Your component must also include a hidden `form-name` input:
+**2. The rendered form** carries a matching hidden `form-name` input:
 
 ```jsx
-<form name="contact" method="POST" data-netlify="true">
-  <input type="hidden" name="form-name" value="contact" />
-  {/* ... fields ... */}
+<form name="pizzaOrder" method="post" data-netlify="true" onSubmit={handleSubmit}>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" onChange={handleChange} />
+  <input type="submit" />
 </form>
 ```
 
-## AJAX Submissions
+**⚠️ SSR POST target:** In SSR apps, `fetch("/")` is intercepted by the SSR catch-all function and never reaches form processing. POST to the static skeleton file itself — `/__forms.html` — not `/` or an arbitrary path.
 
-> **Netlify Forms does not accept JSON.** The submission body must be `application/x-www-form-urlencoded` (encode the fields with `URLSearchParams`) or `multipart/form-data` (a raw `FormData` object, for file uploads). A `fetch` that sends `JSON.stringify(...)` with `Content-Type: application/json` is silently **not** recorded as a submission — always send URL-encoded key/value pairs (or `FormData`), never JSON.
+**⚠️ Astro on-demand routes:** Routes with `export const prerender = false` or `output: "server"` are never scanned at build time, so their forms are never registered. Put the form on a prerendered page, or rely on the static skeleton file.
 
-### Vanilla JavaScript
+**Next.js Runtime v5 (Next.js 13.5+):** extract form definitions to the static skeleton file and submit via AJAX rather than full-page navigation. See https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview#v5-breaking-changes
 
-```javascript
-const form = document.querySelector("form");
-form.addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const formData = new FormData(form);
-  await fetch("/", {
+## AJAX submission
+
+```js
+const handleSubmit = event => {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  fetch("/__forms.html", {   // static sites may POST to "/"; SSR must target the skeleton file
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(formData).toString(),
-  });
+    body: new URLSearchParams(formData).toString()
+  })
+    .then(() => alert("Thank you for your submission"))  // or navigate("/thank-you")
+    .catch(error => alert(error));
+};
+document.querySelector("form").addEventListener("submit", handleSubmit);
+```
+
+- **Body MUST be URL-encoded. JSON is NOT supported.**
+- If the rendered form has no hidden `form-name` input, you MUST include a `form-name` field in the POST body.
+- The honeypot field name and `g-recaptcha-response` (if used) must be in the body — automatic with `FormData()`.
+
+## File uploads
+
+Add `type="file"`; optionally `enctype="multipart/form-data"` on the `<form>`. For AJAX file uploads, **do NOT set a `Content-Type` header** — let the browser set it (with the multipart boundary).
+
+```js
+document.forms.fileForm.addEventListener("submit", event => {
+  event.preventDefault();
+  fetch("/", { body: new FormData(event.target), method: "POST" })  // no headers
+    .then(() => { /* success */ });
 });
 ```
 
-> **SSR frameworks (TanStack Start, Next.js, SvelteKit, Remix, Nuxt):** The `fetch` URL must target the static skeleton
-> file path (e.g. `"/__forms.html"`), **not** `"/"`. In SSR apps, `fetch("/")` is intercepted by the SSR catch-all
-> function and never reaches Netlify's form processing middleware. See the React example and troubleshooting section below.
+Limits: one file per field (use multiple fields for multiple files) · 8 MB max request size · 30 s upload timeout · after form deletion, uploaded files stay at their direct URL for 24 h. PII uploads need extra security (Very Good Security integration).
 
-### React Example
+## Custom success page
 
-```tsx
-function ContactForm() {
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    // For SSR apps, use the skeleton file path instead of "/" (e.g. "/__forms.html")
-    const response = await fetch("/__forms.html", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(formData as any).toString(),
-    });
-    if (response.ok) {
-      // Show success feedback
-    }
-  };
+Add an `action` path relative to site root, starting with `/`. **Use extensionless paths** — Netlify serves `thank-you.html` at `/thank-you`; the `.html` path returns 404.
 
-  return (
-    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" placeholder="Name" />
-      <input type="email" name="email" placeholder="Email" />
-      <textarea name="message" placeholder="Message" />
-      <button type="submit">Send</button>
-    </form>
-  );
-}
+```html
+<form name="contact" action="/thank-you" method="POST" data-netlify="true"></form>
 ```
 
-> **SSR troubleshooting:** If form submissions appear to succeed (200 response) but nothing shows in the Netlify Forms
-> UI, the POST is likely being intercepted by the SSR function. Ensure `fetch` targets the skeleton file path (e.g.
-> `"/__forms.html"`), not `"/"`. The skeleton file path routes through the CDN origin where Netlify's form handler runs.
+Custom success *alert* is only possible via AJAX (substitute the redirect with your own logic).
 
-## Spam Filtering
+## Spam prevention
 
-Netlify uses Akismet automatically. Add a honeypot field for extra protection:
+All submissions are filtered by Akismet. Passed → **Verified submissions**; flagged → **Spam submissions**. Honeypot/reCAPTCHA failures are rejected and appear in neither list.
+
+**Honeypot:** add `netlify-honeypot="bot-field"` to the `<form>` and include a CSS-hidden field of that name. Any value entered → submission quietly rejected.
 
 ```html
 <form name="contact" method="POST" netlify-honeypot="bot-field" data-netlify="true">
-  <p style="display:none">
-    <label>Don't fill this out: <input name="bot-field" /></label>
-  </p>
-  <!-- visible fields -->
+  <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
+  <!-- real fields -->
 </form>
 ```
 
-For reCAPTCHA, add `data-netlify-recaptcha="true"` to the form and include `<div data-netlify-recaptcha="true"></div>` where the widget should appear.
+**Netlify reCAPTCHA 2:** add `data-netlify-recaptcha="true"` to the `<form>` AND an empty `<div data-netlify-recaptcha="true"></div>` where it renders. Only ONE Netlify-provided challenge per page — for multiple, use custom reCAPTCHA. For JS-rendered forms, also add the `div` to the static skeleton file.
 
-By default Netlify provisions and verifies the reCAPTCHA for you — do **not** add a site key/secret or load Google's reCAPTCHA script yourself. To use **your own** reCAPTCHA v2 keys, keep the same `data-netlify-recaptcha="true"` markup and set the credentials as Netlify environment variables: `SITE_RECAPTCHA_KEY` (the site key, scoped to Builds and Runtime) and `SITE_RECAPTCHA_SECRET` (the secret, scoped to Runtime). Netlify picks these up automatically — the secret stays server-side as an env var (never hardcoded in client code), and you still don't render the widget with Google's own script or build a custom Function to verify the token.
+**Custom reCAPTCHA 2:** your own reCAPTCHA snippet + `data-netlify-recaptcha="true"` on the `<form>`, plus env vars:
+- `SITE_RECAPTCHA_KEY` — site key (scopes: Builds + Runtime)
+- `SITE_RECAPTCHA_SECRET` — secret (scope: Runtime)
 
-> **Spam submissions are silent.** Akismet-flagged submissions are moved to a separate **Spam** list in the Forms UI — they do **not** appear in the verified submissions list and do **not** trigger email/Slack notifications. Submissions caught by a honeypot field or a failed reCAPTCHA challenge are discarded entirely and never appear in either list. So a "missing" legitimate submission is usually a false-positive spam classification, not a delivery bug: check the Spam list (or the Submissions API with `?state=spam`) and mark it verified — do not build a custom Function to "recover" it or disable spam filtering as a first resort.
+## Email notifications & subject line
 
-## File Uploads
+Default sender: `formresponses@netlify.com`. Set subject via a hidden `subject` input **or** the Netlify UI (Configuration > Notifications) — **not both; the HTML value always overrides the UI.**
 
 ```html
-<form name="upload" enctype="multipart/form-data" data-netlify="true">
-  <input type="text" name="name" />
-  <input type="file" name="attachment" />
-  <button type="submit">Upload</button>
-</form>
+<input type="hidden" name="subject" value="New lead from %{formName} (%{submissionId})" />
 ```
 
-For AJAX file uploads, use `FormData` directly — do **not** set `Content-Type` (the browser sets it with the correct boundary):
+Variables: `%{formName}`, `%{siteName}`, `%{submissionId}`. Forms created before **May 5, 2023** carry a `[Netlify]` subject prefix — remove it by adding the `data-remove-prefix` attribute to the `subject` input.
 
-```javascript
-await fetch("/", { method: "POST", body: new FormData(form) });
-```
+Set up notifications (email/webhook/Slack) in the UI: Configuration > Notifications > Form submission notifications > **Add notification**.
 
-**Limits:** 8 MB max request size, 30-second timeout, one file per input field.
+## Reading submissions via the API
 
-## Notifications
+Use only documented surfaces. Do NOT invent `api.netlify.com` endpoints or read tokens from local CLI config files. Reference: https://open-api.netlify.com/#tag/submission/operation/listFormSubmissions
 
-Configure in the Netlify UI under **Project configuration > Notifications**:
+- **Page through results using the `Link` header** — code that reads only the first response silently drops the rest.
+- `listFormSubmissions` returns data from old/removed fields no longer shown in the UI.
+- Query spam with `?state=spam`.
 
-- **Email**: Auto-sends on submission. Add `<input type="hidden" name="subject" value="Contact form" />` for custom subject lines.
-- **Slack**: Via Netlify App for Slack.
-- **Webhooks**: Trigger external services on submission.
+## Submission summary (field order matters)
 
-## Submissions API
+The UI summary is derived from field **type**, not name:
+- **Title**: first non-hidden text `<input>` that isn't email-like (`type="email"`, or name matching `email`/`mail`/`from`/`twitter`/`sender`); falls back to a field named `title` or `subject`.
+- **Body**: first `<textarea>`.
 
-Access submissions programmatically:
+Field order in the HTML affects what appears in the summary.
 
-```
-GET /api/v1/forms/{form_id}/submissions
-Authorization: Bearer <PERSONAL_ACCESS_TOKEN>
-```
+## Debugging missing submissions
 
-Key endpoints:
+- **First suspect: Akismet false positive.** A missing legitimate submission is usually spam-flagged — check the **Spam** list (or API `?state=spam`) and mark it verified. Do NOT build a custom recovery function or disable spam filtering as a first resort.
+- Test submissions get flagged as spam: use a real email (not `test@test.com`), write full sentences, don't hammer from one IP.
+- No submissions at all: confirm form detection is enabled and redeploy.
+- SSR/JS forms silently failing: verify the static skeleton file exists with exactly-matching field names and that AJAX targets the skeleton file, not `/`.
+- Missing old-field data: the UI shows only fields from the last deployed form version. Mark old fields `hidden` instead of removing them to keep them visible; old data remains available via `listFormSubmissions`.
 
-| Action | Method | Path |
-|---|---|---|
-| List forms | GET | `/api/v1/sites/{site_id}/forms` |
-| Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
-| Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
-| Delete submission | DELETE | `/api/v1/submissions/{id}` |
+## Constraints
 
-### Pagination
+- Deleting a form is permanent: future submissions return `404`, past submissions become unavailable. Export CSV first.
+- Submitted code is sanitized (`<script>` → escaped entities).
+- For PII, export and delete data regularly.
+- Data is stored in Netlify's database, not accessible except via UI/API/CSV.
 
-The Netlify API paginates any response over 100 items (100 per page by default). Pass `?page=` (1-based) and optionally `?per_page=` (max 100), and follow the `Link` response header — it carries the `rel="next"` and `rel="last"` page URLs. To sync **every** submission, page through until there is no `rel="next"` link (or a page returns fewer than `per_page` items). A single request does **not** return all submissions once a form has more than 100 — code that reads only the first response silently drops the rest.
+<!-- system: agent-context/forms/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (forms)
 
-## Use only documented surfaces
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-forms skill; owned by the
+skills maintainer.
 
-To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
-
-- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
-- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
-
-If a documented path fails, report the exact error and context to the user and stop.
+1. In SSR apps (Next.js, Nuxt, SvelteKit, etc.), `fetch("/")` is intercepted
+   by the SSR catch-all function and never reaches Netlify's form processing.
+   POST the AJAX submission to the static skeleton file itself (e.g.
+   `/__forms.html`), not to an arbitrary path.
+2. Use only documented surfaces: do not curl `https://api.netlify.com/...`
+   with an invented endpoint shape, and do not read tokens out of local CLI
+   config files (`~/Library/Preferences/netlify/config.json`).
+3. When reading submissions via the API, page through results (`Link`
+   header); code that reads only the first response silently drops the rest.
+4. For JS-rendered and SSR forms, always create the static skeleton file
+   `public/__forms.html`: a hidden copy of each form with
+   `data-netlify="true"`, a hidden `form-name` input, and every field the
+   component submits — names matching exactly (Netlify validates field names
+   against the registered form). Without this file, submissions silently fail.
+5. Astro routes rendered on demand (`export const prerender = false`, or
+   `output: "server"` routes) are never scanned at build time, so their forms
+   are never registered. Put the form on a prerendered page or rely on the
+   static skeleton file.
+6. A "missing" legitimate submission is usually an Akismet false positive:
+   check the Spam list (or the API with `?state=spam`) and mark it verified.
+   Do not build a custom recovery function or disable spam filtering as a
+   first resort.
+7. For custom success pages, use extensionless `action` paths (`/thank-you`,
+   not `/thank-you.html`) — Netlify serves `thank-you.html` at `/thank-you`
+   and the `.html` path returns 404.

--- a/codex/skills/netlify-frameworks/SKILL.md
+++ b/codex/skills/netlify-frameworks/SKILL.md
@@ -1,116 +1,241 @@
 ---
 name: netlify-frameworks
-description: Guide for deploying web frameworks on Netlify. Use when setting up a framework project (Vite/React, Astro, TanStack Start, Next.js, Nuxt, SvelteKit, Remix) for Netlify deployment, configuring adapters or plugins, running a framework project locally with Netlify's platform features, or troubleshooting framework-specific Netlify integration. Covers what Netlify needs from each framework, how adapters handle server-side rendering, and the general local development options (`netlify dev` versus the Netlify Vite plugin family).
+description: Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and env vars. Use when setting up or fixing a framework deploy (Next.js / Astro / Nuxt / SvelteKit / Remix / React Router / TanStack Start / SolidStart / Gatsby / Angular / Vite / Express / Hydrogen / Hugo / Eleventy / Vue / React), adding SSR or edge functions or middleware wired to Netlify context, fixing SPA redirect and catch-all rules, setting a build command or publish directory, or debugging "why isn't my env var updating" and framework build failures.
 ---
 
-# Frameworks on Netlify
+Route framework-specific deep work to the guides in this skill: `references/astro.md`, `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`, `references/tanstack.md`, `references/vite.md`.
 
-Netlify supports any framework that produces static output. For frameworks with server-side capabilities (SSR, API routes, middleware), an adapter or plugin translates the framework's server-side code into Netlify Functions and Edge Functions automatically.
+## Env vars: modern rules (read first)
 
-## How It Works
+Env values are injected **at build time**. Any change (client- or server-side) requires a **redeploy** — editing a var in the UI/CLI does NOT reach the live site or already-deployed functions until a new build runs.
 
-During build, the framework adapter writes files to `.netlify/v1/` — functions, edge functions, redirects, and configuration. Netlify reads these to deploy the site. You do not need to write Netlify Functions manually when using a framework adapter for server-side features.
+**Never use a client prefix for secrets.** Client-prefixed vars are inlined into the browser bundle:
+`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`.
 
-## Detecting Your Framework
+Client-embed prefixes by framework: CRA `REACT_APP_`, Gatsby `GATSBY_`, Next `NEXT_PUBLIC_`, Nuxt `NUXT_ENV_`, Vue CLI `VUE_APP_`.
 
-Check these files to determine the framework:
+**Scopes:** build-time access needs **Builds** scope; SSR/DSG runtime access needs **both Functions and Builds**. `netlify.toml` is read only during build — functions cannot read it at runtime; set runtime vars in UI/CLI/API.
 
-| File | Framework |
-|---|---|
-| `astro.config.*` | Astro |
-| `next.config.*` | Next.js |
-| `nuxt.config.*` | Nuxt |
-| `vite.config.*` + `react-router` | Vite + React (SPA or Remix) |
-| `vite.config.*` + `@tanstack/react-start` | TanStack Start |
-| `svelte.config.*` | SvelteKit |
-
-## Framework Reference Guides
-
-Each framework has specific adapter/plugin requirements and local dev patterns:
-
-- **Vite + React (SPA or with server routes)**: See [references/vite.md](references/vite.md)
-- **Astro**: See [references/astro.md](references/astro.md)
-- **TanStack Start**: See [references/tanstack.md](references/tanstack.md)
-- **Next.js**: See [references/nextjs.md](references/nextjs.md)
-- **Nuxt**: See [references/nuxt.md](references/nuxt.md)
-- **SvelteKit**: See [references/sveltekit.md](references/sveltekit.md)
-
-## Local Development
-
-Running a framework project locally with Netlify's platform features (environment variables, Functions, Edge Functions) generally comes from one of two places:
-
-### `netlify dev`
-
-```bash
-netlify dev
-```
-
-Wraps the framework's own dev server and adds:
-- Environment variable injection
-- Functions and Edge Functions
-- Redirects and headers processing
-
-Works with any framework — run `netlify dev` in place of the framework's native dev command (e.g. instead of `npm run dev`).
-
-Custom dev-server wiring — a non-standard `command`, a `port`/`targetPort`, or the `framework` key — goes in `netlify.toml`'s `[dev]` block; see the **netlify-config** skill for the full syntax. One easy-to-miss rule: if you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`, otherwise Netlify Dev runs its own detector and silently ignores your command.
-
-### Netlify Vite plugin family (Vite-based frameworks)
-
-For frameworks built on Vite, a Netlify Vite plugin exposes platform primitives (Functions, Blobs, DB, environment variables) directly inside the framework's own dev server, so no `netlify dev` wrapper is needed — run the framework's normal dev command (e.g. `npm run dev`) once the plugin is registered in `vite.config.ts`.
-
-- Vite-based projects (React SPA, SvelteKit, Remix): `@netlify/vite-plugin` — see [references/vite.md](references/vite.md)
-- TanStack Start: `@netlify/vite-plugin-tanstack-start` — see [references/tanstack.md](references/tanstack.md)
-
-The per-framework reference guides may also document other local dev options (e.g. `netlify dev`) — check the guide for your framework for setup specifics.
-
-### Running a single command with the Netlify environment loaded
-
-```bash
-netlify dev:exec <cmd>
-```
-
-Loads the Netlify environment (env vars, etc.) for a single command without starting a dev server — useful for scripts, tests, or one-off tasks that need Netlify-managed environment variables.
-
-## General Patterns
-
-### Client-Side Routing (SPA)
-
-For single-page apps with client-side routing, add a catch-all redirect:
-
+Netlify build variables can't be used as values in the UI or `netlify.toml` env sections. Set them inline before the build command:
 ```toml
-# netlify.toml
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+[build]
+  command = "REACT_APP_CONTEXT=$CONTEXT npm run build"
 ```
 
-> **Remove this catch-all when you adopt an SSR adapter.** A `/* → /index.html` rule left over from an SPA setup will shadow your server routes: user-defined redirects in `netlify.toml`/`_redirects` take precedence over the routes a framework adapter generates, so every request — including SSR pages and API/function routes — is served the static `index.html` with a 200. When you migrate a client-rendered app to SSR, delete the SPA catch-all.
+## SPA redirects and the SSR catch-all footgun
 
-### Custom 404 Pages
+SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.html` for `pushState`:
+```
+/* /index.html 200
+```
 
-- **Static sites**: Create a `404.html` in your publish directory. Netlify serves it automatically for unmatched routes.
-- **SSR frameworks**: Handle 404s in the framework's routing (the adapter maps this to Netlify's function routing).
+**Remove any SPA catch-all when adopting an SSR adapter.** A leftover `/* → /index.html 200` silently serves static `index.html` for SSR pages and API routes — user redirects beat adapter-generated routes.
 
-### Environment Variables in Frameworks
+## Local dev with platform emulation (no Netlify CLI)
 
-Each framework exposes environment variables to client-side code differently:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
 
-| Framework | Client prefix | Access pattern |
-|---|---|---|
-| Vite / React | `VITE_` | `import.meta.env.VITE_VAR` |
-| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_VAR` |
-| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_VAR` |
-| Nuxt | `NUXT_PUBLIC_` | `useRuntimeConfig().public.var` |
+| Framework | Plugin/module | Run |
+|-----------|---------------|-----|
+| Astro (5.12+) | built-in (Netlify Vite plugin auto-loaded) | `astro dev` |
+| Nuxt | `@netlify/nuxt` | `nuxt dev` |
+| React Router | `@netlify/vite-plugin` | `react-router dev` |
+| SolidStart 2 | `@netlify/vite-plugin` | `vite dev` |
+| TanStack Start | `@netlify/vite-plugin-tanstack-start` | (vite) |
+| Vite | `@netlify/vite-plugin` | `npx vite` |
 
-In server-side code, prefer `Netlify.env.get("VAR")` to read environment variables. `process.env.VAR` also works inside Netlify Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps server code working in both.
+Still need `netlify dev` (Netlify CLI) for: Gatsby generated functions (run `netlify build` first), Angular SSR local test (`netlify serve`), and frameworks without a Vite plugin.
 
-**Never use a client prefix (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) for secrets.** Client-prefixed variables are inlined into the client bundle and exposed to the browser.
+**`netlify dev` gotcha:** with both a custom `command` and a `targetPort` in `[dev]`, you must set `framework = "#custom"` — otherwise the detector runs and your custom command is silently ignored.
 
-### Environment Variable Changes Require a Redeploy
+## Build settings by framework
 
-Client-prefixed vars (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`) are **inlined into the client bundle at build time** — their values are compiled into the JavaScript shipped to the browser. Editing one in the Netlify UI or CLI has no effect on the live site until a new build runs. The same applies server-side: Netlify injects environment variables at build time, so changing a value in the dashboard does **not** propagate to already-deployed functions on the next request. Any env var change — client- or server-side — requires a redeploy to take effect. If a value looks stale after you changed it, trigger a new deploy.
+| Framework | Build command | Publish |
+|-----------|---------------|---------|
+| Angular (standard) | `ng build --prod` | `dist/YOUR_PROJECT_NAME` |
+| Astro | `astro build` | `dist` |
+| Create React App | `react-scripts build` | `build` |
+| Eleventy | `eleventy` | `_site` |
+| Gatsby | `gatsby build` | `public` |
+| Hugo | `hugo` | `public` |
+| Hydrogen | `remix vite:build` | `dist/client` |
+| Next.js (SSR/hybrid) | `next build` | `.next` |
+| Next.js (static export) | `next build && next export` | `out` (`NETLIFY_NEXT_PLUGIN_SKIP=true`) |
+| Nuxt 3 | `nuxt build` | `dist` |
+| Nuxt 2 | `nuxt generate` | `dist` |
+| React Router | `react-router build` | `build/client` |
+| Remix (Vite) | `remix vite:build` | `build/client` |
+| SolidStart 2 (Vite plugin) | `vite build` | `dist/client` |
+| SolidStart 2 (Nitro) | `vite build` | `dist` |
+| SolidStart 1.x | `vinxi build` | `dist` |
+| SvelteKit | `vite build` | `build` |
+| TanStack Start (1.132.0+) | `vite build` | `dist/client` |
+| Vite | `vite build` | `dist` |
+| Vue CLI | `vue-cli-service build` | `dist` |
 
-### Runtime File Reads in Adapter-Generated Functions
+Detection suggests these; override in `netlify.toml` or UI (project configuration > Build & deploy > Continuous deployment > Build settings).
 
-When an adapter turns your server code into a Netlify Function, only traced module dependencies are bundled. Arbitrary files you read from disk at runtime — a local JSON/Markdown data file, an email template, an `fs.readFile()` target — are **not** uploaded with the function unless you declare them. Such a read succeeds under `npm run dev` (the whole project is on disk) but throws `ENOENT` in production. Declare the files so they ship with the function: in Next.js set `outputFileTracingIncludes` in `next.config`; for a hand-written Netlify Function use `included_files` in its `config`. Never assume the project filesystem is present at function runtime.
+## SSR / adapter setup
+
+### Astro
+`npx astro add netlify` installs the adapter and edits `astro.config.mjs`. Adapter needed for SSR and out-of-the-box Image CDN for `<Image />`. SSR → Netlify Functions; middleware → Edge Functions. Adapter-less deploy only if no server features and no Image CDN need. Skew protection from 5.15.0.
+
+### Next.js (13.5+ only)
+Zero-config via the OpenNext adapter (`@netlify/plugin-nextjs`). Do NOT pin the version — Netlify auto-updates each build. Treat the legacy adapter as read-only history, never a recommendation.
+Adapter provisions: serverless function for SSR/ISR/PPR/route handlers/Server Actions; Edge Function for Middleware; Full Route + Data Cache; Image CDN with `next/image`.
+Skew protection is opt-in: set `NETLIFY_NEXT_SKEW_PROTECTION=true`, redeploy. No automatic support for client `fetch` — direct calls with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`. Details in `references/nextjs.md`.
+
+### SvelteKit
+```bash
+npm install -D @sveltejs/adapter-netlify
+```
+```js
+import adapter from '@sveltejs/adapter-netlify';
+export default { kit: { adapter: adapter() } };
+```
+Replace `@sveltejs/adapter-auto` with the specific import. SSR routes → a `render` function.
+- `split: true` → one function per route. **Incompatible with Edge Functions** (`edge: false` or omit).
+- `edge: true` → SSR in a Deno edge function; can't combine with `split`.
+- **Redirects NOT supported in `netlify.toml`** — use `_redirects`.
+- Edge functions don't work locally with `netlify dev` for SvelteKit.
+
+### React Router (7+)
+New: `npx create-react-router@latest --template netlify/react-router-template`. Existing:
+```bash
+npm install @netlify/vite-plugin-react-router
+```
+Add `netlifyReactRouter()` to Vite plugins. Default target = Serverless Functions.
+**Edge (Deno):** needs plugin v2.1.1+, set `edge: true`, and you **must** create `app/entry.server.tsx`:
+```typescript
+export { default } from 'virtual:netlify-server-entry'
+```
+Exclude your own function paths: `netlifyReactRouter({ edge: true, excludedPaths: ['/api/*'] })`.
+**Moving back to Serverless:** remove `edge: true` AND delete `app/entry.server.tsx`.
+Middleware (React Router v7.9.0+, plugin v2.0.0+): opt in via `future.v8_middleware`; import `netlifyRouterContext` from `@netlify/vite-plugin-react-router/serverless` (or `/edge` when `edge: true`); access `context.get(netlifyRouterContext)`.
+
+### Remix
+New: `npx create-remix@latest --template netlify/remix-template` (CLI prompts functions vs Edge Functions). Manual (Remix Vite required):
+```bash
+npm install --save-dev @netlify/remix-adapter
+```
+Add `netlifyPlugin()` from `@netlify/remix-adapter/plugin` to Vite plugins.
+
+### Nuxt
+SSR via Nitro, automatic on Nuxt 3. Local parity via `@netlify/nuxt` (`npx nuxi module add @netlify/nuxt`).
+- SSR on Edge Functions requires a different Nitro deployment preset (not auto-detected).
+- pnpm + Nuxt 3: set `PNPM_FLAGS=--shamefully-hoist`.
+- `nuxt/image` auto-uses Netlify Image CDN; set remote domains in `nuxt.config.ts`.
+
+### SolidStart
+SolidStart 2 builds on Vite — **no SolidStart-specific adapter**. Install `@netlify/vite-plugin`:
+```ts
+import netlify from "@netlify/vite-plugin";
+import { solidStart } from "@solidjs/start/config";
+import { defineConfig } from "vite";
+export default defineConfig({
+  plugins: [solidStart(), netlify({ build: { enabled: true } })],
+});
+```
+Publish `dist/client`. SSR routes, server functions, middleware → Netlify Functions, zero extra config.
+**Nitro alternative:** add `nitro()`, use plain `netlify()` (no `build.enabled`), publish `dist`.
+SolidStart 1: Nitro auto-configures; optionally set `preset: "netlify"` in `app.config.ts`; `vinxi build` / `dist`.
+
+### TanStack Start
+React (and Solid.js) full-stack; SSR/Server Routes/Server Functions/middleware → serverless functions.
+```bash
+npm install -D @netlify/vite-plugin-tanstack-start
+```
+Add `netlify()` to Vite plugins alongside `tanstackStart()`; `vite build` / `dist/client` (1.132.0+). Netlify CLI deploys require netlify-cli 17.31+. Older versions: see `references/tanstack.md`.
+
+### Gatsby
+- **5.12.0+ (adapter):** auto-detects and installs `gatsby-adapter-netlify` (zero-config). Generates functions `SSR`, `DSG`. No Essential Gatsby plugin needed.
+- **5.11.0 or earlier (Essential Gatsby plugin):** auto-installs `@netlify/plugin-gatsby`; also manually install `gatsby-plugin-netlify` (required for SSR, Gatsby redirects, asset caching). Generates `__api`, `__ssr`, `__dsg`, `__ipx`. Skip via `NETLIFY_SKIP_GATSBY_FUNCTIONS` (all) / `NETLIFY_SKIP_API_FUNCTION` / `NETLIFY_SKIP_SSR_FUNCTION` / `NETLIFY_SKIP_DSG_FUNCTION`.
+- Gatsby 5 requires Node 18.
+- Large sites: set `GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE` to load datastore from CDN (avoids max function deploy size; slower first SSR/DSG load).
+- Image CDN: set `NETLIFY_IMAGE_CDN=true` (Contentful/Drupal/WordPress source plugins). **Not supported on 5.12.x with adapter — upgrade to 5.13.0+.**
+- `StaticImage` and `gatsby-transformer-sharp` don't work for SSR/DSG — host images on a CDN.
+
+### Angular
+SSR auto-configured via an Edge Function. Suggested dev: `ng serve` / `4200`.
+- **SSR pages are NOT subject to `_redirects` or `netlify.toml` redirects** — SSR uses Edge Functions that run before redirects. Use Angular's built-in redirects.
+- Access `Request`/`Context` in SSR via `netlify.request` / `netlify.context` providers (from `@netlify/edge-functions`); unavailable client-side or during prerendering. Test locally with `netlify serve`.
+- `NgOptimizedImage` auto-uses Image CDN; set `remote_images` (array of regex) under `[images]` in `netlify.toml`.
+
+### Express
+Node 18.14.0+. Deploy as a Netlify Function via `serverless-http`:
+```bash
+npm i express serverless-http @netlify/functions @types/express
+```
+```ts
+// netlify/functions/api.ts
+import express, { Router } from "express";
+import serverless from "serverless-http";
+const api = express();
+const router = Router();
+router.get("/hello", (req, res) => res.send("Hello World!"));
+api.use("/api/", router);
+export const handler = serverless(api);
+```
+```toml
+[functions]
+  external_node_modules = ["express"]
+  node_bundler = "esbuild"
+[[redirects]]
+  force = true
+  from = "/api/*"
+  status = 200
+  to = "/.netlify/functions/api/:splat"
+```
+No frontend: set a placeholder build command (e.g. `echo Building Functions`). All Function limits apply; not recommended as background/scheduled functions.
+
+### Hydrogen
+Shopify stack on React Router 7. **SSR only on Netlify Edge Functions — Netlify Functions NOT officially supported.** Node 24+. Use the starter:
+```bash
+npm create @shopify/hydrogen@latest -- --template https://github.com/netlify/hydrogen-template
+cp .env.example .env && npm run dev
+```
+
+## Static-site gotchas
+
+### Hugo
+Set `HUGO_VERSION` (any release after 0.19) in `[build.environment]` — a missing/mismatched version causes `exit code: 255`. Install themes as **git submodules** (`git submodule add ...`), not `git clone`.
+
+### Eleventy
+`eleventy` / `_site`. **Build plugins require editing `.gitignore`: change `node_modules` to `**/node_modules/**`** — otherwise Netlify plugins and Eleventy collide on `.netlify/plugins/node_modules/` and the build errors.
+
+## Vite meta-framework support matrix
+Astro (auto on 5.12+), Nuxt (via `@netlify/nuxt`), TanStack Start (via `@netlify/vite-plugin-tanstack-start`), React Router, SolidStart — all **full**. SvelteKit — **experimental**.
+
+## Deploy via CLI (Express, Nuxt, React, Vite)
+```sh
+npm install netlify-cli -g
+netlify init
+```
+Follow prompts to create/link the site and set build settings.
+
+<!-- Node version floors (18.14.0+) are stated per-framework where documented; no cross-framework build-image default is given in sources. -->
+
+<!-- system: agent-context/frameworks/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (frameworks)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Per-framework deep guides live in this skill: `references/astro.md`,
+   `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`,
+   `references/tanstack.md`, `references/vite.md` — route framework-specific
+   work there before improvising.
+2. Next.js: modern runtime (v5, Next ≥13.5) only — treat the legacy adapter
+   as read-only history, never a recommendation.
+3. Remove any SPA catch-all (`/* → /index.html 200`) when adopting an SSR
+   adapter — user redirects beat adapter-generated routes, so a leftover
+   catch-all silently serves static `index.html` for SSR pages and API routes.
+4. Any env var change — client- or server-side — requires a redeploy. Values
+   are injected at build time; editing one in the UI/CLI does not reach the
+   live site or already-deployed functions until a new build runs.
+5. `netlify dev` with both a custom `command` and a `targetPort` requires
+   `framework = "#custom"` in the `[dev]` block — otherwise the detector runs
+   and the custom command is silently ignored.
+6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
+   `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
+   client-prefixed vars are inlined into the browser bundle.

--- a/codex/skills/netlify-functions/SKILL.md
+++ b/codex/skills/netlify-functions/SKILL.md
@@ -1,286 +1,348 @@
 ---
 name: netlify-functions
-description: Guide for writing Netlify serverless functions. Use when creating API endpoints, background processing, scheduled tasks, or any server-side logic using Netlify Functions. Covers modern syntax (default export + Config), TypeScript, path routing, background functions, scheduled functions, streaming, and method routing.
+description: Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API endpoint or backend route, adding a contact form handler, wiring auth or Identity signup/login hooks, building streaming or AI-proxy responses, scheduling cron jobs, running long background jobs (batch processing/scraping), reacting to deploy or form events, setting up rate limiting or region/memory config, or reading environment variables and secrets inside a function. Covers file locations, the Request/Context/Response handler shape, path routing, config options, and local testing with netlify dev.
 ---
 
 # Netlify Functions
 
-## Modern Syntax
+Reach for the modern default-handler API (`.mts` TypeScript). Export a default async handler taking a web `Request` and a Netlify `Context`, returning a web `Response`. Avoid the legacy AWS Lambda handler shape unless writing Go or migrating old code (see Legacy at the end).
 
-Always use the modern default export + Config pattern. Never use the legacy `exports.handler` or named `handler` export.
+## File locations
 
-```typescript
-import type { Context, Config } from "@netlify/functions";
+- Default directory: `netlify/functions/` (relative to base directory). Keep it **outside** your publish directory or source files ship as static assets.
+- A function is one file or a subdirectory whose entry file is named `index` or matches the subdirectory name. All of these create a function `hello`:
+  - `netlify/functions/hello.mts`
+  - `netlify/functions/hello/hello.mts`
+  - `netlify/functions/hello/index.mts`
+- Use `.mts` (TS) / `.mjs` (JS) for ES modules. `.cts`/`.cjs` force CommonJS; `.ts`/`.js` follow the nearest `package.json` `"type"`.
+
+## Minimal function
+
+No `config` export. Serves at `/.netlify/functions/hello`.
+
+```ts title="netlify/functions/hello.mts"
+import type { Context } from "@netlify/functions"
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello, world!");
-};
-
-export const config: Config = {
-  path: "/api/hello",
-};
+  return new Response("Hello, world!")
+}
 ```
 
-The handler receives a standard Web API `Request` and returns a `Response`. The second argument is a Netlify `Context` object.
+Install types: `npm install @netlify/functions` (required for TS types; optional for JS).
 
-The bare default export shown above is the recommended form. The default export can also be an object with a `fetch` method — prefer this form only if (1) other functions in the project already use it, or (2) the function also subscribes to platform events (see [Event Handlers](#event-handlers) below), since events are exposed as named handlers on the same object:
+Read env vars and secrets with `Netlify.env.get()`:
 
-```typescript
+```ts
+const apiKey = Netlify.env.get("STRIPE_SECRET_KEY")
+```
+
+Never hardcode secrets. For the variable to exist at runtime its scope must include **Functions**. Variables set in `netlify.toml` are NOT available to functions. Values are frozen per deploy — change them and redeploy to apply.
+
+**Response headers are set in code** on the returned `Response`. `[[headers]]` in `netlify.toml`, `_headers`, and redirect header rules apply ONLY to static CDN responses, not function responses. Do not add CORS headers unless explicitly requested.
+
+## Custom path routing
+
+Set `config.path` to route to custom URLs. When set, the function serves ONLY at that path — not at `/.netlify/functions/<name>`.
+
+```ts title="netlify/functions/travel.mts"
+import type { Config, Context } from "@netlify/functions"
+
+export default async (req: Request, context: Context) => {
+  const { city, country } = context.params
+  return new Response(`You're visiting ${city} in ${country}!`)
+}
+
+export const config: Config = {
+  path: "/travel-guide/:city/:country",
+}
+```
+
+- Multiple paths: `path: ["/cats", "/dogs"]`.
+- Patterns: `path` supports [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) syntax — `path: ["/sale/*", "/item/:sku"]`. Named groups land on `context.params`. For the query string use `req.url`.
+- `excludedPath`: carve exceptions, e.g. `excludedPath: ["/product/*.css"]` with `path: "/product/*"`.
+- `preferStatic: true`: let a real static file at the URL win.
+- `method`: restrict methods, e.g. `method: ["GET", "POST"]`.
+
+## Fetchable module shape (alternative)
+
+Equivalent to the bare handler; carries `config` inline and lets you add event handlers.
+
+```ts
+import type { NetlifyFunction } from "@netlify/functions"
+
 export default {
-  fetch(req: Request, context: Context) {
-    return new Response("Hello, world!");
-  },
-};
+  fetch: (req, context) => new Response("Hello, world!"),
+  config: { path: "/hello" },
+} satisfies NetlifyFunction
 ```
 
-## File Structure
+## Context object
 
-Place functions in `netlify/functions/`:
+Second handler argument (or `getContext()` from `@netlify/functions` when out of handler scope — throws outside a request; wrap in try/catch).
 
-```
-netlify/functions/
-  _shared/           # Non-function shared code (underscore prefix)
-    auth.ts
-    db.ts
-  items.ts           # -> /.netlify/functions/items (or custom path via config)
-  users/index.ts     # -> /.netlify/functions/users
-```
+- `context.params` — named path params.
+- `context.geo` — `city`, `country.code/name`, `latitude`, `longitude`, `subdivision`, `timezone`, `postalCode`.
+- `context.ip` — client IP string.
+- `context.cookies` — `get(name)` / `set(options)` / `delete(name|options)`. Cross-subdomain cookies need a custom domain (`netlify.app` is on the Public Suffix List).
+- `context.site` — `id`, `name`, `url`. `context.deploy` — `context`, `id`, `published`, `skewProtectionToken`. `context.account.id`. `context.server.region`. `context.requestId`.
+- `context.waitUntil(promise)` — run work after the response is sent (analytics, logs) without blocking. Billing/log duration counts until the promise settles. Available for functions deployed on/after 2025-03-20.
 
-Use `.ts` or `.mts` extensions. If both `.ts` and `.js` exist with the same name, the `.js` file takes precedence.
+⚠️ Under `netlify dev`, `context.geo` and `context.ip` are **mocked** — placeholder values that never change. Don't conclude geo code is broken locally. Exercise branches with `netlify dev --geo=mock --country=DE` and verify on a real deploy.
 
-## Path Routing
+## Config object
 
-Define custom paths via the `config` export:
+Export `const config` (or the `config` property of a Fetchable module):
 
-```typescript
-export const config: Config = {
-  path: "/api/items",                    // Static path
-  // path: "/api/items/:id",            // Path parameter
-  // path: ["/api/items", "/api/items/:id"], // Multiple paths
-  // excludedPath: "/api/items/special", // Excluded paths
-  // preferStatic: true,                // Don't override static files
-};
-```
+- `path` / `excludedPath` — `string | string[]`, must start with `/`.
+- `method` — one method or array.
+- `preferStatic` — `boolean`.
+- `background` — `boolean` (see Background).
+- `schedule` — cron string (see Scheduled). Mutually exclusive with `path`/`excludedPath`.
+- `rateLimit` — `{ action: 'rate_limit'|'rewrite', aggregateBy: 'domain'|'ip'|[...], to?, windowSize, windowLimit }`.
+- `memory` / `vcpu` — see below; mutually exclusive.
+- `region` — airport code; see below.
 
-Without a `path` config, functions are available at `/.netlify/functions/{name}`. Setting a `path` makes the function available **only** at that path.
+## Integrations
 
-Access path parameters via `context.params`:
+```ts title="netlify/functions/users.mts"
+import type { Config } from "@netlify/functions"
+import { getDatabase } from "@netlify/database"
 
-```typescript
-// config: { path: "/api/items/:id" }
-export default async (req: Request, context: Context) => {
-  const { id } = context.params;
-  // ...
-};
-```
+const db = getDatabase()
 
-## Method Routing
-
-```typescript
-export default async (req: Request, context: Context) => {
-  switch (req.method) {
-    case "GET":    return handleGet(context.params.id);
-    case "POST":   return handlePost(await req.json());
-    case "DELETE": return handleDelete(context.params.id);
-    default:       return new Response("Method not allowed", { status: 405 });
-  }
-};
-
-export const config: Config = {
-  path: "/api/items/:id",
-  method: ["GET", "POST", "DELETE"],
-};
-```
-
-## Background Functions
-
-For long-running tasks (up to 15 minutes). The client receives an immediate `202` response; return values are ignored.
-
-Enable background mode by setting `background: true` in config:
-
-```typescript
 export default async (req: Request) => {
-  await someLongRunningTask();
-};
+  const users = await db.sql`SELECT id, email FROM users LIMIT 10`
+  return Response.json({ users })
+}
+
+export const config: Config = { path: "/users" }
+```
+
+Blobs: `import { getStore } from "@netlify/blobs"`; `getStore("uploads").set(key, await req.blob())`.
+
+`purgeCache()` from `@netlify/functions` invalidates the edge cache from inside a function:
+
+```ts
+import { purgeCache } from "@netlify/functions"
+
+export default async () => {
+  await purgeCache({ tags: ["products"] }) // omit tags to purge all
+  return new Response("Purged!", { status: 202 })
+}
+```
+
+## Streaming responses
+
+Return a `ReadableStream` as the `Response` body. Limits: **60s execution, 20 MB response**.
+
+```ts
+export default async (req: Request) => {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${Netlify.env.get("OPENAI_API_KEY")}`,
+    },
+    body: JSON.stringify({ model: "gpt-4o-mini", stream: true, messages: [/* ... */] }),
+  })
+  return new Response(res.body, { headers: { "content-type": "text/event-stream" } })
+}
+```
+
+To build a stream manually, `new ReadableStream({ start(controller) { controller.enqueue(...); controller.close() } })`.
+
+## Background functions (long-running)
+
+`config.background: true`. Client gets an immediate `202`; the return value is discarded; runs up to **15 minutes**. No streaming. Retries: on invocation error, retry after 1 min, then again 2 min later. Send results somewhere other than the client.
+
+```ts title="netlify/functions/process.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  // Long-running work. Client already has its 202.
+}
+
+export const config: Config = { background: true, path: "/process" }
+```
+
+Limits: background payload **256 KB**. Legacy `-background` filename suffix still works but prefer `config.background`.
+
+## Scheduled functions (cron)
+
+`config.schedule` with a cron expression, executed in **UTC**. The request body is JSON with `next_run` (ISO-8601). Inline config is TS/JS only — Go must use `netlify.toml`.
+
+Always compute the UTC time for the target local hour. E.g. 9 AM ET → `"0 13 * * *"` UTC (note this shifts by an hour across DST; pick the UTC offset you need). Prefer explicit cron over `@daily`/`@hourly` shortcuts, which can't target a specific local hour.
+
+```ts title="netlify/functions/daily-digest.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  const { next_run } = await req.json()
+  console.log("Next invocation at:", next_run)
+}
 
 export const config: Config = {
-  path: "/process",
-  background: true,
-};
+  schedule: "0 13 * * *", // 9 AM ET (EST); UTC
+}
 ```
 
-Store results externally (Netlify Blobs, database) for later retrieval.
+Via `netlify.toml` (all languages):
 
-The legacy filename convention (`process-background.ts`) is still supported, but new functions should use `config.background`.
-
-## Region
-
-Functions deploy to `cmh` (Ohio) by default for new sites. This is a deliberate choice: US East is centrally located for an international audience, has a broad provider ecosystem, and gives most projects the lowest overall latency without any configuration. Sites created before October 4, 2023 may have a different default region — check Project configuration > Build & deploy > Continuous deployment > Functions region to confirm.
-
-Do NOT override `config.region` unless the user has stated a specific reason — for example, a database or backend service in another region with measurable roundtrip savings, a data-residency requirement, or an audience concentrated in one region whose compute dependencies (database, backend services) also live in that region.
-
-Two constraints to be aware of before adding `config.region`:
-
-- A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
-- For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
-
-Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
-
-## Memory or vCPU
-
-Functions run with 1024 MB of memory and a proportional amount of compute by default. The default fits most workloads, and raising it has a direct cost impact: function billing scales linearly with the configured size.
-
-Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them when:
-
-- The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
-- The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
-
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
-
-## Scheduled Functions
-
-Run on a cron schedule (UTC timezone):
-
-```typescript
-export default async (req: Request) => {
-  const { next_run } = await req.json();
-  console.log("Next invocation at:", next_run);
-};
-
-export const config: Config = {
-  schedule: "@hourly", // or cron: "0 * * * *"
-};
+```toml
+[functions."daily-digest"]
+  schedule = "0 13 * * *"
 ```
 
-Shortcuts: `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`. Scheduled functions have a **30-second timeout** and only run on published deploys.
+Constraints: **30s limit** (use background for longer); only fire on **published deploys** (not Deploy Previews/branch deploys — invoke manually with **Run now**); no URL invocation; no streaming; no request payloads/POST data; incompatible with Split Testing. All extensions supported **except** `@reboot` and `@annually`.
 
-**Testing and triggering.** A scheduled function does **not** fire on its cron schedule under `netlify dev` — the local dev server never runs the schedule, so waiting for the clock will appear to do nothing. Test it by invoking it directly: `netlify functions:invoke <name>` calls the function once, on demand. In production a scheduled function also has **no public HTTP URL** — it is not reachable at `/.netlify/functions/{name}` and cannot be triggered by an external HTTP request; it runs only on its schedule. If you also need to trigger the same work over HTTP (a manual "run now" or a webhook), expose that logic through a separate ordinary HTTP function and share the implementation rather than trying to POST to the scheduled function.
+## Platform-event functions
 
-## Streaming Responses
+Export a default object with handlers named after events. They always run in the background — no response to a client. Combine with `fetch` in the same function. Every handler is fully typed; import event types from `@netlify/functions`.
 
-Return a `ReadableStream` body for streamed responses (up to 20 MB):
-
-```typescript
-export default async (req: Request) => {
-  const stream = new ReadableStream({ /* ... */ });
-  return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream" },
-  });
-};
-```
-
-## Event Handlers
-
-A function can subscribe to platform events by exporting an object instead of a function as its default. Each event has a named handler property:
-
-```typescript
-import type { DeploySucceededEvent, UserSignupEvent } from "@netlify/functions";
+```ts title="netlify/functions/on-deploy.mts"
+import type { DeploySucceededEvent, DeployFailedEvent } from "@netlify/functions"
 
 export default {
   deploySucceeded(event: DeploySucceededEvent) {
-    console.log(`Deploy ${event.deploy.id} succeeded`);
+    console.log(`Deploy ${event.deploy.id} succeeded for ${event.site.name}`)
   },
-
-  userSignup(event: UserSignupEvent) {
-    return {
-      user: {
-        ...event.user,
-        appMetadata: { ...event.user.appMetadata, roles: ["member"] },
-      },
-    };
+  deployFailed(event: DeployFailedEvent) {
+    console.log(`Deploy ${event.deploy.id} failed: ${event.deploy.errorMessage}`)
   },
-};
+}
 ```
 
-A single function can declare multiple handlers; multiple functions can also subscribe to the same event.
+**Deploy events** (`event.deploy`, `event.site`; return `void`): `deployBuilding`, `deploySucceeded`, `deployFailed`, `deployDeleted`, `deployLocked`, `deployUnlocked`.
 
-**Available handlers:**
+**Identity events** (`event.user`, only `id` guaranteed):
 
-| Handler | Trigger |
-|---|---|
-| `fetch` | HTTP request (equivalent to a bare function default export) |
-| `deployBuilding` / `deploySucceeded` / `deployFailed` / `deployDeleted` / `deployLocked` / `deployUnlocked` | Deploy lifecycle |
-| `userSignup` / `userLogin` / `userValidate` / `userModified` / `userDeleted` | Identity lifecycle |
-| `formSubmitted` | Form submission verified |
+| Handler | Can deny? | Can mutate? |
+|---|---|---|
+| `userValidate` | Yes | Yes |
+| `userSignup` | Yes | Yes |
+| `userLogin` | Yes | Yes |
+| `userModified` | Yes | Yes |
+| `userDeleted` | No | No |
 
-### Identity handlers: deny an action
+- Deny: call `event.deny()` inside the handler → end user gets `401`. First function to deny aborts the chain.
+- Mutate: return `{ user: {...} }` to persist changes; return `undefined` to pass through.
 
-`userSignup`, `userLogin`, `userValidate`, and `userModified` can reject the action by calling `event.deny()`. The end user receives a 401; no observability error is produced (unlike throwing).
+**Form events**: `formSubmitted` → `event.data` (object keyed by field name). Return `void`.
 
-```typescript
-export default {
-  userLogin(event: UserLoginEvent) {
-    if (!event.user.email?.endsWith("@example.com")) {
-      return event.deny();
-    }
-  },
-};
+Multiple functions can handle the same event (all run). Netlify signs each event (JWS) and verifies before invoking, blocking external requests. Legacy filename convention (file named after the event, payload via `await req.json()` → `payload`) still works but prefer typed handlers.
+
+## Region
+
+⚠️ Do NOT override `config.region` unless the user states a specific reason (co-located DB/backend, data residency, regional audience). The default `cmh` (US East, Ohio) is deliberate.
+
+When justified — e.g. an EU-resident database:
+
+```ts
+export const config: Config = { path: "/eu-data", region: "dub" }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain.
+Airport codes (self-serve): `cmh`, `dub`, `fra`, `gru`, `iad`, `lhr`, `nrt`, `pdx`, `sfo`, `sin`, `syd`, `yul`. Support-assisted: `cdg`, `mxp`. Each function runs in exactly one region (no multi-region geo-routing). Region selection needs Pro/Enterprise. Framework-adapter-generated functions can't take `export const config` — set region at project level in the UI. After changing region, **redeploy**. Function-level region beats the site-level UI setting.
 
-## Context Object
+## Memory / vCPU
 
-| Property | Description |
-|---|---|
-| `context.params` | Path parameters from config |
-| `context.geo` | `{ city, country: {code, name}, latitude, longitude, subdivision, timezone, postalCode }` |
-| `context.ip` | Client IP address |
-| `context.cookies` | `.get()`, `.set()`, `.delete()` |
-| `context.deploy` | `{ context, id, published }` |
-| `context.site` | `{ id, name, url }` |
-| `context.account.id` | Team account ID |
-| `context.requestId` | Unique request ID |
-| `context.waitUntil(promise)` | Extend execution after response is sent |
+⚠️ Do NOT set `config.memory` or `config.vcpu` speculatively — billing scales linearly with size. Raise them only for known memory/compute-intensive work (AI inference, image/PDF, large JSON/CSV) or observed OOM/timeouts caused by the function's own work.
 
-**`context.geo` and `context.ip` are mocked under `netlify dev`.** Locally these return placeholder values, not your real location or client IP, so a value that looks "stuck" on a default country does not mean your geo code is broken — real geolocation is populated only for deployed functions. To exercise geo branching locally, start dev with the geo flags: `netlify dev --geo=mock --country=DE` forces mock data (`--geo=mock`) and sets the mock country (`--country`). Don't conclude `context.geo` is broken because local values never change.
+When justified (e.g. observed OOM processing large PDFs):
 
-## Environment Variables
-
-Prefer `Netlify.env.get` inside functions:
-
-```typescript
-const apiKey = Netlify.env.get("API_KEY");
+```ts
+export const config: Config = { path: "/heavy", memory: "2gb" } // or memory: 2048
 ```
 
-`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
+- `memory`: 1024–4096 MB. `vcpu`: 0.5–2.0 (0.5 → 1024 MB, 2.0 → 4096 MB). Mutually exclusive; Netlify sizes the other automatically. Needs Credit-based Pro/Enterprise. Via `netlify.toml`: `[functions.heavy]\n  memory = "2gb"`.
 
-**Environment variables have a small total size budget.** Functions run on AWS Lambda, which caps the *combined* size of all environment variables at roughly 4 KB. A single large value — a service-account JSON credential, a PEM private key, a big config blob — can blow past that on its own and break the deploy or the function at runtime. Do not store large payloads in environment variables; keep only small secrets and config (API keys, connection strings) there and move anything large into a bundled file, Netlify Blobs, or a fetch at runtime. There is no Netlify setting that raises this cap.
+## Bundling & files on disk
 
-## Reading Files at Runtime
-
-Only a function's own code and the modules it `import`s are bundled and deployed. A file the function opens from disk at runtime — `fs.readFile`/`readFileSync` on a template, a JSON data file, a WASM binary, a fixture — is **not** part of the bundle unless you declare it. This is a classic "works locally, ENOENT in production" trap: under `netlify dev` the function reads the file straight from your working tree, but the deployed function only contains what was bundled.
-
-Declare runtime-read files with `included_files` in `netlify.toml` so they ship with the function:
+⚠️ Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM) are **not bundled**: works under `netlify dev`, ENOENT in production. Prefer importing static data as a module. Otherwise declare it in `netlify.toml`:
 
 ```toml
 [functions]
-  included_files = ["netlify/functions/templates/**"]
-
-# or scope it to one function:
-[functions."render-email"]
-  included_files = ["netlify/functions/templates/welcome.html"]
+  included_files = ["files/*.md"]
+  external_node_modules = ["package-1"]
 ```
 
-When the data is static, prefer importing it as a module (`import data from "./data.json"`) so bundling is automatic; reach for `included_files` for files you must read from the filesystem at runtime.
+⚠️ The combined env-var limit is **~4 KB** for ALL functions (they run on AWS Lambda) — no Netlify setting raises it. Keep large payloads (service-account JSON, PEM keys) out of env vars; use a bundled file, Blobs, or a runtime fetch.
 
-## Resource Limits
+JS-only esbuild: `[functions]\n  node_bundler = "esbuild"`.
 
-| Resource | Limit |
-|---|---|
-| Synchronous timeout | 60 seconds |
-| Background timeout | 15 minutes |
-| Scheduled timeout | 30 seconds |
-| Memory | 1024 MB default; configurable 1024–4096 MB (see [Memory or vCPU](#memory-or-vcpu)) |
-| Buffered payload | 6 MB |
-| Streamed payload | 20 MB |
+## Limits (not configurable)
 
-## Framework Considerations
+- Synchronous execution: **60s**. Scheduled: **30s**. Background: **15 min**.
+- Buffered request/response payload: **6 MB** (binary is Base64-encoded, ~30% overhead → effective **4.5 MB** binary limit).
+- Streamed response: **20 MB**. Background payload: **256 KB**.
 
-Frameworks with server-side capabilities (Astro, Next.js, Nuxt, SvelteKit, TanStack Start) typically generate their own serverless functions via adapters. You usually do not write raw Netlify Functions in these projects — the framework adapter handles server-side rendering and API routes. Write Netlify Functions directly when:
+## Local testing & deploy
 
-- Using a client-side-only framework (Vite + React SPA, vanilla JS)
-- Adding background or scheduled tasks to any project
-- Building standalone API endpoints outside the framework's routing
+- Most frameworks emulate functions in their dev server. Vite frameworks (Astro, Nuxt, TanStack Start, React Router): install `@netlify/vite-plugin` and run the dev server. Next.js and anything else: use the [Netlify CLI](https://docs.netlify.com/api-and-cli-guides/cli-guides/local-development/) (`netlify dev`).
+- Scheduled functions don't fire on a schedule locally — invoke once with `netlify functions:invoke <name>`.
+- Deploy: push to Git for continuous deployment, or use the Netlify CLI/API.
+- Logs & metrics live in the Netlify UI; stream with the CLI.
 
-See the **netlify-frameworks** skill for adapter setup.
+## Node runtime version
+
+Runtime follows the build's Node.js version (fallback: Node.js 24). Override by setting env var `AWS_LAMBDA_JS_RUNTIME` (e.g. `nodejs24.x`) via UI/CLI/API — **not** `netlify.toml` — then redeploy. ES modules: `__dirname`/`__filename` unavailable, use `import.meta.url`; named imports of CommonJS packages fail, use a default import.
+
+## Legacy / Go (avoid unless needed)
+
+Go must use the [Lambda-compatible API](https://docs.netlify.com/build/functions/lambda-compatibility/?fn-language=go); Go routing/region/memory are set in `netlify.toml`. For migrating Lambda-style JS/TS, `@netlify/aws-lambda-compat` wraps an AWS handler:
+
+```ts
+import { withLambda } from "@netlify/aws-lambda-compat"
+import type { HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/aws-lambda-compat"
+
+export default withLambda(async (event: HandlerEvent, context: HandlerContext): Promise<HandlerResponse> => {
+  const name = event.queryStringParameters?.name ?? "World"
+  return { statusCode: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ name }) }
+})
+```
+
+Lambda-compat mode enforces the 4 KB env-var limit; [upgrade to modern functions](https://developers.netlify.com/guides/migrating-to-the-modern-netlify-functions/) to remove it.
+
+<!-- system: agent-context/functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (functions)
+
+These are org conventions, not docs facts — they are merged into the rendered
+skill by ctx-gen and are never generated. Extracted from the previous
+hand-written netlify-functions skill; owned by the skills maintainer.
+
+1. Use TypeScript (`.mts`) when possible.
+2. Access environment variables via `Netlify.env.get()` (prefer it over
+   `process.env` for consistency).
+3. Never add CORS headers unless explicitly requested.
+4. Store secrets in environment variables, never in code.
+5. `context.geo` and `context.ip` are mocked under `netlify dev` — placeholder
+   values, not the real location or client IP. Don't conclude geo code is
+   broken because local values never change; exercise branches with
+   `netlify dev --geo=mock --country=DE` and verify on a deploy.
+6. Do NOT set `config.memory` or `config.vcpu` speculatively. Raise them only
+   for known memory/compute-intensive work or observed OOM/timeouts caused by
+   the function's own work — billing scales linearly with size.
+7. Do NOT override `config.region` unless the user has stated a specific
+   reason (co-located database/backend, data residency, regional audience).
+   The `cmh` default is a deliberate choice.
+8. Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM)
+   are not bundled: works under `netlify dev`, ENOENT in production. Prefer
+   importing static data as a module; otherwise declare the file with a
+   scoped `included_files` entry in `netlify.toml`.
+9. The ~4 KB combined environment-variable limit applies to ALL functions
+   (they run on AWS Lambda), not just Lambda-compat mode. Keep large payloads
+   (service-account JSON, PEM keys) out of env vars — use a bundled file,
+   Blobs, or a runtime fetch. No Netlify setting raises this cap.
+10. The body's FIRST function example must be the minimal default: no
+    `config` export at all, stating the function serves at
+    `/.netlify/functions/<name>`. Custom `path` routing appears only in a
+    later example — agents imitate the first example they see.
+11. Never demonstrate `memory`, `vcpu`, or `region` in a generic example —
+    show them only attached to an explicit stated reason (observed OOM,
+    co-located backend, data residency).
+12. Scheduled-function examples use a real cron expression with the UTC
+    conversion spelled out (e.g. 9 AM ET → `"0 13 * * *"` UTC, noting DST) —
+    never only `@hourly`/`@daily` shortcuts, which can't target a specific
+    local hour.
+13. The body must state that `[[headers]]` in netlify.toml, `_headers`, and
+    redirect header rules apply ONLY to static CDN responses — response
+    headers for a function are set in code on the returned `Response`.

--- a/codex/skills/netlify-identity/SKILL.md
+++ b/codex/skills/netlify-identity/SKILL.md
@@ -1,464 +1,293 @@
 ---
 name: netlify-identity
-description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity` for new projects; `netlify-identity-widget` and `gotrue-js` still work but are no longer recommended.
+description: Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social login (Google/GitHub/GitLab/Bitbucket), server-side user verification in Functions, role-based access control (RBAC), admin user management, and Identity event hooks. Use when adding a login/signup flow, "add social login", gating content by user role, protecting a function or page behind auth, assigning roles at signup, customizing auth emails, or handling OAuth/confirmation/recovery callbacks. Not for locking an entire site to a company/team — that is netlify-access-control.
 ---
 
 # Netlify Identity
 
-Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+Auth and user management for a Netlify site without requiring visitors to be Netlify users. Package: `@netlify/identity`.
 
-**Always use `@netlify/identity` for new projects.** `netlify-identity-widget` and `gotrue-js` still work and are maintained, but are no longer the recommended choice. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+**Reach for `@netlify/identity`.** Do NOT use the legacy `netlify-identity-widget` or `gotrue-js` for new work — same capabilities, simpler API, built-in server-side support.
 
-## Identity is app-level — don't confuse it with site access control
+## Footguns — read first
 
-Netlify Identity manages **your app's end users** (signups, logins, roles) and issues the `nf_jwt` cookie. It is a different layer from **Secure Access / Password Protection**, which gates *who can load the site at all* (Basic shared-password is Pro+; team-login/SAML gating is Enterprise), and from **Team/Org SAML SSO**, which controls *who can log in to the Netlify dashboard*. The same provider can appear in more than one (Google, say): Google as an Identity OAuth provider signs in *app users*; Google as a SAML IdP signs in *Netlify team members*. They are unrelated systems with separate sessions, which is where the confusion comes from.
-
-If the task involves "lock this site to my company," "only employees can access it," password protection, or SSO at the site/team level, **read the `netlify-access-control` skill first** to pick the right layer. This skill covers the app-level user-management layer only.
-
-## Dashboard configuration (user handoff required)
-
-**All Identity instance configuration is dashboard-only — there is no public API.** The agent owns the code, deploys, and the handoff checklist; the user owns flipping dashboard settings. Outside of a Netlify Agent Runner deploy, the Identity instance must be enabled in the dashboard before any auth flow will work. If you write Identity code first and only discover this when `/.netlify/identity/signup` 404s after a production deploy, that's wasted work — surface the dashboard handoff up front instead.
-
-**Dashboard URL pattern:** `https://app.netlify.com/projects/<project-slug>/configuration/identity` (it's under project configuration — not under Integrations, and not a top-level sidebar item).
-
-### Dashboard-only operations
-
-- **Enable Identity** — turns the Identity instance on for the site. **Required** before any auth flow works.
-- **Registration mode** — Open (anyone can sign up, the default) or Invite only.
-- **Autoconfirm** — ON skips the email-confirmation step on signup; OFF requires the new user to click a confirmation email before they can log in.
-- **External providers** — Add Google / GitHub / GitLab / Bitbucket. The "Use Netlify's app" option means no `client_id`/`secret` needed — good for prototypes. Adding an OAuth provider does NOT disable email/password — email/password is always available unless the front-end omits it.
-- **Custom email templates / SMTP** — advanced; out of scope for typical prototypes.
-
-There is no CLI command and no public API for any of these. **Do not** curl `https://api.netlify.com/...` to flip toggles, **do not** read auth tokens out of `~/Library/Preferences/netlify/config.json`, and **do not** probe for an undocumented endpoint. Give the user the dashboard URL and exact checklist instead.
-
-### Agent/user sequence
-
-1. Agent asks any missing auth-shape questions before scaffolding.
-2. Agent writes the Identity code and runs a draft deploy.
-3. User enables Identity and any OAuth providers in the dashboard using the handoff checklist.
-4. Agent verifies the draft URL and then runs the production deploy.
-
-### Recommended settings per use case
-
-| Use case | Registration | Autoconfirm | External providers |
-|---|---|---|---|
-| Prototype / demo | Open | ON | as requested |
-| Production with email signup | Open or Invite per product | OFF (real email confirmation) | configured with custom email templates / SMTP as needed |
-
-### Handoff checklist
-
-When the dashboard work is needed, give the user a copy-pasteable checklist **between the draft deploy and the production deploy** — not after the prod deploy fails:
-
-```
-Before this works end-to-end, flip these in the Netlify dashboard at
-https://app.netlify.com/projects/<your-slug>/configuration/identity:
-
-- [ ] Identity → Enable
-- [ ] Registration → Open (default) or Invite only
-- [ ] Autoconfirm → ON for prototypes; OFF for prod with email confirmation
-- [ ] External providers → Add Google (etc.) with "Use Netlify's app"
-
-Tell me when these are flipped and I'll run the production deploy.
-```
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any auth code — the answers shape both the dashboard config above and the auth UI you'll write:
-
-- Should the whole site be locked so only your company/team can even load it (a perimeter), should it be public with per-user accounts inside the app, or both? This decides whether Netlify Identity alone is enough or you also need site-level access control — if "company-only" or "both" comes up, check the `netlify-access-control` skill before scaffolding.
-- Which sign-in methods should this app expose: email/password, OAuth, or both?
-- Which parts of the app need authenticated access: the whole app, specific routes, or only specific actions?
-- Who can create accounts: public signup or invite-only?
-- Should new email/password users be able to log in immediately for a prototype (Autoconfirm ON), or confirm by email first for production (Autoconfirm OFF)?
-- Which OAuth providers should be enabled (Google, GitHub, GitLab, Bitbucket)?
-
-**If you don't have preferences here, tell me what you want overall and I'll pick sensible defaults** — typically email/password + Google OAuth, autoconfirm ON, registration Open for a prototype.
-
-Asking these *after* coding causes rework — both the auth UI shape and the dashboard config fall out of these answers.
-
-## When something fails, surface and stop
-
-If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
-
-## Never hardcode secrets
-
-Never hardcode secrets. Identity URLs, GoTrue endpoints, and OAuth `client_id`/`secret` values do not belong in client or server code — configure OAuth credentials in the Netlify dashboard, not the frontend, and store anything sensitive as a Netlify environment variable (mark it secret). The Identity **admin token** is not one of these: you don't set or read it — the Netlify Functions runtime injects it automatically for `admin.*` calls made inside a Function (see [Authorization and sessions](references/authorization-and-sessions.md)). Never hardcode an admin token or expose admin operations to the browser.
+- **Identity does not work under `netlify dev`.** Test auth flows on a deploy — Deploy Previews work. Local `netlify dev` cannot exercise `/.netlify/identity/*`.
+- **Never build a from-scratch third-party OAuth flow beside Identity** — no provider app registration in code, no `client_id`/`secret` in code, no custom callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`. Raw OAuth beside Identity is the single most common source of rework.
+- **Identity config has no public API — dashboard only.** Never curl `api.netlify.com` to flip/inspect Identity settings, never read tokens from `~/Library/Preferences/netlify/config.json`, never probe undocumented endpoints.
+- **RBAC redirects without a fallback = raw 404.** A visitor lacking the role gets a bare 404 with no way to log in. Always add a fallback rule.
+- **Server-side `login()`/`signup()`/`logout()` need CSRF protection.** Call `verifyRequestOrigin(req)` first, or an attacker can log a victim into the attacker's account.
+- **Site-gating** ("lock this site to my company", employees-only) → route to **netlify-access-control** first. Identity is the app-level user layer only.
+- **On failure** (callback 404s, `/.netlify/identity/*` unreachable, OAuth doesn't return): surface the error, the dashboard URL, and the setting to check — then stop. Do not invent recovery commands.
 
 ## Setup
+
+Identity must be enabled in the dashboard first (no API): **Project configuration > Identity** (`https://app.netlify.com/projects/{site_name}/configuration/identity`) → **Enable Identity**.
 
 ```bash
 npm install @netlify/identity
 ```
 
-The Identity instance must be enabled in the dashboard first (see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above). The one exception: a deploy created by a Netlify Agent Runner session that includes Identity code auto-enables the instance.
+HTTPS is required. On a custom domain, get HTTPS/SSL working before integrating Identity.
 
-### Local Development
+## Client / universal auth
 
-Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+```ts
+import { signup, login, logout, getUser, oauthLogin, handleAuthCallback } from '@netlify/identity'
 
-## Quick Start
+// Sign up — sends a confirmation email by default (skippable via autoconfirm setting)
+const user = await signup('jane@example.com', 'securepassword', { full_name: 'Jane Doe' })
 
-Log in from the browser:
+// Log in / log out
+await login('jane@example.com', 'securepassword')
+await logout()
 
-```typescript
-import { login, getUser } from '@netlify/identity'
+// Current user — null if not logged in (works in browser + server)
+const u = await getUser()
+if (u) console.log(u.email)
 
-const user = await login('user@example.com', '<password>')
-console.log(`Hello, ${user.name}`)
-
-// Later, check auth state
-const currentUser = await getUser()
+// OAuth — redirects browser to provider login
+oauthLogin('github') // 'google' | 'github' | 'gitlab' | 'bitbucket'
 ```
 
-Protect a Netlify Function:
+**Callback handling is mandatory.** Call `handleAuthCallback()` on your landing page. It processes ALL token types in the URL hash — OAuth redirect, email confirmation, password recovery, invite. Without it, confirmation links and OAuth redirects never complete.
 
-```typescript
-// netlify/functions/protected.mts
+```ts
+import { handleAuthCallback } from '@netlify/identity'
+
+const result = await handleAuthCallback()
+if (result) console.log(result.type, result.user.email) // may be falsy if nothing to process
+```
+
+Other client functions:
+- `recoverPassword()` — complete a password reset (alternative to letting `handleAuthCallback()` handle the `recovery_token`).
+- `acceptInvite()` — complete invite acceptance (alternative to `handleAuthCallback()` handling `invite_token`).
+- `refreshSession()` — refresh token/session so newly-assigned roles take effect.
+
+**Don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns.
+
+## Server-side (Functions / Edge Functions)
+
+Handlers are modern v2 functions: `export default async (req, context) => {}`. **v1 `export { handler }` is not supported** for `getUser()`/`login()`/`admin.*`.
+
+```ts
 import { getUser } from '@netlify/identity'
-import type { Context } from '@netlify/functions'
+import type { Context } from '@netlify/functions'      // or '@netlify/edge-functions' for Edge
 
 export default async (req: Request, context: Context) => {
   const user = await getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
+  if (!user.roles.includes('admin')) return new Response('Forbidden', { status: 403 })
   return Response.json({ id: user.id, email: user.email })
 }
 ```
 
-`getUser()` reads the request's `nf_jwt` cookie automatically — no argument is needed in a function or edge function. Server-side auth (`getUser`, `login`, `admin.*`) requires a **modern v2 function** (`export default`); v1 Lambda-compatible functions (`export { handler }`) are not supported.
+`getUser()` works in browser, Netlify Functions, and Edge Functions.
 
-## Core API
+**CSRF — always guard exposed `login`/`signup`/`logout` endpoints:**
 
-Import and use headless functions directly:
+```ts title="netlify/functions/login.ts"
+import { login, verifyRequestOrigin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-```typescript
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  signup,
-  oauthLogin,
-  onAuthChange,
-  getSettings,
-} from '@netlify/identity'
-```
-
-### Login
-
-```typescript
-import { login, AuthError } from '@netlify/identity'
-
-async function handleLogin(email: string, password: string) {
-  try {
-    const user = await login(email, password)
-    showSuccess(`Welcome back, ${user.name ?? user.email}`)
-  } catch (error) {
-    if (error instanceof AuthError) {
-      // Bad credentials → GoTrue returns 400 (invalid_grant) server-side; in the
-      // browser the status is undefined, so fall back to the message there.
-      showError(error.status === 400 ? 'Invalid email or password.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  verifyRequestOrigin(req)   // throws 403 on Origin mismatch; supports { allowedOrigins }
+  const { email, password } = await req.json()
+  await login(email, password)
+  return new Response(null, { status: 302, headers: { Location: '/dashboard' } })
 }
 ```
 
-### Signup
+### admin — Netlify Functions ONLY
 
-After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+`admin.*` uses a short-lived admin token and runs **only in Netlify Functions** — NOT browser, NOT Edge Functions.
 
-```typescript
-import { signup, AuthError } from '@netlify/identity'
+```ts
+import { admin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-async function handleSignup(email: string, password: string, name: string) {
-  try {
-    const user = await signup(email, password, { full_name: name })
-    if (user.emailVerified) {
-      // Autoconfirm ON — user is logged in immediately
-      showSuccess('Account created. You are now logged in.')
-    } else {
-      // Autoconfirm OFF — confirmation email sent
-      showSuccess('Check your email to confirm your account.')
-    }
-  } catch (error) {
-    if (error instanceof AuthError) {
-      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  const users = await admin.listUsers()   // array of users
+  return Response.json({ total: users.length })
 }
 ```
 
-### Logout
+- `admin.listUsers()` — array of users.
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
 
-```typescript
-import { logout } from '@netlify/identity'
+### Session cookies
+JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.
 
-await logout()
-```
+### The `User` object
+`id`, `email`, `roles` (array from `app_metadata.roles`, included in the JWT).
 
-### OAuth
+## Identity event functions
 
-**When Netlify Identity is the goal, never build a from-scratch third-party OAuth flow.** Don't tell the user to go register their own Google/GitHub OAuth app, don't ask for a `client_id`/`secret`, and don't write your own `/auth/callback` token-exchange handler. Identity already brokers the OAuth handshake: the provider is enabled in the dashboard with the **"Use Netlify's app"** option (no credentials needed — see the handoff checklist above), and your code just calls `oauthLogin(provider)` + `handleAuthCallback()`. Scaffolding raw OAuth alongside Identity is the single most common source of rework in this flow — it produces two competing auth systems that then have to be untangled by hand. Custom OAuth credentials exist only to *brand* the consent screen, and even then they're pasted into the dashboard, not wired into app code.
+Functions the platform invokes automatically on Identity events (you don't call them).
 
-OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+**Modern typed-handler syntax** — export a default object with a method per event. Typed handlers require `@netlify/functions` ≥ 5.2.0.
 
-```typescript
-import { oauthLogin } from '@netlify/identity'
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
-// Step 1: Redirect to provider (navigates away — never returns)
-function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
-  oauthLogin(provider)
+export default {
+  userSignup(event: UserSignupEvent) {
+    console.log(`New signup: ${event.user.email}`)
+  },
 }
 ```
 
-Providers must be enabled in the dashboard before `oauthLogin()` works — see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above. Registration is Open by default, so OAuth users can create accounts without any extra signup-related configuration; only the provider itself must be enabled.
+Handlers and triggers:
 
-Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, omit the email/password form from your UI; the front-end is the gate.
-
-### Handling Callbacks
-
-Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
-
-```typescript
-import { handleAuthCallback, AuthError } from '@netlify/identity'
-
-async function processCallback() {
-  try {
-    const result = await handleAuthCallback()
-    if (!result) return // No callback hash — normal page load
-
-    switch (result.type) {
-      case 'oauth':
-        showSuccess(`Logged in as ${result.user?.email}`)
-        break
-      case 'confirmation':
-        showSuccess('Email confirmed. You are now logged in.')
-        break
-      case 'recovery':
-        // User is authenticated but must set a new password
-        showPasswordResetForm(result.user)
-        break
-      case 'invite':
-        // User must set a password to accept the invite
-        showInviteAcceptForm(result.token)
-        break
-      case 'email_change':
-        showSuccess('Email address updated.')
-        break
-    }
-  } catch (error) {
-    if (error instanceof AuthError) showError(error.message)
-  }
-}
-```
-
-### Auth State
-
-```typescript
-import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
-
-// Check current user (never throws — returns null if not authenticated)
-const user = await getUser()
-
-// Subscribe to auth state changes (returns unsubscribe function)
-const unsubscribe = onAuthChange((event, user) => {
-  switch (event) {
-    case AUTH_EVENTS.LOGIN:
-      console.log('Logged in:', user?.email)
-      break
-    case AUTH_EVENTS.LOGOUT:
-      console.log('Logged out')
-      break
-    case AUTH_EVENTS.TOKEN_REFRESH:
-      break
-    case AUTH_EVENTS.USER_UPDATED:
-      console.log('Profile updated:', user?.email)
-      break
-    case AUTH_EVENTS.RECOVERY:
-      console.log('Password recovery initiated')
-      break
-  }
-})
-```
-
-### Settings-Driven UI
-
-You cannot see a project's live Identity configuration while you are writing the code — there is no API, MCP tool, or CLI command that reports whether Identity is enabled or which providers are on; that state lives in the dashboard. So **don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns, so the UI matches whatever the user actually enabled — and a provider you assumed was on but isn't won't render a dead button. (`getSettings()` hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev`, which proxies to the live service — but it can't tell you anything pre-run, so ask the user what's configured while you're still scaffolding.)
-
-```typescript
-import { getSettings } from '@netlify/identity'
-
-const settings = await getSettings()
-// settings.autoconfirm — boolean
-// settings.disableSignup — boolean
-// settings.providers — Record<AuthProvider, boolean>
-
-if (!settings.disableSignup) showSignupForm()
-
-for (const [provider, enabled] of Object.entries(settings.providers)) {
-  if (enabled) showOAuthButton(provider)
-}
-```
-
-## Minimal React Example
-
-```tsx
-import { useEffect, useState } from 'react'
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  oauthLogin,
-  onAuthChange,
-} from '@netlify/identity'
-
-function App() {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    ;(async () => {
-      await handleAuthCallback()
-      setUser(await getUser())
-      setLoading(false)
-    })()
-    return onAuthChange((_event, currentUser) => setUser(currentUser))
-  }, [])
-
-  const handleLogin = async (email, password) => {
-    const currentUser = await login(email, password)
-    setUser(currentUser)
-  }
-
-  const handleGoogleLogin = () => oauthLogin('google')
-
-  const handleSignOut = async () => {
-    await logout()
-    setUser(null)
-  }
-
-  if (loading) return <p>Loading...</p>
-  // Render login form or user details based on `user` state
-}
-```
-
-## Error Handling
-
-`@netlify/identity` throws two error classes:
-
-- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
-- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
-
-`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
-
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid login credentials — wrong email/password (GoTrue `invalid_grant`) |
-| 401 | Missing, invalid, or expired bearer token on an authenticated endpoint |
-| 403 | Action not allowed (e.g., signups disabled) |
-| 422 | Validation error (e.g., weak password, malformed email) |
-| 404 | User or resource not found |
-
-Note: in the browser, `login()` surfaces gotrue-js failures as an `AuthError` with `status` **undefined** (the HTTP status isn't propagated), so don't branch on `status` for bad-credentials UX there — fall back to `error.message`. Server-side (`login()` in a Function) passes the real status through, so `400` is reliable.
-
-## Identity Event Functions
-
-Functions can subscribe to Identity lifecycle events by exporting an object whose properties are named event handlers. See the **netlify-functions** skill for the full event-handler pattern.
-
-The typed handler API below (the `userSignup`/`userValidate`/… object export, the typed `*Event` types, and `event.deny()`) requires **`@netlify/functions` ≥ 5.2.0** — it isn't present in 5.1.x. On older installs, use the legacy filename convention described at the end of this section.
-
-**Available identity handlers:**
-
-| Handler | Trigger |
+| Handler | Fires when |
 |---|---|
-| `userValidate` | User attempts to sign up. Can deny. |
-| `userSignup` | User completes signup. Can deny or mutate. |
-| `userLogin` | User logs in. Can deny or mutate. |
-| `userModified` | User profile is updated. Can deny or mutate. |
-| `userDeleted` | User is deleted. Notification only. |
+| `userValidate` | User attempts signup, before account creation — block by email domain, rate-limit, custom validation. |
+| `userSignup` | Signup completes (email or external). Fires *after* email confirmation if confirmation is enabled. Assign roles, sync, notify. |
+| `userLogin` | User logs in — track logins, sync, block a user. |
+| `userModified` | Profile updated. |
+| `userDeleted` | User deleted (notification only). |
 
-Each handler receives a typed event with a parsed `user` object (camelCase fields: `appMetadata`, `userMetadata`, `confirmedAt`, etc.).
+**Deny an action:** call `event.deny()` from `userValidate`/`userSignup`/`userLogin`/`userModified` (NOT `userDeleted`). User gets a `401`; no observability error. With multiple subscribers, the first `event.deny()` aborts the chain.
 
-### Mutate the user
+```typescript title="netlify/functions/identity.mts"
+import type { UserValidateEvent } from "@netlify/functions"
 
-Return `{ user: ... }` to substitute the user record before it's persisted. This is the common pattern for role assignment at signup.
+export default {
+  userValidate(event: UserValidateEvent) {
+    if (!event.user.email?.endsWith("@example.com")) return event.deny()
+  },
+}
+```
 
-```typescript
-// netlify/functions/identity.mts
-import type { UserSignupEvent } from '@netlify/functions'
+**Assign roles at signup** — return `{ user: {...} }` to mutate the persisted record. Payload fields are **camelCase** (`appMetadata`, `userMetadata`, `confirmedAt`).
+
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
 export default {
   userSignup(event: UserSignupEvent) {
     return {
-      user: {
-        ...event.user,
-        appMetadata: {
-          ...event.user.appMetadata,
-          roles: ['member'],
-        },
-      },
+      user: { ...event.user, appMetadata: { ...event.user.appMetadata, roles: ["member"] } },
     }
   },
 }
 ```
 
-### Deny an action
+**Background mode** — action completes immediately, handler runs async:
 
-Call `event.deny()` to reject a signup, login, validation, or modification. The end user receives a 401. Do not throw — `event.deny()` is the canonical denial mechanism and does not produce an error in observability.
+```typescript title="netlify/functions/identity.mts"
+import type { Config, UserLoginEvent } from "@netlify/functions"
 
-```typescript
-import type { UserValidateEvent } from '@netlify/functions'
-
-export default {
-  userValidate(event: UserValidateEvent) {
-    if (!event.user.email?.endsWith('@example.com')) {
-      return event.deny()
-    }
-  },
-}
+export default { userLogin(event: UserLoginEvent) { /* async tracking */ } }
+export const config: Config = { background: true }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain — subsequent functions are not invoked.
+Event types from `@netlify/functions`: `UserValidateEvent`, `UserSignupEvent`, `UserLoginEvent`, `UserModifiedEvent`, `UserDeletedEvent`, `Config`.
 
-### Legacy filename convention
+## Registration & providers (dashboard)
 
-The previous syntax — files named `identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, exporting `handler` and signaling denial via non-2xx response — still works. New functions should prefer the typed handler syntax above.
+- **Registration preferences** — **Open** (default: any visitor signs up via `signup()`) or **Invite only** (all new users, including external-provider logins, must be invited first).
+- **Confirmation:** open registration sends a confirmation email; skip via **Emails > Confirmation template > Configure** (allow signup without verifying email / autoconfirm).
+- **External providers** — enable Google/GitHub/GitLab/Bitbucket under **Registration > External providers**. Set your own client ID/secret for branded OAuth (your app name shows on the provider screen). No email confirmation for external-provider signup, but Invite-only still requires an invite.
+- **Invitations** — **Project configuration > Identity > Users**; Netlify team users with any role can invite. Invite link carries an `invite_token` → process with `handleAuthCallback()` or `acceptInvite()`.
 
-## Roles and Authorization
+## Roles & metadata
 
-### First Admin User
+Stored on the User object; edit in **Identity > Users > Edit settings**:
+- **Name** — user-editable: `user_metadata.full_name`.
+- **Email** — user-editable; triggers email-change confirmation; changes login credentials: `user_metadata.email`.
+- **Roles** — NOT user-editable: `app_metadata.roles`. Read via `getUser()`.
 
-The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
+Set roles: at signup via `userSignup` handler returning `{ user: {...} }`; for existing users via `admin.updateUser()` in a Function. **Role changes take effect on next login or token refresh**, not immediately (they don't invalidate the current JWT — client can `refreshSession()`).
 
-1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
-2. Click **Invite users** and enter the admin user's email address
-3. After the user accepts the invite, click the user in the Identity list to open their detail page
-4. In the **Roles** field, add the `admin` role and save
+## Role-based access control (redirect rules)
 
-Once the first admin exists, subsequent users can be managed programmatically using Identity event functions (e.g., assigning roles in `identity-signup`) or role-based redirects.
+Enforced at the CDN edge (no origin round trip). Add a `Role` parameter to redirect rules.
 
-- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
-- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+```
+# _redirects — ALWAYS include a fallback or non-admins get a raw 404
+/admin/*  /admin/:splat  200!  Role=admin
+/admin/*  /login         401!
 
-### Role-Based Redirects
+# multiple roles, comma-chained
+/private/* /private/:splat  200!  Role=editor,admin
+```
 
 ```toml
 # netlify.toml
 [[redirects]]
   from = "/admin/*"
   to = "/admin/:splat"
+  force = true
   status = 200
-  conditions = { Role = ["admin"] }
-
-[[redirects]]
-  from = "/admin/*"
-  to = "/"
-  status = 302
+  conditions = {Role = ["editor", "admin"]}
 ```
 
-Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+Netlify Identity roles resolve at `app_metadata.roles`.
 
-## References
+### External JWT provider (Enterprise; alternative to Identity)
+You may use Identity **OR** an external JWT provider, **not both** — you cannot authenticate third-party JWT tokens while Identity is enabled. Set the secret at **Project configuration > Access & security > Visitor access > JWT secret** (project-level overrides team-level default).
 
-- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration
-- [Authorization and sessions](references/authorization-and-sessions.md) — where role gating is actually enforced (server-side vs client-side / SPA navigation), admin operations being Functions-runtime-only, and why a role change doesn't apply until the JWT refreshes
+- Tokens must be **HS256**; header requires `"alg": "HS256"`, `"typ": "JWT"`.
+- Payload requires `exp` (future Unix Epoch); other fields optional.
+- External-provider roles resolve at `app_metadata.authorization.roles`. Different path → contact support for a custom role path (support-configured, not self-service).
+
+## Emails (Pro+ for customization)
+
+Default sender `no-reply@netlify.com`. Custom sender (Pro+): set SMTP hostname/port/username/password under **Emails > Outgoing email address** (use SendGrid/Mailjet/etc. for volume).
+
+Custom templates (Pro+): publish HTML to a path on your deployed project, set the path (relative to domain, starting `/`) under **Emails**. Rules: inline CSS only, absolute image links, NO `<html>`/`<head>`/`<body>` tags. Keep template variables intact — don't let your build rewrite them.
+
+Go template variables: `{{ .Email }}`, `{{ .NewEmail }}` (email-change only), `{{ .SiteURL }}`, `{{ .ConfirmationURL }}`, `{{ .Token }}`. Custom link form: `{{ .SiteURL }}/path/#confirmation_token={{ .Token }}` (also `invite_token`, `recovery_token`, `email_change_token`).
+
+## Audit log (Pro+)
+
+**Project configuration > Identity > Identity audit log**. Search with a required scope prefix: `author:[string]` or `action:[string]`. Action names: `login`, `logout`, `user_signedup`, `user_deleted`, `user_modified`, `token_revoked`, `token_refreshed`, `user_recovery_requested`, `user_invited`.
+
+## Plan gating
+
+- Identity itself: all credit-based plans, no extra cost. Unlimited active + invite-only users, custom OAuth credentials, Functions integration — all plans.
+- **Pro+ only:** custom outgoing email, custom email templates, Identity audit log.
+- **Enterprise only:** external JWT providers.
+
+## Deep guides
+
+- `references/advanced-patterns.md` — SSR / session hydration.
+- `references/authorization-and-sessions.md`.
+
+## Legacy (avoid for new work)
+
+- `netlify-identity-widget` / `gotrue-js` — superseded by `@netlify/identity`.
+- Legacy event-function filenames (`identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, `-background` suffix) still work but prefer typed handlers. Legacy denial = return non-2xx status; new code uses `event.deny()`.
+
+<!-- getSettings() referenced in house rules but not documented in sources; its return shape/signature is not specified in the intermediate. -->
+
+<!-- system: agent-context/identity/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (identity)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Deep guides live in this skill: `references/advanced-patterns.md`
+   (SSR/session hydration) and `references/authorization-and-sessions.md`.
+2. Identity does not work under `netlify dev` — test auth flows on deploys
+   (Deploy Previews work).
+3. Identity configuration has no public API — it is dashboard-only. Never curl
+   `api.netlify.com` to flip or inspect Identity settings, never read auth
+   tokens from `~/Library/Preferences/netlify/config.json`, never probe for
+   undocumented endpoints.
+4. On failure (callback 404s, `/.netlify/identity/*` unreachable, OAuth flow
+   doesn't return), surface the error, the dashboard URL, and the setting to
+   check — then stop. Do not invent recovery commands.
+5. Never build a from-scratch third-party OAuth flow when Identity is in play —
+   no provider app registration, no `client_id`/`secret` in code, no custom
+   callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`;
+   raw OAuth beside Identity is the single most common source of rework.
+6. Server-side `getUser()`/`login()`/`admin.*` require modern v2 functions
+   (`export default`) — v1 `export { handler }` is not supported. Typed
+   Identity event handlers (`UserSignupEvent`, `event.deny()`) require
+   `@netlify/functions` ≥ 5.2.0; older installs use the legacy filenames.
+7. Don't hard-code which auth providers exist — call `getSettings()` at
+   startup and render the signup form and OAuth buttons from what it returns.
+8. Site-gating requests ("lock this site to my company", employees-only)
+   route to the netlify-access-control skill first — Identity is the
+   app-level user layer only.

--- a/codex/skills/netlify-image-cdn/SKILL.md
+++ b/codex/skills/netlify-image-cdn/SKILL.md
@@ -1,99 +1,157 @@
 ---
 name: netlify-image-cdn
-description: Guide for using Netlify Image CDN for image optimization and transformation. Use when serving optimized images, creating responsive image markup, setting up user-uploaded image pipelines, or configuring image transformations. Covers the /.netlify/images endpoint, query parameters, remote image allowlisting, clean URL rewrites, and composing uploads with Functions + Blobs.
+description: Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use when adding responsive images, generating thumbnails, converting formats (avif/webp/png), cropping to aspect ratios, tuning image quality, creating blurred placeholders, allowlisting remote image domains, serving user-uploaded images, or wiring framework image components (Next.js, Astro, Nuxt, Angular, Gatsby) to Netlify. Triggers on tasks like "optimize images", "add image thumbnails", "resize images on the fly", "serve images from an external domain", or "add blur placeholders".
 ---
 
 # Netlify Image CDN
 
-Every Netlify site has a built-in `/.netlify/images` endpoint for on-the-fly image transformation. No configuration required for local images.
+Transform images by requesting `/.netlify/images` with query parameters. No function or file authoring required — it's a built-in edge endpoint.
 
-## Basic Usage
-
-```html
-<img src="/.netlify/images?url=/photo.jpg&w=800&h=600&fit=cover&q=80" />
+```bash
+# resize + crop to a 50px square, retain left side, convert to webp at q=80
+curl -vs 'https://mysitename.netlify.app/.netlify/images?url=/owl.jpeg&fit=cover&w=50&h=50&position=left&fm=webp&q=80'
 ```
 
-## Query Parameters
+There is no legacy/deprecated form — the endpoint above is the only programmatic surface. Use framework image components where available (below) rather than hand-building URLs.
 
-| Param | Description | Values |
+## Endpoint & query parameters
+
+`GET /.netlify/images?url=<source>&...`
+
+| Param | Values | Notes |
 |---|---|---|
-| `url` | Source image path (required) | Relative path or absolute URL |
-| `w` | Width in pixels | Any positive integer |
-| `h` | Height in pixels | Any positive integer |
-| `fit` | Resize behavior | `contain` (default), `cover`, `fill` |
-| `position` | Crop alignment (with `cover`) | `center` (default), `top`, `bottom`, `left`, `right` |
-| `fm` | Output format | `avif`, `webp`, `jpg`, `png`, `gif`, `blurhash` |
-| `q` | Quality (lossy formats) | 1-100 (default: 75) |
+| `url` | relative path or full remote URL | **REQUIRED**. Only required param. |
+| `w` | integer px | width |
+| `h` | integer px | height |
+| `fit` | `contain` (default), `cover`, `fill` | resize behavior |
+| `position` | `center` (default), `top`, `bottom`, `left`, `right` | only applies when `fit=cover` |
+| `fm` | `avif`, `jpg`, `png`, `webp`, `gif`, `blurhash` | output format; `webp`/`gif` can be animated |
+| `q` | integer `1`–`100` (default `75`) | only for `avif`, `jpg`, `gif`, `webp` |
 
-When `fm` is omitted, Netlify auto-negotiates the best format based on browser support (preferring `webp`, then `avif`).
+### `fit` behavior
 
-### `fm=blurhash` returns a string, not an image
+| `fit=` | aspect ratio kept | crops excess | returns exact dimensions |
+|---|---|---|---|
+| `contain` | yes | no | no — one dimension may be smaller |
+| `cover` | no | yes | yes — scaled proportionally, then cropped |
+| `fill` | no | no | yes — stretched/squished if needed |
 
-`fm=blurhash` is special: the response body is a short BlurHash **text string**, not image bytes. Pointing an `<img src>` (or CSS `background-image`) straight at a `/.netlify/images?...&fm=blurhash` URL does not work — the browser receives text and has nothing to render. Use it as a placeholder workflow instead: obtain the blurhash string ahead of time (server-side, in a data loader, via a `fetch`, or at build time), decode it with a BlurHash decoder library into a rendered placeholder (a canvas or a data-URI), and show that while the real image loads. The real, displayable image is a **separate** `/.netlify/images` request **without** `fm=blurhash`.
+- **`fit=cover` requires BOTH `w` and `h`.** Supplying only one silently misbehaves.
+- `contain` with one dimension calculates the other to preserve aspect ratio.
 
-## Remote Image Allowlisting
+### Format & content negotiation
 
-External images must be explicitly allowed in `netlify.toml`:
+- Source-only request (just `url`, no size/format): image is unchanged in size/shape but **still reformatted** to `avif`/`webp` based on the browser's `Accept` header.
+- No `fm` specified → `webp` if accepted, else `avif` if accepted, else original.
+- `fm=blurhash` returns a BlurHash **text string, not image bytes.** Pointing `<img src>` or a CSS background at it renders nothing. Fetch the string server-side/ahead of time, decode it client-side with a BlurHash library (https://blurha.sh), then load the real image as a separate request without `fm=blurhash`.
+
+### Response codes
+
+- Invalid transformation param values → `404`.
+- Valid, new transformation → `200` with content + `content-type`.
+- Previously transformed → `304`.
+
+## Remote source images
+
+Remote `url` values require allowlisting the domain in `netlify.toml`:
 
 ```toml
 [images]
-remote_images = ["https://example\\.com/.*", "https://cdn\\.images\\.com/.*"]
+  remote_images = ["https://my-images.com/.*", "https://animals.more-images.com/[bcr]at/.*"]
 ```
 
-Values are regex patterns.
+Then percent-encode the remote URL and request it:
 
-A remote source URL that does **not** match any `remote_images` pattern is rejected with a **404** — Netlify does not fetch or proxy it. This is a strict allowlist, not a fallback: there is no automatic proxying of arbitrary external hosts. Add the host (as an escaped regex) to `remote_images` *before* referencing it through `/.netlify/images`, or every transform request for that source will 404. (Local images on the same site never need allowlisting.)
-
-When referencing an allow-listed remote image, **percent-encode the source URL** before placing it in the `url` parameter:
-
-```html
-<!-- source: https://cdn.example.com/marketing/banner.jpg -->
-<img src="/.netlify/images?url=https%3A%2F%2Fcdn.example.com%2Fmarketing%2Fbanner.jpg&w=800&fm=webp&q=80" />
+```js
+const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/owl.jpeg")}`;
 ```
 
-Percent-encode the source value (e.g. with `encodeURIComponent`) whenever it contains characters that would otherwise be read as Image CDN params — `?`, `&`, `=`, `#`, or whitespace. This applies to remote URLs and relative paths alike (a filename or user-generated key can contain them too, e.g. `url=/uploads/a%26b.jpg`). Basic paths without those characters don't need encoding.
+- **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
+- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
-## Clean URL Rewrites
+## Reusable transformations (redirects)
 
-Create user-friendly image URLs with redirects:
+Reuse the same params across many images via a redirect:
 
+`_redirects`:
+```
+/transform-small/* /.netlify/images?url=/:splat&w=50&h=50 200
+```
+
+`netlify.toml`:
 ```toml
-# Basic optimization
 [[redirects]]
-from = "/img/*"
-to = "/.netlify/images?url=/:splat"
-status = 200
-
-# Preset: thumbnail
-[[redirects]]
-from = "/img/thumb/:key"
-to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
-status = 200
-
-# Preset: hero
-[[redirects]]
-from = "/img/hero/:key"
-to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
-status = 200
+  from = "/transform-small/*"
+  to = "/.netlify/images?url=/:splat&w=50&h=50"
+  status = 200
 ```
 
-## Local Development
+Then `GET /transform-small/owl.jpeg` yields a 50×50 transform. **Avoid cross-site redirects for transformations** — they hurt performance.
 
-`/.netlify/images` is a Netlify platform endpoint — it does **not** exist in a framework's own dev server. Running `vite`, `next dev`, `astro dev`, etc. directly will **404** on `/.netlify/images`, and `[images]` allowlisting and your image redirects won't apply either. Run `netlify dev` for local work: it emulates the Image CDN endpoint, remote-image allowlisting, and redirect rules, so image URLs resolve locally the same way they do in production. A 404 on `/.netlify/images` locally almost always means a framework dev server is being run directly instead of `netlify dev` — the URL itself is fine.
+## Custom headers (caching)
 
-## Caching
-
-- Transformed images are cached at the CDN edge automatically
-- Cache invalidates on new deploys
-- Set cache headers on source images to control caching:
-
-```toml
-[[headers]]
-for = "/uploads/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
+`_headers`:
+```
+/source-images/*
+  Cache-Control: public, max-age=604800, must-revalidate
 ```
 
-## User-Uploaded Images
+- Headers set on a source image are applied to the transformed asset served by Image CDN.
+- Custom headers **cannot** be applied to remote (other-domain) source images; Netlify respects whatever cache headers the external domain sends.
+- `Cache-Control` on source images applies only to browsers/CDNs in front of Netlify, **not** the Netlify Cache itself.
 
-Combine **Netlify Functions** (upload handler) + **Netlify Blobs** (storage) + **Image CDN** (serving/transforming) to build a complete user-uploaded image pipeline. See [references/user-uploads.md](references/user-uploads.md) for the full pattern.
+## Framework integrations
+
+Use the framework's native image component/handling; it wires to Image CDN automatically. Configure the remote allowlist per framework:
+
+| Framework | Prerequisite | Remote allowlist |
+|---|---|---|
+| Angular | none — `NgOptimizedImage` auto-uses it | `[images] remote_images` in `netlify.toml` |
+| Astro | none — `<Image />` auto-uses it | `image.domains` / `image.remotePatterns` in `astro.config.mjs` |
+| Nuxt | none — `nuxt/image` auto-uses it | `image.domains` in `nuxt.config.ts` |
+| Next.js | Next 13.5+ and adapter v5 | `remotePatterns` in `next.config.js` |
+| Gatsby | env `NETLIFY_IMAGE_CDN=true` + Contentful/Drupal/WordPress source plugin | `[images] remote_images` in `netlify.toml` |
+
+## Local development
+
+Run `netlify dev` (Netlify CLI) to test transformations locally — it mimics production including Image CDN.
+
+- **A local `404` on `/.netlify/images` almost always means a framework dev server (`vite`, `next dev`, `astro dev`) is running instead of `netlify dev`.** The endpoint, `[images]` allowlisting, and image redirects only exist under `netlify dev`. The URL itself is usually fine.
+
+## Caching & deploys
+
+Transformed results are uniquely cached on Netlify's edge. Atomic deploys are respected: changing a source image in a new deploy re-runs transformations on new requests so stale assets aren't served.
+
+## User-uploaded image pipelines
+
+For user-uploaded image pipelines (Functions + Blobs + Image CDN composed), see `references/user-uploads.md` in this skill.
+
+## Limitations
+
+- **Split Testing is not supported** — you may get inconsistent image results between split test branches.
+- Not currently supported in Netlify's HIPAA-compliant hosting offering. See the Trust Center for the HIPAA-compliant reference architecture.
+
+<!-- system: agent-context/image-cdn/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (image-cdn)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. For user-uploaded image pipelines (Functions + Blobs + Image CDN
+   composed), see `references/user-uploads.md` in this skill — an authored
+   guide with no single docs source.
+2. Percent-encode remote source URLs before placing them in the `url`
+   parameter (`encodeURIComponent`) — URLs containing `?` or `&` break
+   otherwise.
+3. `fm=blurhash` returns a BlurHash TEXT string, not image bytes. Pointing an
+   `<img src>` (or CSS background) at it renders nothing — fetch the string
+   ahead of time, decode it client-side with a BlurHash library, and load the
+   real image as a separate request without `fm=blurhash`.
+4. A local 404 on `/.netlify/images` almost always means a framework dev
+   server (`vite`, `next dev`, `astro dev`) is running instead of
+   `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
+   only exist under `netlify dev`. The URL itself is usually fine.
+5. In `remote_images` patterns, the meaningful escape is the dot:
+   `"https://example\.com/.*"`. Forward slashes are not regex
+   metacharacters — do not write `https:\/\/`.

--- a/cursor/rules/netlify-access-control.mdc
+++ b/cursor/rules/netlify-access-control.mdc
@@ -1,65 +1,165 @@
 ---
-description: Use when the task involves controlling who can reach a Netlify site, or telling Netlify Identity apart from Secure Access. Trigger whenever the user wants to lock a site or deploy to their company/team, restrict access to employees only, build an internal or employees-only app, set up password protection, SSO, or SAML, asks "who can access my site", or is confused about Netlify Identity vs Secure Access vs team login vs OAuth providers. Routes the request to the right layer — app-level Identity, site-visitor Password Protection, the Auth0 extension, or Team/Org SAML SSO — and explains the two-layer (perimeter + in-app identity) pattern and its double-login tradeoff. For building the app-level auth itself, use the netlify-identity skill.
+description: Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call "auth". Use when a developer wants to password-protect a site or previews, restrict a project to their team, make a project public/private, set team visibility defaults, require SSO to view a site, or debug SSO-session symptoms like being logged out mid-session / getting 401s on an SSO-protected site / token expiry or refresh. Routes app-user login ("who is this user in my app") to the netlify-identity skill and dashboard/team SSO SSO elsewhere; this skill only chooses the perimeter layer for site/preview access.
 alwaysApply: false
 ---
 
-# Netlify Access Control
+# Netlify access control (picking the protection layer)
 
-"Auth" on Netlify means three different things that are easy to conflate. Picking the wrong one — or stacking two when one would do — is the main source of friction. This skill disambiguates the layers and routes you to the right one. For actually building app-level user auth, see the **netlify-identity** skill.
+This skill ROUTES. Its job is choosing the correct protection layer for loading a site, not implementing app auth. Before recommending anything, disambiguate — three unrelated layers get called "auth":
 
-## The three layers
+- **Netlify Identity** — "who is this user *inside* my app" (issues `nf_jwt`). App login, OAuth providers for your users, auth code. → Route to the **netlify-identity** skill. Not covered here.
+- **Password Protection / Project visibility** — "can this request load the site at all." Platform perimeter. **This skill.**
+- **Team/Org SAML SSO** — "can you log into the Netlify dashboard." Team member access to Netlify itself.
 
-| Layer | Answers | Who it's for | Plan | How it's configured |
-|---|---|---|---|---|
-| **Netlify Identity** | "Who is this user *inside my app*?" (signups, logins, roles; issues `nf_jwt`) | Your app's end users | All plans, free | Dashboard + `@netlify/identity` code |
-| **Password Protection** (Secure access to *sites*) | "Can this request even *load the site*?" | Basic: anyone with a shared password · Team login: Netlify team members | Basic: Pro+ · Team login: Enterprise | Dashboard-only |
-| **Team / Org SAML SSO** (Secure access to *Netlify*) | "Can you log in to the *Netlify dashboard*?" (and, with strict mode, pass the site gate) | Netlify team members, via a corporate SAML IdP | Enterprise | Dashboard-only |
+Sessions are separate. The same provider (e.g. Google) can be an Identity OAuth provider for app users AND a SAML IdP for team members — unrelated wiring.
 
-These are independent. The `nf_jwt` cookie is issued by app-level JWT auth: Netlify Identity, or a configured external JWT provider such as Auth0/Okta (the two are mutually exclusive); Password Protection and SAML SSO sessions are separate, with their own lifecycles, and do not populate `nf_jwt`.
+## Footgun: no API, CLI, or MCP for these settings
 
-> **Note on terminology:** Netlify's docs file Identity, Password Protection, role-based access, and more under an umbrella called "Secure access to your sites," while SAML SSO lives under "Secure access to Netlify." So "Secure Access" is not one feature — when a user says it, find out whether they mean *gating site visitors* (Password Protection) or *gating dashboard login* (SAML SSO).
+These settings have **no public API, no CLI command, and no MCP tool**. Do NOT curl `api.netlify.com` or read local auth tokens to inspect or change them. Hand the user the dashboard path and checklist. On failure, report what you tried and stop.
 
-## Why Google causes confusion
+## Footgun: the double login is real
 
-The same provider can show up in two unrelated places:
+A Password-Protection / team-login perimeter session and a Netlify Identity app session have **no bridge** — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire them together. For the combined Password-Protection + Identity pattern and its tradeoffs, see `references/two-layer-pattern.md`.
 
-- **Google as a Netlify Identity OAuth provider** — your app's end users click "Log in with Google." Any Google account works, it creates an Identity user, and it issues an `nf_jwt`. This is app-level auth.
-- **Google Workspace as a SAML IdP for Team/Org SSO** — your *Netlify team members* log in to the dashboard (and, with strict mode + team-login, pass the site gate) using their corporate Google account. It does **not** create an Identity user and does **not** issue an `nf_jwt`.
-
-Both are "sign in with Google," but they target different populations and produce different sessions. Don't assume one implies the other.
+For company-wide app-level SSO with a single sign-in (no double login), recommend the **Auth0 extension** (federating to the corporate IdP) BEFORE the two-layer stack.
 
 ## Pick the layer
 
-Start from what the user actually needs and walk down:
+| Goal | Use |
+|---|---|
+| Restrict site to your team, invite by email | Private project (Credit-based) or team login protection |
+| Shared password anyone can use | Basic password protection, or Password visibility (Pro only) |
+| Protect only previews, keep production open | "Non-production deploys only" / "Previews only" |
+| Require SSO to view the site | Org/Team SSO with **Only SSO allowed (strict)** + team login protection |
+| Log in users *inside* your app | → netlify-identity skill |
+| Single company-wide app SSO, no double login | → Auth0 extension |
 
-1. **Does anyone need to be blocked from loading the site at all?**
-   - **No — the site is public, but I need user accounts/roles inside the app** → **Netlify Identity** (open or invite-only registration). Use the **netlify-identity** skill. Done.
-   - **Yes — restrict who can reach it** → keep going.
+## UI naming by plan (same mechanism, different labels)
 
-2. **What kind of restriction?**
-   - **Just keep the public out — a shared secret is fine, no per-user identity needed** (staging, a soft pre-launch gate) → **Basic Password Protection** (Pro+, one shared password). Dashboard-only.
-   - **Only my employees, it's an internal tool / smaller team, and I also want to tell users apart inside the app** → **invite-only Netlify Identity** (all plans, free). Invite only company addresses; Identity itself becomes the gate because no uninvited user can sign in. **One login, full per-user identity, every plan.** This is the best default for "employees-only internal tool." Tradeoff: you manage invites manually and rely on invite links not being shared — it doesn't auto-provision from a corporate directory.
-   - **Big company, app-level company SSO with a single sign-in (no double login), where company-only is enforced inside the IdP** → the **Auth0 extension**. The extension links an Auth0 tenant to your site and exposes `AUTH0_*` env vars so your app authenticates end users through Auth0; Auth0 federates to your corporate IdP (Okta, Entra, Google Workspace) and enforces who counts as company, so users sign in once. This is **app-level**, not a CDN-edge perimeter: the site still loads and your app redirects unauthenticated visitors. Use it when invite-only Identity won't scale to a real org but you don't need a true edge perimeter; that's Option D below. Configured via the Netlify Auth0 extension (dashboard); see the Netlify docs setup guide.
-   - **I genuinely need a CDN-edge perimeter (Enterprise team login / SSO-gated site access) AND a separate app-level Identity** → the **two-layer pattern**. This works, but users sign in **twice** (once at the perimeter, once in the app) — there is no passthrough today. Read [references/two-layer-pattern.md](references/two-layer-pattern.md) before recommending it.
+The UI names differ by plan — the underlying protection is identical:
 
-If the user isn't sure, the most common real answer is **invite-only Netlify Identity** for "just my team" and the **Auth0 extension** for "my whole company with our existing IdP." Lead with those before reaching for the double-login stack.
+- **Credit-based Free / Personal / Pro:** per-project **Project visibility**; team-level **Default project visibility**.
+- **Enterprise / Open Source / legacy (non-Credit-based):** per-site **Password Protection**; team-level **Default Password Protection settings**.
 
-## The double login is real — name it early
+Legacy → Credit-based translation:
 
-When Password Protection (team login) and Netlify Identity are both on, **users authenticate twice** and there is no documented bridge between them — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire the perimeter session into the app session; it isn't supported. If single sign-on matters, that's a reason to choose the Auth0 extension (or invite-only Identity) instead of the two-layer stack. Full detail and the per-option tradeoffs are in [references/two-layer-pattern.md](references/two-layer-pattern.md).
+| Password Protection (old) | Project visibility (new) |
+|---|---|
+| No protection settings | Public |
+| Basic protection | Password |
+| Team protection | Private |
+| All deploys | Production and previews |
+| Non-production deploys only | Previews only |
 
-Also flag the hidden cost of team-login: it admits only **Netlify team members**, so every employee who passes that gate needs a paid Netlify seat. That alone usually rules it out for company-wide apps.
+## Dashboard paths
 
-## Configuration is dashboard-only — hand it off, don't probe
+**Credit-based (Project visibility):**
+- Per-project: `Project configuration > General > Visitor access > Project visibility` — `https://app.netlify.com/projects/{site_name}/configuration/general/#project-visibility`
+- Team default: `Team settings > General > Visitor access > Default project visibility` — `https://app.netlify.com/teams/{team_name}/settings/general#default-project-visibility`
 
-Password Protection, Team/Org SAML SSO, and the Auth0 extension are all configured in the Netlify dashboard or the extensions UI — **there is no public API, CLI command, or MCP tool to set or read them**, and there is no way for an agent to see this state while writing code. So:
+**Enterprise / Open Source / legacy (Password Protection):**
+- Per-site: `Project configuration > Access & security > Visitor access > Password Protection` — `https://app.netlify.com/projects/{site_name}/configuration/access#site-protection`
+- Team default: `Team settings > Access & security > Visitor access > Default Password Protection settings` — `https://app.netlify.com/teams/{team_name}/settings/access#default-site-protection-settings`
 
-- Give the user the dashboard location and an exact checklist; let them flip the setting and confirm.
-- **Do not** `curl https://api.netlify.com/...`, read tokens off disk, or probe for an undocumented endpoint to inspect or change access settings.
-- If a documented path fails, report it to the user with context (what you tried, the URL, the error) and stop — don't work around it.
+## Checklist: set a password (Credit-based, Pro)
 
-For the one piece an agent *can* read at runtime (which Identity providers are live), call `getSettings()` from `@netlify/identity` rather than hard-coding assumptions. It hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev` (which proxies to the live service). See the netlify-identity skill.
+1. Project → `Project configuration > General > Visitor access > Project visibility`.
+2. **Edit visibility**. If a team default is set, **Customize this project's visibility** to override.
+3. Select **Password**, enter the password (share it with visitors).
+4. Choose **Preview access**: **Production and previews** or **Previews only**.
+5. **Save**. Change later via **Change password**; remove by choosing **Public** or **Private**.
 
-## References
+## Checklist: Password Protection (Enterprise / OSS / legacy)
 
-- [Two-layer pattern (perimeter + in-app identity)](references/two-layer-pattern.md) — the four architecture options for "company-only access + per-user identity," the double-login reality, plan/seat costs, and the visibility gap.
+Per-site or team default via the paths above → **Configure Password Protection** → **Customize this site's protection settings** (if a default exists) → choose **Basic password protection** (single shared password) or **Team login protection** (Netlify team login, SSO-capable) → scope **All deploys** or **Non-production deploys only** → **Save**.
+
+## Checklist: require SSO to view a site
+
+1. FIRST set up Organization SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-organization-saml-sso`) or Team SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-team-saml-sso`).
+2. Configure Password Protection → **Team login protection**.
+3. To force SSO, set the SSO config to **Only SSO allowed (strict)**.
+
+## SSO session symptoms (logged out mid-session, 401s)
+
+SSO auth tokens **expire after 1 hour**. An SSO-protected site starts returning HTTP `401` once the token expires — this is the "logged out mid-session" symptom.
+
+The platform returns a `Netlify-Site-Protection-Expires-In` response header (seconds until the token expires) on requests to SSO-protected sites. Read it and re-auth before it hits zero:
+
+```js
+// SSO-protected site: refresh before the 1-hour token expires to avoid a 401.
+const res = await fetch(window.location.href, { credentials: "include" });
+const secondsLeft = Number(res.headers.get("Netlify-Site-Protection-Expires-In"));
+if (!Number.isNaN(secondsLeft) && secondsLeft < 60) {
+  window.location.reload(); // triggers re-auth via the identity provider
+}
+```
+
+The header name and semantics are documented; the JS wrapper is illustrative.
+
+## Project visibility values (Credit-based)
+
+One visibility setting — **Public**, **Password**, or **Private** — plus a separate scope (**Production and previews** or **Previews only**).
+
+- **Public** — anyone with the URL.
+- **Private** — team + invitees only, enforced with Netlify login. Recommended way to restrict to your team; lets you invite by email. No password needed.
+- **Password** — public but requires a shared password. **Pro only** among Credit-based plans.
+
+Previews stay private unless you change preview visibility (includes Deploy Previews, agent-run previews, and branch deploys). There is **no** default shared password — set a password per project.
+
+**Team defaults:** *Private for new projects* (new start behind team login; existing keep visibility), *Private for all projects* (new + all existing locked to team login; none can be made public), *Public for new projects* (new are public; existing keep visibility).
+
+## Constraints & gotchas
+
+- **Previews-only Password scope is Enterprise-only** for Password Protection settings ("Protecting only non-production deploys is only available for Enterprise plans"). Credit-based plans expose a "Previews only" scope via Project visibility separately — the docs do not fully reconcile these; state Enterprise-only for the Password Protection path.
+- **Access order:** Advanced Web Security (Firewall rules → WAF → rate limiting) runs BEFORE any password/login prompt. A blocked IP can hit an error page before ever seeing a login prompt.
+- **Team login excludes Git Contributors** — they cannot access team-login-protected deploys. It applies to Developers, Team Owners, Billing Admins; Reviewers can be invited (unlimited).
+- **Basic password protection prompts everyone**, including managing team members.
+- **Private projects can't receive third-party webhooks** (Slack, Stripe, etc.) — receiving webhooks requires the project to be **public**.
+- **Plan gating:** Basic password (whole site) available on Pro and Enterprise; all options (incl. team login) on Enterprise. Project visibility is Credit-based Free/Personal/Pro only; Free/Personal private projects are visible only to the Team Owner, Pro allows unlimited members. Enterprise/OSS/legacy have no project visibility — use team login protection.
+- **Who can change:** Password Protection — Developer (per-site), Team Owner (default). Project visibility — Org Owners (certain Enterprise plans), Team Owners, Developers with project access. Internal Builders can't publish to production, so can't make a project public.
+- **Team default by creation date:** teams created on/after July 28, 2026 default to **Private for new projects**; teams created before default to **Public**.
+- **Make public** requires at least one successful production deploy. Making public exposes production deploys; previews stay private unless changed.
+- **Invites:** Free/Personal are single-seat (upgrade to Pro to invite); Pro invites unlimited members to a single project or the whole team.
+
+## Compatibility
+
+- "Site-wide password protection" — old name, now part of **Password Protection**.
+- "Selective password protection" — old name for **Basic authentication with custom HTTP headers** (`https://docs.netlify.com/manage/security/secure-access-to-sites/basic-authentication-with-custom-http-headers`), which is code you author — out of scope here.
+
+See also: `references/two-layer-pattern.md` for the combined Password-Protection + Identity pattern.
+
+<!-- system: agent-context/access-control/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (access-control)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. This is a routing/disambiguation skill: keep it narrow — its job is
+   picking the right protection layer, not teaching each one.
+2. The combined Password-Protection + Identity pattern lives in this skill's
+   `references/two-layer-pattern.md`.
+3. "Auth" on Netlify is three unrelated layers users constantly conflate:
+   Netlify Identity ("who is this user inside my app" — issues `nf_jwt`),
+   Password Protection / project visibility ("can this request load the site
+   at all"), and Team/Org SAML SSO ("can you log in to the Netlify
+   dashboard"). Sessions are separate; the same provider (Google) can appear
+   in two unrelated places — Identity OAuth for app users, SAML IdP for team
+   members. Disambiguate before recommending anything.
+4. The double login is real: a Password-Protection/team-login perimeter
+   session and an Identity app session have no bridge — no shared cookie, no
+   header forwarding, no JWT exchange. Don't burn iterations wiring them
+   together; tradeoffs live in `references/two-layer-pattern.md`.
+5. These settings have no public API, CLI command, or MCP tool. Never curl
+   `api.netlify.com` or read local auth tokens to inspect or change them —
+   hand the user the dashboard path and checklist; on failure, report what
+   you tried and stop.
+6. Identity setup, auth code, and OAuth providers for app users belong to the
+   netlify-identity skill — route there; this skill only picks the layer.
+7. For company-wide app-level SSO with a single sign-in (no double login),
+   the Auth0 extension — federating to the corporate IdP — is the
+   recommendation before the two-layer stack.
+8. The description's triggers must include the SSO-session symptoms users
+   actually report — "logged out mid-session", 401s on an SSO-protected
+   site, token expiry/refresh — not only setup phrasing. The
+   `Netlify-Site-Protection-Expires-In` guidance is unreachable if the
+   skill never triggers on the symptom.

--- a/cursor/rules/netlify-ai-gateway.mdc
+++ b/cursor/rules/netlify-ai-gateway.mdc
@@ -1,239 +1,200 @@
 ---
-description: Reference for Netlify AI Gateway — the managed proxy that routes calls to OpenAI, Anthropic, and Google Gemini SDKs without provider API keys. Use this skill any time the user wants to add AI on a Netlify site (chat, completion, reasoning, image generation, image-to-image edit/stylize), choose or change a model, wire up the OpenAI / Anthropic / @google/genai SDK, decide which provider to use for an image-gen feature (it's Gemini-only on the gateway), or debug "model not found" / "API key missing" against the gateway. Required reading before pinning a model — the gateway exposes a curated subset, not every provider model.
+description: Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing provider API keys or accounts — the gateway injects credentials automatically. Reach for this when you add an AI chatbot or completion endpoint, generate images or text with Gemini/GPT/Claude, summarize form submissions with AI, build an LLM-backed API route, stream a long AI generation, or wire up any server-side AI provider call on Netlify. Covers provider SDK setup, injected env vars, model availability, rate limits, credit costs, streaming for long generations, and local dev with netlify dev or the Vite plugin.
 alwaysApply: false
 ---
 
 # Netlify AI Gateway
 
-> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model returns an HTTP error from the gateway.
+Call AI providers from Netlify server-side compute using each provider's **official SDK** with zero credential config — the gateway injects the API keys and base URLs the SDKs already read. Instantiate the client with no args (except OpenRouter, which needs an explicit base URL).
 
-> **First-deploy requirement:** The AI Gateway only activates after a site has had at least one production deploy. Local dev (`netlify dev`, `@netlify/vite-plugin`) will NOT have gateway access on a brand-new project until you deploy to production once.
+**Never do these** (they silently fail or cost money):
+- **Not browser-callable.** The gateway lives in Functions/Edge Functions only. Never call it from client-side React/browser code.
+- **Runtime-only credentials.** Never call the gateway from build scripts, prerender/SSG, or build plugins — those get no credentials and fail. Do AI work at request time; cache to Netlify Blobs if output must look precomputed.
+- **60s sync timeout.** A slow generation in a synchronous function is killed at 60s. Stream it (SDK streaming + `ReadableStream`), or use a background function that persists output for the client to fetch.
+- **Requires a production deploy.** The gateway does not activate until the project has at least one production deploy — even in local dev.
+- **Don't hardcode model lists.** Model availability changes; check the live providers endpoint rather than baking in IDs.
 
-> **Usage is credit-metered:** Gateway calls draw down your Netlify AI credit/inference allowance and start returning errors once it's exhausted — there's no separate provider bill behind it. Budget for this explicitly in any bulk or fan-out design (generating content for hundreds of rows/pages, retry loops), and don't retry unbounded.
+## Function example
 
-Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
+File: `netlify/functions/joke.js` (`mkdir -p netlify/functions`). Install: `npm install openai`.
 
-## How It Works
-
-The AI Gateway acts as a proxy — you use standard provider SDKs but point them at Netlify's gateway URL. Netlify auto-injects both the base URL and a placeholder API key for each provider, then authenticates upstream on your behalf.
-
-Always make the call through the provider's official SDK, constructed bare (`new OpenAI()`, `new Anthropic()`, `new GoogleGenAI()`) — the SDK reads the auto-injected base URL and key from the environment. **Don't hand-roll the gateway call with a raw `fetch()` and a manually-read `process.env.OPENAI_API_KEY`** (or a hardcoded key/URL): the injected key is only a placeholder, and rolling your own request bypasses the supported path the gateway expects.
-
-## Setup
-
-1. Enable AI on your site in the Netlify UI
-2. Deploy to production at least once — the gateway does not activate until then
-3. Install the provider SDK you want to use
-
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
-
-## Using OpenAI SDK
-
-```bash
-npm install openai
-```
-
-```typescript
+```js
+import process from "process";
 import OpenAI from "openai";
 
-const openai = new OpenAI();
-// `OPENAI_API_KEY` and `OPENAI_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+export default async () => {
+  const client = new OpenAI(); // reads OPENAI_API_KEY + OPENAI_BASE_URL
+  try {
+    const res = await client.responses.create({
+      model: "gpt-5-mini",
+      input: [{ role: "user", content: "Give me a random short dad joke" }],
+      reasoning: { effort: "minimal" },
+    });
+    return Response.json({
+      joke: res.output_text?.trim() || "Out of jokes",
+      model: res.model,
+      tokens: { input: res.usage.input_tokens, output: res.usage.output_tokens },
+    });
+  } catch (e) {
+    return Response.json({ error: `${e}` }, { status: 500 });
+  }
+};
 
-const completion = await openai.chat.completions.create({
-  model: "gpt-4o-mini",
-  messages: [{ role: "user", content: "Hello!" }],
-});
+export const config = { path: "/api/joke" }; // route, local + deployed
 ```
 
-## Using Anthropic SDK
+Client-side fetch just hits the route:
 
-```bash
-npm install @anthropic-ai/sdk
+```jsx
+const res = await fetch("/api/joke");
+const data = await res.json();
 ```
 
-```typescript
-import Anthropic from "@anthropic-ai/sdk";
+## Provider SDKs (modern — instantiate with no args)
 
-const client = new Anthropic();
-// `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+Each SDK auto-reads the injected env vars. **OpenRouter is the exception:** its base URL must be passed explicitly.
 
-const message = await client.messages.create({
-  model: "claude-sonnet-4-5-20250929",
+```js
+// Anthropic — npm i @anthropic-ai/sdk
+import Anthropic from '@anthropic-ai/sdk';
+const anthropic = new Anthropic(); // ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
+await anthropic.messages.create({
+  model: 'claude-sonnet-4-5-20250929',
   max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-## Using Google Gemini SDK
-
-Use `@google/genai` (the unified Google GenAI SDK). The older `@google/generative-ai` package does not pick up the gateway env vars.
-
-```bash
-npm install @google/genai
-```
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
-// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
-// injection isn't shadowed.
-
-const response = await ai.models.generateContent({
-  model: "gemini-2.5-flash",
-  contents: "Hello!",
-});
-
-const text = response.text;
-```
-
-## In a Netlify Function
-
-```typescript
-import type { Config, Context } from "@netlify/functions";
-import OpenAI from "openai";
-
-export default async (req: Request, context: Context) => {
-  const { prompt } = await req.json();
-  const openai = new OpenAI();
-
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  return Response.json({
-    response: completion.choices[0].message.content,
-  });
-};
-
-export const config: Config = {
-  path: "/api/ai",
-  method: "POST",
-};
-```
-
-Return the reply as JSON with `Response.json({...})`, even when the request only asks for "the reply text" back — a raw `text/plain` body breaks JSON-consuming clients and diverges from the convention used everywhere else in Netlify Functions.
-
-## Image Generation
-
-Image generation on the gateway is supported through **Gemini image models** (e.g., `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`). OpenAI's image models (`gpt-image-1`, `dall-e-*`) are **not** routed through the gateway.
-
-Both text-to-image and image-to-image use the same `generateContent` method as chat — only the model and response shape differ. The image is returned as base64 `inlineData` on a content part, not as a URL.
-
-### Text-to-image
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: "A watercolor portrait of a corgi wearing a beret",
-});
-
-const imagePart = response.candidates[0].content.parts.find(
-  (p) => p.inlineData,
-);
-const base64 = imagePart.inlineData.data;
-const mimeType = imagePart.inlineData.mimeType; // e.g. "image/png"
-const bytes = Buffer.from(base64, "base64");
-```
-
-### Image-to-image (edit / stylize an input image)
-
-Pass the source image as an additional content part with `inlineData`:
-
-```typescript
-const sourceBase64 = sourceBuffer.toString("base64");
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: [
-    { text: "Restyle this photo as a Picasso-era cubist portrait" },
-    { inlineData: { mimeType: "image/png", data: sourceBase64 } },
-  ],
+```js
+// OpenAI — npm i openai
+import OpenAI from 'openai';
+const openai = new OpenAI(); // OPENAI_API_KEY + OPENAI_BASE_URL
+await openai.chat.completions.create({
+  model: 'gpt-5',
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-The response shape is the same — pull `base64` and `mimeType` off the first part with `inlineData`. Most callers persist the bytes to Netlify Blobs (see `netlify-blobs/SKILL.md`) and serve a URL back to the client rather than returning multi-MB base64 in the function response.
+```js
+// Google Gemini — npm i @google/genai
+import { GoogleGenAI } from '@google/genai';
+const genAI = new GoogleGenAI({}); // GEMINI_API_KEY + GOOGLE_GEMINI_BASE_URL
+await genAI.models.generateContent({
+  model: 'gemini-2.5-pro',
+  contents: 'Hello!',
+});
+```
 
-## Environment Variables
+```js
+// OpenRouter — npm i @openrouter/sdk — base URL REQUIRED
+import { OpenRouter } from '@openrouter/sdk';
+const openRouter = new OpenRouter({
+  serverURL: process.env.OPENROUTER_BASE_URL, // API key auto-read from OPENROUTER_API_KEY
+});
+await openRouter.chat.send({
+  chatRequest: {
+    model: 'x-ai/grok-4.5',
+    messages: [{ role: 'user', content: 'Hello!' }],
+  },
+});
+```
 
-All of these are injected automatically by Netlify when AI is enabled. Setting your own value for any of the per-provider vars disables gateway routing.
+**OpenRouter models via the OpenAI SDK:** you can reach any OpenRouter-served model (xAI, DeepSeek, Meta, Mistral, Qwen) through the plain OpenAI SDK — just pass the model ID in OpenRouter notation, no extra config:
 
-| Variable | Provider | Purpose |
-|---|---|---|
-| `OPENAI_BASE_URL` | OpenAI | Gateway endpoint |
-| `OPENAI_API_KEY` | OpenAI | Placeholder; satisfies the SDK's "key required" check |
-| `ANTHROPIC_BASE_URL` | Anthropic | Gateway endpoint |
-| `ANTHROPIC_API_KEY` | Anthropic | Placeholder; satisfies the SDK's "key required" check |
-| `GOOGLE_GEMINI_BASE_URL` | Google Gemini | Gateway endpoint |
-| `GEMINI_API_KEY` | Google Gemini | Placeholder; satisfies the SDK's "key required" check |
-| `NETLIFY_AI_GATEWAY_BASE_URL` | (universal) | Provider-agnostic gateway endpoint |
-| `NETLIFY_AI_GATEWAY_KEY` | (universal) | Provider-agnostic gateway key |
+```js
+await openai.chat.completions.create({
+  model: 'deepseek/deepseek-v4-flash-0731',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
 
-The real upstream API keys live on Netlify's side. The per-provider `*_API_KEY` vars are placeholders so the SDKs construct successfully; the gateway authenticates server-side. You don't read these yourself — the SDK picks them up.
+## Injected environment variables
 
-When your own code needs some *other* environment value (a config flag, a model name you've parameterized), prefer `Netlify.env.get("VAR")` — it works in Netlify Functions and Edge Functions, and Edge Functions expose **only** `Netlify.env.get`. (In a framework's own server routes, use whatever that framework documents for env access — often `process.env`.)
+Set in all Netlify compute contexts at function init **only if you have not already set them** at project/team level (Netlify never overrides your keys):
 
-## Local Development
+| Provider | Vars |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
+| Anthropic | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
+| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_GEMINI_BASE_URL` |
+| OpenRouter | `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL` |
 
-With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are injected automatically into the local process — but only after the site has had at least one production deploy. A brand-new local-only project will see "API key missing" or "model not found" errors until you deploy.
+**Gemini special case:** Netlify will **not** inject `GEMINI_API_KEY` / `GOOGLE_GEMINI_BASE_URL` if either `GOOGLE_API_KEY` or `GOOGLE_VERTEX_BASE_URL` is set (use those to point at Vertex or your own Google credentials).
 
-Local injection also requires the working directory to be **linked** to the Netlify site. `netlify dev` pulls the gateway base URL and placeholder key from the linked site's environment, so an unlinked directory has no site context — nothing is injected and gateway calls fail even when the site has already been deployed to production. Run `netlify link` (or `netlify init`) in the project first, then start `netlify dev`. A bare framework dev server started outside `netlify dev` / `@netlify/vite-plugin` also gets no gateway env vars.
+**Always injected, never collide with your provider vars:**
+- `NETLIFY_AI_GATEWAY_KEY`
+- `NETLIFY_AI_GATEWAY_BASE_URL`
 
-## Usage metering and where the gateway runs
+Use the SDK path with the per-provider injected vars above as your default. Reach for `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` only when a third-party or unsupported library needs the credentials passed explicitly — that's the correct time to configure them by hand.
 
-**Gateway usage is credit-metered.** Calls draw down your Netlify AI credit/inference allowance; when that limit is reached the gateway **pauses** and returns errors until the allowance resets or is raised. There's no separate provider bill to fall back on — an unbounded loop of gateway calls burns the allowance and then starts failing, so budget for it and don't retry indefinitely.
+## Local dev
 
-**Gateway credentials are runtime-only.** Netlify injects the base URL and placeholder key only into runtime compute — deployed functions, edge functions, and server-rendered routes at request time. They are **not** present during the build: AI calls made at build time, in prerender/SSG, or in a build plugin get no gateway credentials and fail. Do AI work at request time (in a function or server route) and cache the result if you need it to look precomputed (e.g. to Netlify Blobs) — don't call the gateway from build scripts or static-generation hooks.
+Two supported paths — both still require an existing production deploy:
+- **Netlify CLI:** `netlify dev` (full support). Needs `npm install -g netlify-cli@latest` and `netlify login`.
+- **Netlify Vite plugin:** install `@netlify/vite-plugin`, add `netlify()` to `vite.config.js` plugins, run your normal `npm run dev` — gateway access without `netlify dev`.
 
-## No browser-callable gateway — proxy through server code
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import netlify from "@netlify/vite-plugin";
 
-Gateway credentials are injected only into server-side runtime compute (functions, edge functions, server-rendered routes). There is **no browser-callable gateway endpoint**: client-side JavaScript has no gateway credentials, and there is no public URL a browser can hit to reach the gateway directly. Client code (React/Vue/vanilla JS running in the browser) that constructs a provider SDK against the gateway will find no key and fail — and "fixing" it by hardcoding a real provider key in the client leaks that key to every visitor AND bypasses the gateway (a user-set key disables Netlify's auto-injection).
+export default defineConfig({
+  plugins: [react(), netlify()],
+})
+```
 
-The correct pattern is to proxy: put the gateway call in a **Netlify Function** (or edge function / server route), and have the browser `fetch()` your own endpoint (e.g. `/api/chat`). The function talks to the gateway server-side with the auto-injected credentials and returns the result to the client. Never import a provider SDK into a browser bundle to call the gateway, and never expose a provider API key to the client.
+## Enable & deploy
 
-## Long generations and the function timeout
+1. Be on a credit-based plan (Free, Personal, Pro; Enterprise via Account Manager). Legacy plans must switch to a current plan.
+2. Link a project: `netlify init`.
+3. **Deploy to production at least once** — required to activate: `netlify deploy --prod --open`.
+4. Don't disable AI Features; don't set your own provider keys unless you intend to override.
 
-A gateway call runs inside your function, so it is bound by the **60-second synchronous function timeout**. Large completions, reasoning models, and image generations can run longer than that, and a synchronous function that exceeds the ceiling is terminated before it can respond. Two mitigations:
+## Constraints & gotchas
 
-- **Stream the response.** Enable streaming on the SDK call and return a `ReadableStream` (e.g. `Content-Type: text/event-stream`), forwarding the provider's tokens/chunks as they arrive — for example `stream: true` on the OpenAI SDK, `client.messages.stream(...)` on Anthropic, or `generateContentStream(...)` on `@google/genai`. Streaming sends bytes to the client incrementally instead of buffering the whole completion inside the sync window, and is the right default for interactive chat and long text.
-- **Use a background function** for long, fire-and-forget jobs (batch generation, large image renders). Background functions run up to 15 minutes, but they return a `202` immediately and their return value is ignored — they cannot hand the result back to the caller. Persist the output (e.g. to Netlify Blobs or a database) and have the client poll or fetch it.
+- **Plan gating:** Credit-based plans only (Free/Personal/Pro; Enterprise via Account Manager).
+- **Context window:** input capped at **200k tokens**.
+- **Rate limits** (per team, across all projects, per minute, in credits): Free 90 / Personal 450 / Pro 1,800 / Enterprise 9,000. Set up [rate limiting rules](https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/) on AI functions to prevent visitor abuse driving up cost.
+- **Credit cost:** tokens → USD (provider published rates) → credits. **$1 USD of usage = 180 credits.** Enable [auto recharge](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/configure-auto-recharge/) or buy [credit packs](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/buy-credit-packs/) to meet demand.
+- **No request headers passed through** — you can't enable proprietary header-gated experimental features.
+- **Batch inference not supported.**
+- **OpenAI priority processing not supported.**
+- **Prompt caching:** Anthropic — only the default 5-minute ephemeral cache; OpenAI — a per-account `prompt_cache_key` is set; Gemini — explicit context caching not supported.
+- **Zero Data Retention only:** the gateway only routes to ZDR providers. A model listed in the OpenRouter directory is **not** served if no ZDR host offers it. Browse the ZDR-filtered catalog at https://openrouter.ai/models?zdr=true.
+- **Model list is dynamic** — served-directly models (Anthropic, OpenAI, Gemini) are enumerated from a live endpoint; OpenRouter-served models (xAI, DeepSeek, Meta, Mistral, Qwen) use OpenRouter notation. Don't hardcode; check availability at runtime.
+- **Privacy:** the gateway does not store prompts or outputs.
 
-Don't leave a slow synchronous generation unstreamed and assume it will finish — bound the model and `max_tokens`, and choose streaming or a background function based on how long the job runs.
+## Reference
 
-## Errors & Troubleshooting
+- Full docs, quickstart, and example projects (AI SEO Image Generator, form-submission summaries, TanStack Start chat app) at [AI Gateway overview](https://docs.netlify.com/build/ai-gateway/overview.md) and [quickstart](https://docs.netlify.com/build/ai-gateway/quickstart-for-ai-gateway.md).
 
-- **Unsupported model:** the gateway returns an HTTP error. Check the "Available Models" list below — the gateway exposes a curated subset, not every model the provider offers.
-- **`OPENAI_API_KEY missing` (or equivalent) at runtime:** AI Features are disabled on the site, or the project has not had a production deploy yet.
-- **Calls succeed but skip the gateway / aren't tracked:** check you haven't set your own `*_API_KEY`. Any user-set provider key shadows Netlify's auto-injection and routes directly to the provider.
-- **Limits:** 200k-token context window. Batch inference, custom request headers, and OpenAI priority processing are not supported. Anthropic prompt caching is limited to the 5-minute ephemeral cache; Gemini explicit caching is not supported.
+<!-- GAP: source does not enumerate concrete model IDs (dynamic live endpoint); model names in examples are illustrative only. -->
+<!-- GAP: SDK streaming + background-function patterns are mandated by house rules but no streaming code example exists in the source. -->
 
-## Available Models
+<!-- system: agent-context/ai-gateway/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (ai-gateway)
 
-_Verified 2026-04-30 against the live AI Gateway providers list. The user-facing reference is https://docs.netlify.com/build/ai-gateway/overview/ — re-check before pinning a new model._
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
 
-### Anthropic (chat)
-- `claude-haiku-4-5`, `claude-haiku-4-5-20251001`
-- `claude-sonnet-4-0`, `claude-sonnet-4-20250514`, `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-6`
-- `claude-opus-4-1-20250805`, `claude-opus-4-20250514`, `claude-opus-4-5`, `claude-opus-4-5-20251101`, `claude-opus-4-6`, `claude-opus-4-7`
-
-### OpenAI (chat / reasoning / Codex)
-- gpt-4 family: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
-- gpt-5: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-5-codex`; dated: `gpt-5-2025-08-07`, `gpt-5-mini-2025-08-07`
-- gpt-5.1: `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`; dated: `gpt-5.1-2025-11-13`
-- gpt-5.2: `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.2-pro`; dated: `gpt-5.2-2025-12-11`, `gpt-5.2-pro-2025-12-11`
-- gpt-5.3: `gpt-5.3-chat-latest`, `gpt-5.3-codex` (no unversioned `gpt-5.3`)
-- gpt-5.4: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`; dated: `gpt-5.4-2026-03-05`, `gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano-2026-03-17`, `gpt-5.4-pro-2026-03-05`
-- gpt-5.5: `gpt-5.5`, `gpt-5.5-pro`; dated: `gpt-5.5-2026-04-23`, `gpt-5.5-pro-2026-04-23`
-- Reasoning (o-series): `o3`, `o3-mini`, `o4-mini`
-
-### Google Gemini (chat + image)
-- Chat: `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`, `gemini-flash-latest`, `gemini-flash-lite-latest`
-- Image: `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`
+1. Use the provider SDK with the injected env credentials — don't hand-roll
+   a raw `fetch()` against the gateway, even though raw REST is a supported
+   surface. The body must not present raw REST or the
+   `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` pair as a
+   recommended path — but it MUST still document the pair as facts: always
+   injected, never collide with user-set provider vars, and the right choice
+   when a third-party or unsupported library needs explicit configuration.
+   Demote the recommendation; keep the knowledge.
+2. The gateway is not browser-callable: calls belong in functions or edge
+   functions, never client-side code.
+3. Model availability changes: don't hardcode model lists; check the live
+   providers endpoint.
+4. Gateway credentials are runtime-only: never call the gateway from build
+   scripts, prerender/SSG, or build plugins — those calls get no credentials
+   and fail. Do AI work at request time and cache the result (e.g. to
+   Netlify Blobs) if it must look precomputed.
+5. Gateway calls in a synchronous function are bound by the 60-second
+   timeout: stream long generations (SDK streaming + `ReadableStream`), or
+   use a background function that persists output for the client to fetch —
+   never leave a slow generation unstreamed and assume it finishes.

--- a/cursor/rules/netlify-blobs.mdc
+++ b/cursor/rules/netlify-blobs.mdc
@@ -1,171 +1,264 @@
 ---
-description: Guide for using Netlify Blobs for file and asset storage — images, documents, uploads, exports, cached binary artifacts. Covers getStore(), CRUD operations, metadata, listing, deploy-scoped vs site-scoped stores, and local development. Do NOT use Blobs as a dynamic data store — use Netlify Database for that.
+description: Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/value API from Functions, Edge Functions, and Build Plugins. Use when a task involves saving user file or image uploads, persisting form or contact-form submissions, storing generated output from Background Functions (sitemaps/processed media/bulk-email results), building read-only asset stores, adding client-side blob expiration, or wiring file-based blob uploads at deploy time. Not for per-user, transactional, or relational data (counters/balances/sessions) — reach for Netlify DB there instead.
 alwaysApply: false
 ---
 
 # Netlify Blobs
 
-Netlify Blobs is zero-config object storage for **files and assets**: images, documents, uploads, exports, cached binary artifacts. Available from any Netlify compute (functions, edge functions, framework server routes). No provisioning required.
+Modern import — reach for this:
 
-**Not for dynamic data.** If the project needs to store records, user data, application state, or anything queryable, use Netlify Database instead — see `netlify-database/SKILL.md`. Reach for Blobs when the thing you're storing is a file or an asset blob, not a record.
-
-```bash
-npm install @netlify/blobs
+```ts
+import { getStore, getDeployStore, listStores } from "@netlify/blobs";
 ```
 
-## Before you build
+Install: `npm install @netlify/blobs`. Fetch API is required (built into Node 18+); otherwise pass a custom `fetch`.
 
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any blob storage — answers shape access patterns, scoping, and how the assets are served back to clients:
+Two ways to open a store — use the **options-object form** when you need `consistency` or a custom `fetch` (the string form cannot pass them):
 
-- **What kind of asset?** (User uploads, exported documents, cached binaries, generated images — drives the storage and serving pattern.)
-- **Who should be able to read it?** Public (anyone with a URL, or an unauthenticated endpoint that streams the blob) or private (only authenticated users, gated by your server code)? Blobs have **no built-in access control** — the serving layer is the gate. When in doubt, default to private; making something public later is easy, while pulling back data that was inadvertently exposed is not.
-- **Site-scoped or deploy-scoped?** Site-scoped (`getStore()`) persists across deploys — the right default for user data. Deploy-scoped (`getDeployStore()`) is tied to a single deploy and disappears when that deploy is replaced — use only when the lifecycle should match a deploy (e.g., per-deploy build artifacts).
-- **Roughly how big and how many?** Helps choose between a single large blob vs many small keyed blobs, and informs whether you'll need `list({ prefix: ... })` patterns.
+```ts
+const store = getStore("file-uploads");                          // string form
+const store = getStore({ name: "animals", consistency: "strong" }); // options form
+```
 
-**If you don't have preferences here, tell me what the assets are and I'll pick sensible defaults** — typically site-scoped with private access, served through an authenticated function.
+`siteID`, `token`, `deployID`, and `region` are set automatically inside Functions, Edge Functions, and Build Plugins — do not pass them manually there.
 
-## Getting a Store
+## Choosing the store type — READ THIS FIRST
 
-```typescript
+- **`getStore(name)`** — site-scoped. Persists across deploys and is **shared across ALL deploy contexts**. Code on a Deploy Preview reads, overwrites, and deletes production data. **Never seed throwaway data or run destructive tests from a preview.**
+- **`getDeployStore(name)`** — scoped to one deploy; isolated from production. Use this for throwaway/per-deploy data, or use a context-specific store name for isolation.
+
+Blobs have **no built-in access control** — the serving function is the gate. Default to private: gate reads behind an authenticated function rather than exposing blobs publicly. Never accept an arbitrary caller-supplied key against a store holding sensitive data.
+
+## Common tasks
+
+### Persist a user upload with metadata (`set`)
+
+```ts
 import { getStore } from "@netlify/blobs";
+import type { Context } from "@netlify/functions";
+import { v4 as uuid } from "uuid";
 
-const store = getStore({ name: "my-store" });
+export default async (req: Request, context: Context) => {
+  const form = await req.formData();
+  const file = form.get("file") as File;
+  const key = uuid();
 
-// Use "strong" consistency when you need immediate reads after writes
-const store = getStore({ name: "my-store", consistency: "strong" });
+  const uploads = getStore("file-uploads");
+  await uploads.set(key, file, {
+    metadata: { country: context.geo.country.name }
+  });
+
+  return new Response("Submission saved");
+};
 ```
 
-## CRUD Operations
+Edge Function form is identical but imports `Context` from `@netlify/edge-functions`.
 
-These are the **only** store methods. Do not invent others.
+### Persist JSON (`setJSON`)
 
-### Create / Update
-
-```typescript
-// String or binary data
-await store.set("key", "value");
-await store.set("key", fileBuffer);
-
-// With metadata
-await store.set("key", data, {
-  metadata: { contentType: "image/png", uploadedAt: new Date().toISOString() },
-});
-
-// JSON data
-await store.setJSON("key", { name: "Example", count: 42 });
+```ts
+const uploads = getStore("json-uploads");
+await uploads.setJSON(key, data, { metadata: { country: context.geo.country.name } });
 ```
 
-### Read
+### Read a blob (`get`) — always null-check
 
-```typescript
-// Text (default)
-const text = await store.get("key");                    // string | null
+```ts
+const uploads = getStore("file-uploads");
+const entry = await uploads.get(key);          // string by default
+if (entry === null) {
+  return new Response(`Could not find ${key}`, { status: 404 });
+}
+return new Response(entry);
+```
 
-// Typed retrieval
-const json = await store.get("key", { type: "json" });  // object | null
-const stream = await store.get("key", { type: "stream" });
-const blob = await store.get("key", { type: "blob" });
-const buffer = await store.get("key", { type: "arrayBuffer" });
+Pass `type` for other formats: `get(key, { type: "json" | "arrayBuffer" | "blob" | "stream" | "text" })`.
 
-// With metadata
-const result = await store.getWithMetadata("key");
-// { data: any, etag: string, metadata: object } | null
+### Atomic conditional write
 
-// Metadata only (no data download)
-const meta = await store.getMetadata("key");
-// { etag: string, metadata: object } | null
+Write only if the key is new:
+
+```ts
+const { modified } = await store.set("jane@netlify.com", "Jane Doe", { onlyIfNew: true });
+if (!modified) return new Response("Email already exists", { status: 400 });
+```
+
+Write only if the entry matches a known ETag (compare-and-swap):
+
+```ts
+const { modified } = await store.set(key, "New Jane", { onlyIfMatch: etag });
+if (!modified) return new Response("Cached data is stale", { status: 400 });
+```
+
+**Do not build counters, balances, or read-modify-write logic on a blob key** — even with `onlyIfMatch` retries. That is transactional data; use Netlify DB.
+
+### List blobs
+
+```ts
+const { blobs } = await store.list();          // auto-paginates all pages
+// blobs: [ { etag: "\"etag1\"", key: "..." }, ... ]
+```
+
+Manual pagination (returns an `AsyncIterator`):
+
+```ts
+for await (const entry of store.list({ paginate: true })) {
+  console.log(entry.blobs);
+}
+```
+
+Hierarchical listing — group keys with `/`, set `directories: true` to list one level, and use a **trailing slash** on `prefix` to drill in (without it, `cats` would also match `catsuit`):
+
+```ts
+const { blobs, directories } = await store.list({ directories: true });      // top level
+const catList = await store.list({ directories: true, prefix: "cats/" });    // inside cats/
+```
+
+### List stores
+
+```ts
+const { stores } = await listStores();   // does NOT include deploy-specific stores
 ```
 
 ### Delete
 
-```typescript
-await store.delete("key");
+```ts
+await store.delete(key);                       // resolves undefined
+const { deletedBlobs } = await store.deleteAll(); // deletes the whole store; 0 if it didn't exist
 ```
 
-### List
+### Build plugin — write to a deploy-specific store
 
-```typescript
-const { blobs } = await store.list();
-// blobs: [{ etag: string, key: string }, ...]
+Build plugins can **READ from any of the site's stores, but can WRITE only to deploy-specific stores** (`getDeployStore`).
 
-// Filter by prefix
-const { blobs } = await store.list({ prefix: "uploads/" });
+```js
+import { readFile } from "node:fs/promises";
+import { getDeployStore } from "@netlify/blobs";
+import { v4 as uuid } from "uuid";
+
+export const onPostBuild = async () => {
+  const file = await readFile("some-file.txt", "utf8");
+  const uploads = getDeployStore("file-uploads");
+  await uploads.set(uuid(), file);
+};
 ```
 
-`store.list()` **auto-paginates**: a plain `await store.list()` transparently fetches every page and returns the complete `blobs` array — you do NOT hand-roll page cursors or offsets. For a very large store, pass `{ paginate: true }` to get an async iterator and stream results a page at a time instead of buffering every key in memory:
+### Client-side expiration (no server-side TTL)
 
-```typescript
-for await (const page of store.list({ paginate: true })) {
-  for (const { key } of page.blobs) {
-    // handle each key
-  }
+Blobs have no TTL. Store a timestamp in metadata, check it on read, and `delete` when expired:
+
+```ts
+await uploads.set(key, await req.text(), {
+  metadata: { expiration: new Date("2024-01-01").getTime() }
+});
+const entry = await uploads.getWithMetadata(key);
+const { expiration } = entry.metadata;
+if (expiration && expiration < Date.now()) {
+  await uploads.delete(key);
 }
 ```
 
-Pass `{ directories: true }` to group keys by the `/` delimiter (folder-style): the result's `blobs` holds keys at the current level and `directories` holds the common prefixes, which you drill into with `prefix`. Keys are a flat namespace — `/` is only a naming convention that `prefix` and `directories` let you navigate.
+### Conditional read with ETag (`getWithMetadata`)
 
-## Store Types
-
-- **Site-scoped** (`getStore()`): Persist across all deploys. Use for most cases.
-- **Deploy-scoped** (`getDeployStore()`): Tied to a specific deploy lifecycle.
-
-**A site-scoped store is shared across ALL deploy contexts.** Production, deploy previews, and branch deploys all read and write the *same* `getStore()` store — unlike Netlify Database, which forks a separate branch per preview, Blobs does not isolate previews. Code running on a deploy preview reads, overwrites, and deletes the same production data. Don't run destructive tests or seed throwaway data against a `getStore()` store from a preview — it hits production. When you need per-context isolation, use `getDeployStore()`, or partition by deploy context with a context-specific store `name` or key prefix.
-
-## Consistency and concurrency
-
-Blobs are **eventually consistent by default**: an immediate read right after a write may return the previous value or `null`. Opt into **strong** consistency when you need read-your-writes. You can set it once on the store, or request it per read:
-
-```typescript
-import { getStore } from "@netlify/blobs";
-
-const store = getStore({ name: "my-store", consistency: "strong" });
-
-// or just for a single read that must see the latest write:
-const fresh = await store.get("key", { consistency: "strong" });
+```ts
+const { data, etag } = await uploads.getWithMetadata("my-key", { etag: cachedETag });
+if (etag === cachedETag) {
+  // data is null — cached copy still fresh
+}
 ```
 
-Strong reads are **slower** than eventual reads, so don't make everything strong "to be safe" — reserve it for the reads that genuinely need the latest write (typically a read right after a write in the same request). For read-heavy access to data that rarely changes, the default eventual consistency is faster and is the right choice.
+`getWithMetadata` returns `{ data, etag, metadata }`, or `null` if the key is absent. `getMetadata(key)` returns `{ metadata, etag }` (no blob body) — use it to check existence cheaply.
 
-Blobs has **no concurrency control**: there is no locking and there are no transactions, and concurrent writes to the same key are **last-write-wins** — one silently overwrites the other. Do NOT build counters, balances, or any read-modify-write logic over a single blob key and expect it to be correct under concurrent traffic (two requests can both read the old value and both write back, losing an update). When you need atomic or transactional updates, use Netlify Database (see `netlify-database/SKILL.md`), which provides real transactions — not Blobs.
+## API surface
 
-## Limits
+Store instance methods:
+- `set(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`. `value` is `ArrayBuffer | Blob | string`.
+- `setJSON(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`.
+- `get(key, { consistency, type })` → blob in requested format, or `null`.
+- `getWithMetadata(key, { consistency, etag, type })` → `{ data, etag, metadata }` or `null`.
+- `getMetadata(key, { consistency, etag })` → `{ metadata, etag }` or `null`.
+- `list({ directories, paginate, prefix })` → `{ blobs, directories }` (auto-paginates unless `paginate: true`).
+- `delete(key)` → `undefined`.
+- `deleteAll()` → `{ deletedBlobs }`.
 
-| Limit | Value |
-|---|---|
-| Max object size | 5 GB |
-| Metadata per object | 2 KB |
-| Store name max length | 64 bytes |
-| Key max length | 600 bytes |
+Module functions:
+- `listStores({ paginate })` → `{ stores }`. Excludes deploy-specific stores.
 
-Object metadata is capped at **2 KB per object** — it's for small descriptors (content type, size, timestamps, a status flag), not a place to stash large JSON. Anything bigger belongs in the blob value itself, not in `metadata`.
+## Configuration
 
-## Local Development
+### Consistency
+Default is **eventual**: writes are globally readable immediately; updates and deletes propagate within **60 seconds**. Opt into **strong** consistency per store or per read:
 
-Local dev uses a sandboxed store (separate from production). For Vite-based projects, install `@netlify/vite-plugin` to enable local Blobs access. Otherwise, use `netlify dev`.
-
-**Common error**: "The environment has not been configured to use Netlify Blobs" — install `@netlify/vite-plugin` or run via `netlify dev`.
-
-## Inspecting blobs from the CLI
-
-The Netlify CLI can read and write blobs directly — useful for debugging, seeding, or a one-off fix without writing and deploying a function:
-
-```bash
-netlify blobs:list <store-name>
-netlify blobs:get <store-name> <key>
-netlify blobs:set <store-name> <key> <value>
-netlify blobs:delete <store-name> <key>
+```ts
+const store = getStore({ name: "animals", consistency: "strong" }); // whole store
+await store.get("dog", { consistency: "strong" });                  // single read
 ```
 
-These act on the linked site's store, so link the project first (`netlify link`). Reach for these documented subcommands for manual inspection or repair rather than the raw API.
+The CLI always uses strong consistency.
 
-## Uploading blobs at build time
+### Regions (deploy-specific stores)
+Deploy-specific stores default to the function's region. Override with `region`:
 
-You don't have to write blobs from runtime code — you can seed a store during the build by writing files into a special directory. Files placed in `.netlify/blobs/deploy/` during the build are uploaded to a **deploy-scoped** store and are then readable at runtime via `getDeployStore()`. The path under that directory becomes the blob key (so `.netlify/blobs/deploy/products/1.json` is stored under the key `products/1.json`). This avoids a runtime function looping over `store.set` on a cold start.
+```ts
+const uploads = getDeployStore({ name: "file-uploads", region: "ap-southeast-2" });
+```
 
-To attach metadata to a build-time blob, add a JSON sidecar whose name is the blob's filename prefixed with `$` and suffixed with `.json` — metadata for `logo.png` goes in `$logo.png.json`. Read these blobs back with `getDeployStore()`, not `getStore()`: they live in the deploy-scoped store and are replaced when the deploy is replaced.
+Available regions: https://docs.netlify.com/build/functions/configuration#region
 
-## When a store operation fails
+### File-based uploads (no build plugin)
+Place blob files under `.netlify/blobs/deploy/` in the site's base directory; Netlify uploads them to deploy-specific stores (preserving directory structure) after build, before deploy.
 
-If a `get`/`set` call throws in a deployed function, don't guess at a fix or route around it — the exact error is in the **function logs**, and it almost always names the cause. Read it first. Common causes: the store isn't reachable from the calling context, a missing or mismatched store `name`, or a read-after-write timing gap (an immediate read of a just-written key — use `consistency: "strong"` when you need read-your-writes).
+- Attach metadata with a sibling JSON file prefixed with `$`: `$mouse.jpg.json` for `mouse.jpg`, `dogs/$good-boy.jpg.json` for `dogs/good-boy.jpg`.
+- Metadata files must be valid JSON or **the deploy fails**.
+- `.netlify/blobs/deploy` is **wiped before each build** — files must be created DURING the build (build command or plugin). Files committed to the repo beforehand are NOT uploaded.
+- Requires continuous deployment or CLI deploys.
 
-The store exposes only the documented methods above; there is no lower-level REST endpoint to fall back on. If the logs don't resolve it, report the exact error plus the affected site/deploy to the user and stop. Reaching around a failing store — direct `https://api.netlify.com/...` calls, reading auth tokens off disk, or inventing endpoints — can't work (those aren't supported surfaces) and risks corrupting or losing the very data you're trying to save.
+## Constraints & gotchas
+
+- **Store names:** no `/`, no `:`, max 64 bytes.
+- **Keys:** non-empty, cannot start with `/`, max 600 bytes, any Unicode. (UTF-8: most chars 1 byte, some more, e.g. `à` = 2 bytes.)
+- **Sizes:** object ≤ 5 GB; metadata ≤ 2 KB.
+- **Pagination pages:** `list` and `listStores` cap pages at 1,000 entries/stores.
+- **Last write wins** — no concurrency control beyond `onlyIfMatch` / `onlyIfNew`.
+- **Go Functions cannot access Blobs.**
+- **Local dev (Netlify Dev)** uses a sandboxed local store: no file-based uploads, and you cannot read production data.
+- **Not supported** under Netlify's HIPAA-compliant hosting.
+- Deploy deletion cleans up deploy-specific stores only; other stores need manual deletion or your own expiration logic.
+- Downloading a deploy does NOT include deploy-specific blobs; locking a published deploy does NOT prevent writes to its deploy-specific stores.
+- Encrypted at rest and in transit; blobs are reachable only through your own site.
+
+## When something fails
+Surface the error and read the function logs. Do not invent REST endpoints or side-channel APIs to retry a failed store operation.
+
+## CLI & migration
+Inspect blobs with `netlify blobs:list` / `:get` / `:set` / `:delete` — reference: https://cli.netlify.com/commands/blobs/
+
+If you wrote to site-wide stores with `@netlify/blobs` ≤ 6.5.0, data becomes inaccessible after upgrading (namespacing change). Migrate with the latest CLI, which makes the store accessible on 7.0.0+:
+
+```sh
+netlify recipes blobs-migrate YOUR_STORE_NAME
+```
+
+<!-- system: agent-context/blobs/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (blobs)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Blobs is not a database. For dynamic, per-user, or transactional data,
+   use Netlify DB — Blobs is for objects, files, and cache-like state.
+2. When a store operation fails, surface the error and read the function
+   logs — do not invent REST endpoints or side-channel APIs to retry.
+3. `netlify blobs:list/get/set/delete` exist for inspection; the CLI
+   reference is their source of truth — link, don't restate.
+4. Blobs have no built-in access control — the serving function is the gate.
+   When in doubt, default to private: gate reads behind an authenticated
+   function rather than exposing blobs publicly.
+5. Site-scoped stores are shared across ALL deploy contexts — code on a
+   deploy preview reads, overwrites, and deletes production data. Never run
+   destructive tests or seed throwaway data from previews; use
+   `getDeployStore()` or a context-specific store name for isolation.
+6. Don't build counters, balances, or read-modify-write logic on a blob key —
+   even with `onlyIfMatch` retries. That's transactional data; use Netlify DB.
+7. Build plugins: state BOTH halves — they can read from any of the site's
+   stores, but write only to deploy-specific stores (`getDeployStore`).

--- a/cursor/rules/netlify-caching.mdc
+++ b/cursor/rules/netlify-caching.mdc
@@ -1,186 +1,311 @@
 ---
-description: Guide for controlling caching on Netlify's CDN. Use when configuring cache headers, setting up stale-while-revalidate, implementing on-demand cache purge, or understanding Netlify's CDN caching behavior. Covers Cache-Control, Netlify-CDN-Cache-Control, cache tags, durable cache, and framework-specific caching patterns.
+description: Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add caching or cache-control headers to a function response, tune cache TTL or stale-while-revalidate, set up the durable cache, vary a cache key by query/header/cookie/country/language, purge or invalidate the cache by site or cache tag, use the programmatic Cache API (caches.open/match/put) or @netlify/cache helpers (fetchWithCache/cacheHeaders/getCacheStatus), speed up an expensive API call, add ISR or on-demand revalidation, or debug why a response is or isn't cached via the Cache-Status header.
 alwaysApply: false
 ---
 
-# Caching on Netlify
+# Netlify caching
 
-## Default Behavior
+## Cache-control header to reach for
 
-**Static assets** are cached automatically:
-- CDN: cached for 1 year, invalidated on every deploy
-- Browser: always revalidates (`max-age=0, must-revalidate`)
-- No configuration needed
+Dynamic responses (Functions, Edge Functions, proxies) are **NOT cached by default** — you must opt in. Set `Netlify-CDN-Cache-Control` on the response:
 
-**Dynamic responses** (functions, edge functions, proxied) are **not cached by default**. Add cache headers explicitly.
+```ts
+import type { Context } from "@netlify/functions";
 
-**Only `GET` requests are cached.** Netlify's CDN caches responses to `GET` requests only. Responses to `POST`, `PUT`, `PATCH`, `DELETE`, and other non-`GET` methods are never cached, no matter what cache headers you set on them. If a response needs to be CDN-cacheable, expose it on a `GET` route (put the inputs in the URL/query string) — you cannot make the CDN cache a mutating `POST` endpoint by adding cache headers.
-
-## Cache-Control Headers
-
-Three headers control caching, from most to least specific:
-
-| Header | Who sees it | Use case |
-|---|---|---|
-| `Netlify-CDN-Cache-Control` | Netlify CDN only (stripped before browser) | CDN-only caching |
-| `CDN-Cache-Control` | All CDN caches (stripped before browser) | Multi-CDN setups |
-| `Cache-Control` | Browser and all caches | General caching |
-
-### Common Patterns
-
-```typescript
-// Cache at CDN for 1 hour, browser always revalidates
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, s-maxage=3600, must-revalidate",
-    "Cache-Control": "public, max-age=0, must-revalidate",
-  },
-});
-
-// Stale-while-revalidate (serve stale for 2 min while refreshing)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=120",
-  },
-});
-
-// Durable cache (shared across edge nodes, serverless functions only)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, durable, max-age=60, stale-while-revalidate=120",
-  },
-});
-```
-
-### Immutable Assets
-
-For fingerprinted files (hash in filename):
-
-```toml
-# netlify.toml
-[[headers]]
-for = "/assets/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-```
-
-## Cache Tags and On-Demand Purge
-
-Tag responses for selective cache invalidation:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-Tag": "product,listing",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
-```
-
-Purge by tag:
-
-```typescript
-import { purgeCache } from "@netlify/functions";
-
-export default async () => {
-  await purgeCache({ tags: ["product"] });
-  return new Response("Purged", { status: 202 });
+export default async (req: Request, context: Context) => {
+  return new Response("Hello world", {
+    headers: {
+      'Netlify-CDN-Cache-Control': 'public, durable, max-age=60, stale-while-revalidate=120'
+    }
+  });
 };
 ```
 
-Purge entire site:
+Header choice (most specific wins; `CDN-Cache-Control`/`Cache-Control` always pass downstream):
+- `Netlify-CDN-Cache-Control` — Netlify CDN only. **Reach for this.**
+- `CDN-Cache-Control` — all CDNs that support it.
+- `Cache-Control` — any CDN or the browser.
 
-```typescript
-await purgeCache();
+**Legacy path to avoid:** On-demand Builders do **not** support these headers or `Netlify-Vary` — they use a TTL pattern and key on URL path only. Don't reach for ODBs in new code.
+
+## Footguns (read first)
+
+- **Only `GET` is cached.** POST/PUT/etc. are never cached regardless of headers — expose cacheable data on a GET route (inputs in the URL or query string).
+- **`netlify dev` does not emulate the CDN cache.** A local cache miss every time is expected. Verify caching on a deployed URL (Deploy Preview or production) via its `Cache-Status` header.
+- **Without `Netlify-Vary: query=...`, the full query string is the cache key** — every distinct query string (`utm_*`, `fbclid`, …) is a separate cache entry. Enumerate only the params that change the response.
+- **Static assets are fresh for up to a year** — a shorter `max-age` is ignored. They change only on a new deploy or manual purge.
+- **basic-auth on ANY page disables caching for the ENTIRE site.**
+- **`durable` is serverless-only** — it has no effect on Edge Function responses.
+- Never opt sensitive content out of automatic invalidation — it can stay publicly cached after deploys/firewall changes.
+
+## Directives
+
+- `public` cache it / `private` browser-only, not Netlify's shared cache / `no-store` don't cache.
+- `s-maxage=N` seconds in Netlify's shared cache (overrides `max-age` there).
+- `max-age=N` seconds in any cache.
+- `stale-while-revalidate=N` serve stale for N seconds after expiry while revalidating in background.
+- `durable` (serverless only) store in Netlify's durable cache so other edge nodes reuse it instead of re-invoking the function.
+
+Defaults when no header is set — static: `Netlify-CDN-Cache-Control: public, s-maxage=31536000, must-revalidate`; dynamic: `Cache-Control: public, max-age=0, must-revalidate`.
+
+## Cache key variation — `Netlify-Vary`
+
+Comma-delimited instructions on the response; pipe-delimited value lists:
+
+```
+Netlify-Vary: query=item_id|page, country=es+de|us, cookie=ab_test|is_logged_in
 ```
 
-`purgeCache()` picks up the site ID and credentials automatically **only when it runs inside a deployed Netlify Function**. Called from anywhere else — a local script, a CI job, a build step, or any code outside the Netlify Functions runtime — it has no ambient credentials, and you must pass a Netlify personal access token (and the site ID). Read the token from an environment variable; never hardcode it:
+- `query=a|b` subset, or bare `query` for all params. Keys case-sensitive; param order irrelevant.
+- `header=Device-Type|App-Version` — custom + most standard headers.
+- `language=en|es+pt` — `+` groups; checked against `Accept-Language` with quality weighting.
+- `country=us|es+pt` — GeoIP, ISO 3166-1 two-letter codes; `+` groups.
+- `cookie=ab_test|is_logged_in` — target specific keys, not the whole `Cookie` header.
 
-```typescript
-await purgeCache({
-  token: process.env.NETLIFY_PURGE_TOKEN, // a Netlify personal access token, from env
-  siteID: process.env.NETLIFY_SITE_ID,
-  tags: ["product"],
-});
+**Cannot vary by header on:** `Accept*`, `Cache-Control`, `Connection`, `Content-Length`, `Cookie`, `Host`, `If-*`, `Range`, `Referer`, `Upgrade`, `User-Agent`. For language/cookie/format use `Vary: Accept-Language`/`Vary: Cookie` or the specific `Netlify-Vary` instruction.
+
+**Consistency rule:** a URL must return the same `Netlify-Vary` on every response — the first cached response's instructions win and later ones are ignored. `Netlify-Vary` + standard `Vary` are both respected (use `Vary` for format/encoding, and to pass instructions to an upstream CDN like Cloudflare).
+
+## Cache tags & opt-out
+
+Tag responses for taggable purging:
+
+```
+Netlify-Cache-Tag: tag1,tag2,tag3
 ```
 
-`Netlify-Cache-Tag` is **purge-only**: tagged responses are still cleared by automatic deploy-based invalidation like everything else. The tag only lets you purge them on demand between deploys.
+- `Netlify-Cache-Tag` (Netlify CDN) wins over `Cache-Tag` (passed downstream). Some providers strip `Cache-Tag` — set both when proxying through them.
+- Constraints: case-insensitive, UTF-8 only, ≤1024 chars/tag, ≤500 tags/response.
 
-### Surviving deploys with `Netlify-Cache-ID`
+Opt a response out of automatic atomic-deploy invalidation with `Netlify-Cache-ID` (comma-separated; auto-registered as cache tags for purging; separate 500-ID limit):
 
-To keep a cached response *across* deploys, set a `Netlify-Cache-ID` header. A response carrying it is **excluded from automatic deploy-based invalidation** — it persists across deploys and clears only on explicit purge. The `Netlify-Cache-ID` value also auto-registers as a purge tag, so you purge it by that same id:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-ID": "catalog",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
+```
+Netlify-Cache-ID: cms-proxy,product,image
 ```
 
-```typescript
+After opting out, purge on-demand after relevant changes (e.g. redirect/proxy or function changes behind a `Netlify-Cache-ID`).
+
+## On-demand invalidation (purge)
+
+Purge from a **deployed function** with `purgeCache` (site ID is passed automatically):
+
+```ts
 import { purgeCache } from "@netlify/functions";
 
-// Purge by the same id — it doubles as a purge tag.
-await purgeCache({ tags: ["catalog"] });
+export default async () => {
+  await purgeCache(); // no args = purge everything for the site
+  return new Response("Purged!", { status: 202 });
+};
 ```
 
-## Cache Key Variation
+Purge by tag, optionally targeting a deploy/subdomain:
 
-`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
+```ts
+import { purgeCache } from "@netlify/functions";
 
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Vary": "cookie=ab_test|is_logged_in",
-  },
+export default async (req: Request) => {
+  const cacheTag = new URL(req.url).searchParams.get("tag");
+  if (!cacheTag) return;
+  await purgeCache({
+    tags: [cacheTag],
+    deployAlias: "deploy-preview-11",
+    domain: "early-access.company.com",
+  });
+  return new Response("Purged!", { status: 202 });
+};
+```
+
+**Ambient credentials only work inside a deployed function.** From CI, local scripts, or the build, pass `token` (a personal access token read from an env var — never hardcoded) and `siteID`.
+
+**Lambda-compatible functions** use the legacy `module.exports.handler = async (event, context) => {…}` signature and must pass `context.clientContext.custom.purge_api_token`:
+
+```ts
+import { purgeCache } from "@netlify/functions";
+
+module.exports.handler = async (event, context) => {
+  const token = context.clientContext.custom.purge_api_token;
+  await purgeCache({ tags: ["tag1", "tag2"], token });
+  return { body: "Purged!", statusCode: 202 };
+};
+```
+
+Direct API (from outside a function) — `POST https://api.netlify.com/api/v1/purge` with `Authorization: Bearer <personal_access_token>` and `Content-Type: application/json`:
+
+```sh
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <personal_access_token>" \
+  --data '{"site_slug": "mysitename", "cache_tags": ["news"], "deploy_alias": "deploy-preview-11", "domain": "early-access.company.com"}' \
+  'https://api.netlify.com/api/v1/purge'
+```
+
+- Purge by site: `site_id` or `site_slug`. By tag: `cache_tags` + site. Omitting `cache_tags` purges the whole site; an **empty** `cache_tags` list purges NOTHING.
+- Identifier mapping: in the UI (Project configuration > General > Project details), **Project ID** = `site_id`, **Project name** = `site_slug`. See https://docs.netlify.com/api-and-cli-guides/api-guides/get-started-with-api#get-site.
+- **Rate limit:** each tag or site can be purged only twice per 5s — exceeding returns `429`.
+
+## Cache API (`caches` global)
+
+Programmatic read/write of HTTP responses from Functions/Edge Functions. Use for caching individual components of a route or arbitrary fetches, alongside header-based route caching.
+
+**Scope rule:** `caches.open()` anywhere, but `match`/`put`/`delete` **only inside the request handler** — doing them at module/global scope throws.
+
+```ts
+import type { Config, Context } from "@netlify/functions";
+
+const cache = await caches.open("my-cache"); // ok in global scope
+
+export default async (req: Request, context: Context) => {
+  const request = new Request("https://example.com/expensive-api");
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const fresh = await fetch(request);
+  if (fresh.ok) {
+    cache.put(request, fresh.clone()).catch((error) => {
+      console.error("Failed to add to the cache:", error);
+    });
+  }
+  return fresh;
+};
+
+export const config: Config = { path: "/cache-api-example" };
+```
+
+`CacheStorage` subset:
+- `caches.match(request)` → `Response` from any cache, or `undefined`.
+- `caches.open(name)` → `Cache`. Distinct names fragment the cache and lower hit ratio — use few, meaningful names.
+
+`Cache` methods (all require `caches.open()`):
+- `cache.match(request)` → `Response` | `undefined`.
+- `cache.put(request, response)` → adds a response.
+- `cache.add(request)` / `cache.addAll(requests)` → fetch + store.
+- `cache.delete(request)` → `true`.
+- `keys()` is **not implemented** — no way to list contents.
+
+Consistency: reads/writes strongly consistent; **deletes eventually consistent** (a deleted entry may still return briefly).
+
+**Cannot cache:** partial responses (206), `Vary: *`, or non-`GET` methods. Responses need a cache-control header with `max-age`/`s-maxage` ≥ 1s, `public` (not `private`/`no-cache`/`no-store`), and a 2xx status — otherwise storage errors. For responses you don't control, rewrite headers with `fetchWithCache`.
+
+**Limits per invocation:** 100 lookups, 20 insertions/deletions. Exceeding: further lookups return nothing; writes/deletes no-op. Limits are shared across edge functions in a request but separate between serverless and edge functions. Cache data is per-region (not replicated), auto-invalidated on redeploy and on `max-age`/`s-maxage` expiry.
+
+## `@netlify/cache` module
+
+Install to get helpers, time constants (`MINUTE`/`HOUR`/`DAY`), and a `caches` export for local dev:
+
+```
+npm install @netlify/cache
+```
+
+**Local-dev workaround:** the `caches` global isn't part of Node.js. Netlify provides it in its Functions/Edge runtimes (live and under `netlify dev`), but if you run your framework's own dev server the global is undefined and throws — import it instead:
+
+```ts
+import { caches } from "@netlify/cache";
+const cache = await caches.open("my-cache");
+```
+
+Requires Netlify CLI 20.0.3+; nothing persists locally (lookups return nothing, writes/deletes don't mutate). No functional change from the global.
+
+### `cacheHeaders(settings)` → header object
+
+```ts
+import { cacheHeaders, DAY } from "@netlify/cache";
+
+const headers = {
+  "x-custom-header": "some value",
+  ...cacheHeaders({
+    ttl: 2 * DAY,          // s-maxage
+    swr: HOUR,             // stale-while-revalidate
+    durable: true,
+    tags: ["product", "sale"],
+    overrideDeployRevalidation: ["tag"], // opt out of atomic-deploy invalidation
+    vary: {
+      cookie: ["ab_test_name", "ab_test_bucket"],
+      query: ["item_id", "page"], // or true for all
+      country: ["us", ["es", "pt"]], // nested = OR
+      language: ["en"],
+      header: ["Device-Type"],
+    },
+  }),
+};
+```
+
+For only generic (non-Netlify) headers, use the `cdn-cache-control` npm module instead.
+
+### `fetchWithCache(resource, options?, cacheSettings?)`
+
+Drop-in `fetch` that returns a cached response or fetches, stores, and returns. `cacheSettings` override conflicting response headers; with `swr`, background revalidation is handled automatically.
+
+```ts
+import { fetchWithCache, DAY } from "@netlify/cache";
+
+const response = await fetchWithCache("https://example.com/expensive-api", {
+  ttl: 2 * DAY,
+  tags: ["product", "sale"],
+  vary: { cookie: ["ab_test_name"], query: ["item_id", "page"] },
 });
 ```
 
-- `query=param1|param2` — key on the named query parameters
-- `header=X-Custom` — key on the named request header
-- `cookie=ab_test|is_logged_in` — key on the named cookies
-- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
-- `language=en|fr` — key on the listed `Accept-Language` values
+### `getCacheStatus(response | headers | headerString)`
 
-Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
+Returns `{ hit, caches: { durable: { hit, stale, stored, ttl }, edge: { hit, stale } } }`.
 
-## Framework-Specific Caching
-
-### Next.js
-ISR uses Netlify's durable cache automatically (runtime 5.5.0+). `revalidatePath` and `revalidateTag` trigger cache purge.
-
-### Astro / Remix
-Full control over cache headers in server routes. Set `Netlify-CDN-Cache-Control` in responses for CDN caching.
-
-### Nuxt
-Default Nitro preset handles caching. ISR-style patterns use `routeRules` with `swr` or `isr` options.
-
-### Vite SPA
-Static assets are cached by default. API responses from Netlify Functions need explicit cache headers.
-
-**The full query string is part of the cache key by default.** With no `Netlify-Vary: query=` directive, every distinct query string is cached as a separate entry — so appending tracking or marketing params (`?utm_source=…`, `fbclid`, and the like) silently fragments the cache into many near-duplicate entries and lowers the hit rate, even when those params don't change the response. Add `Netlify-Vary: query=<names>` listing only the parameters that actually affect the output; the CDN then keys on just those and ignores all other query params, collapsing the variants onto one cache entry.
-
-## Local Development
-
-`netlify dev` does not emulate the CDN cache. Header-based CDN caching is only observable on a deployed site: locally, cache headers pass through untouched, nothing is stored in or served from the CDN cache, Cache-API reads return no persisted entries, and the `Cache-Status` response header is absent. A "cache miss every time" on `localhost` is expected, not a bug — you cannot validate `Netlify-Vary` keying, cache tags, durable cache, or purge behavior locally. Verify caching on a deployed URL instead (a Deploy Preview or production) and read its `Cache-Status` header.
-
-## Debugging
-
-Check the `Cache-Status` response header. Netlify emits it in the RFC 9211 format — one entry per named cache layer the request passed through, not a bare `HIT`/`MISS`:
-
-```
-Cache-Status: "Netlify Edge"; fwd=miss, "Netlify Durable"; hit; ttl=3600
+```ts
+const { hit, edge, durable } = getCacheStatus(response);
 ```
 
-- A named layer (`"Netlify Edge"`, `"Netlify Durable"`) with `hit` — served from that cache
-- `fwd=miss` — the entry was not in that layer, so the request was forwarded onward
-- `ttl=…` — remaining freshness (seconds) for a hit
+### `needsRevalidation(response)` → boolean
 
-## Constraints
+Only needed when calling `cache.match`/`cache.put` directly (not with `fetchWithCache`+`swr`). True when a Cache-API response is stale within its SWR window — return it, then revalidate in `context.waitUntil` and `cache.put` the fresh copy:
 
-- Basic auth disables caching for the entire site
-- Durable cache is serverless functions only (not edge functions)
-- Same URL must return identical `Netlify-Vary` headers across responses
-- Deploy invalidation is scoped to deploy context (production vs preview)
+```ts
+if (cached) {
+  if (needsRevalidation(cached)) {
+    context.waitUntil(
+      fetch(request).then((fresh) => {
+        const response = new Response(fresh.body, {
+          headers: { ...Object.fromEntries(fresh.headers), ...cacheHeaders({ ttl: MINUTE, swr: HOUR }) },
+        });
+        return cache.put(request, response);
+      })
+    );
+  }
+  return cached;
+}
+```
+
+## Durable cache
+
+Add `durable` (serverless only) so edge nodes lacking a local copy check the shared durable cache before invoking the function — fewer invocations, better cache-miss latency. Eventually consistent, so multiple regions may still invoke the function a few times per version. Co-located with the site's functions region. Works with `Netlify-Vary`, SWR, and on-demand invalidation. **Next.js:** Next Runtime 5.5.0+ uses the durable cache automatically.
+
+## Debugging with `Cache-Status`
+
+Netlify sets `Cache-Status` (RFC 9211) on all responses. Check it on a **deployed** URL. Look for values starting `"Netlify Edge"` or `"Netlify Durable"`:
+
+- `"Netlify Edge"; fwd=miss` — nothing cached.
+- `"Netlify Edge"; hit` — served from cache.
+- `"Netlify Edge"; hit; fwd=stale` — stale served while revalidating (SWR).
+- Durable stored on miss: `"Netlify Durable"; fwd=uri-miss; stored=true; ttl=3600`.
+- Durable hit: `"Netlify Durable"; hit; ttl=1234`.
+
+`ttl` negative = seconds since expiry. Each request may hit a different cache instance — without production traffic or `durable`, expect several empty caches before a hit; repeat requests to warm one.
+
+<!-- Gaps: package/method inconsistency in @netlify/cache local-dev docs (caches import shown with cache.set, not the documented cache.put) resolved to cache.put per Cache API surface. -->
+
+<!-- system: agent-context/caching/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (caching)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Only `GET` responses are cached by the CDN. `POST`/`PUT`/etc. are never
+   cached regardless of headers — expose cacheable data on a `GET` route
+   (put the inputs in the URL or query string).
+2. Without `Netlify-Vary: query=...`, the full query string is the cache key —
+   every distinct query string (`utm_*`, `fbclid`, ...) is a separate cache
+   entry. Enumerate only the params that actually change the response.
+3. `netlify dev` does not emulate the CDN cache — a cache miss every time
+   locally is expected, not a bug. Verify caching behavior on a deployed URL
+   (Deploy Preview or production) via its `Cache-Status` header.
+4. `purgeCache()` has ambient credentials only inside a deployed function.
+   From CI, local scripts, or the build, pass `token` (a personal access
+   token read from an env var, never hardcoded) and `siteID`.

--- a/cursor/rules/netlify-config.mdc
+++ b/cursor/rules/netlify-config.mdc
@@ -1,228 +1,302 @@
 ---
-description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, the `[dev]` block that controls `netlify dev` (command, port, targetPort, framework), or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, edge functions config, and the `[dev]` block (including when `framework` must be `"#custom"` — required when both a custom `command` and `targetPort` are set).
+description: Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy contexts alongside environment variables/scopes and the Secrets Controller plus redirect/rewrite/proxy and custom-header rules. Use when setting a build command or publish directory, adding redirect or rewrite or proxy rules, configuring custom headers or basic auth, setting or scoping environment variables and secrets, wiring up a monorepo or SPA fallback, or skipping unnecessary builds. Reach for this whenever you touch netlify.toml or ask "why is my env var undefined in a function" or "how do I redirect this path".
 alwaysApply: false
 ---
 
-# Netlify Configuration (netlify.toml)
+# Netlify configuration
 
-Place `netlify.toml` at the repository root. In a monorepo, Netlify searches for the config and uses the **first** one it finds: the package directory (the subdirectory containing the site), then the base directory, then the repository root — so put a site-specific `netlify.toml` in the package directory to take precedence over root-level config (see the **netlify-deploy** skill's monorepo notes).
+`netlify.toml` lives at the repo root (or set `base`/package directory for monorepos). Settings in `netlify.toml` **override** the Netlify UI on conflict. `_headers` and `_redirects` are extensionless plain-text files in the **publish directory**, processed **before** `netlify.toml` rules.
 
-**`netlify.toml` takes precedence over the Netlify UI.** When the same property (build command, publish directory, an environment variable, a redirect, a header) is configured in both places, the value in `netlify.toml` wins and silently overrides the corresponding Netlify UI setting — the dashboard field still shows its old value but is inert. Once a `netlify.toml` is present, treat it as the source of truth and change settings there, not in the UI.
+## Footguns (read first)
 
-## Build Settings
+- **Env vars in `netlify.toml` are NOT available to functions or edge functions at runtime** — reading them there returns `undefined`. Vars declared in `netlify.toml` only get the **Builds** and **Post processing** scopes. Set runtime vars in the UI or with `netlify env:set`.
+- **Never put secrets in client-prefixed vars** (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, …) — they are inlined into the client bundle. `--secret` does not protect them.
+- **`.env` is not read by the Netlify build system** — import variables into Netlify first (`netlify env:import`). The CLI reads `.env` only for local builds.
+- **Direct env injection into `netlify.toml` (`key = "$VAR"`) is unsupported** — except signed proxy redirects. Use a build plugin or `sed` in the build command.
+- **`[[redirects]]` and `[[headers]]` are global** — NOT context-aware, cannot be scoped to branches/contexts. Workaround: per-context build command copies a custom file into the publish directory.
+- **Proxy rewrites time out at 26 seconds.** HTTP `307` is unsupported — use `302`.
+
+## `netlify.toml` — core structure
 
 ```toml
 [build]
-  base = "project/"          # Base directory (default: root)
-  command = "npm run build"  # Build command
-  publish = "dist/"          # Output directory
+  base = "project/"          # base directory
+  publish = "build-output/"  # relative to base, default /
+  command = "npm run build"  # runs in Bash shell
+  [build.environment]
+    NODE_VERSION = "18"
+
+[context.production]         # production branch deploy
+  command = "make publish"
+  environment = { NODE_VERSION = "14.15.3" }
+[context.deploy-preview]     # PR/MR previews
+  publish = "dist/"
+[context.branch-deploy]      # non-production branches
+  command = "echo branch"
+[context.dev.environment]    # local dev env vars ONLY
+  NODE_ENV = "development"
+[context.staging]            # a specific branch name
+  command = "echo staging"
+[context."feat/branch"]      # quote branches with special chars
+  command = "echo special"
 ```
 
-## Redirects
+Context precedence (least → most specific): UI settings < base context-aware key < `[context.production|deploy-preview|branch-deploy|dev]` < `[context.branchname]`. Only `[build]` and `[[plugins]]` are context-aware. All paths are absolute relative to the base directory (root `/` default).
 
-```toml
-# Basic redirect
-[[redirects]]
-from = "/old"
-to = "/new"
-status = 301              # 301 (default), 302, 200 (rewrite), 404
+Config file search order: package directory → base directory → root.
 
-# SPA catch-all
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
-
-# Splat (wildcard)
-[[redirects]]
-from = "/blog/*"
-to = "/news/:splat"
-
-# Path parameters
-[[redirects]]
-from = "/users/:id"
-to = "/api/users/:id"
-status = 200
-
-# Force (override existing files)
-[[redirects]]
-from = "/app/*"
-to = "/index.html"
-status = 200
-force = true
-
-# Proxy to external service
-[[redirects]]
-from = "/api/*"
-to = "https://api.example.com/:splat"
-status = 200
-[redirects.headers]
-  X-Custom = "value"
-
-# Country/language conditions
-[[redirects]]
-from = "/*"
-to = "/fr/:splat"
-status = 200
-conditions = { Country = ["FR"], Language = ["fr"] }
-```
-
-**Rule order matters** — Netlify processes the first matching rule. Place specific rules before general ones.
-
-Redirect rules can also live in a plain-text `_redirects` file in the publish directory. If both a `_redirects` file and `[[redirects]]` in `netlify.toml` exist, the `_redirects` file rules are processed **first**, then the `netlify.toml` rules, reading top to bottom — and the first matching rule wins. The same ordering applies to a `_headers` file versus `[[headers]]`. Because a `_redirects` rule can silently shadow a `netlify.toml` rule for the same path, keep overlapping rules in a single source.
-
-## Headers
-
-```toml
-[[headers]]
-for = "/*"
-[headers.values]
-  X-Frame-Options = "DENY"
-  X-Content-Type-Options = "nosniff"
-
-[[headers]]
-for = "/assets/*"
-[headers.values]
-  Cache-Control = "public, max-age=31536000, immutable"
-```
-
-Headers apply only to files served from Netlify's CDN (not to function or edge function responses — set those in code).
-
-## Deploy Contexts
-
-Override settings per deploy context:
-
-```toml
-[context.production]
-command = "npm run build"
-environment = { NODE_ENV = "production" }
-
-[context.deploy-preview]
-command = "npm run build:preview"
-
-[context.branch-deploy]
-command = "npm run build:staging"
-
-[context.dev]
-environment = { NODE_ENV = "development" }
-
-# Specific branch
-[context."staging"]
-command = "npm run build:staging"
-```
-
-**`[[redirects]]` and `[[headers]]` are global — they cannot be scoped to a deploy context.** Context tables like `[context.production]` work for keys such as `[build]`, `[build.environment]`, and `[[plugins]]`, but redirect and header rules apply to every context no matter where you place them in the file; there is no `[context.production.redirects]` or context-nested `[[redirects]]`. For context-specific redirects or headers, use the per-deploy escape hatch: generate a `_redirects` or `_headers` file during that context's build (those files ship per deploy), or gate the behavior on a runtime signal in an edge function.
-
-## Environment Variables
-
-```toml
-[build.environment]
-NODE_VERSION = "20"
-
-[context.production.environment]
-API_URL = "https://api.prod.com"
-
-[context.deploy-preview.environment]
-API_URL = "https://api.staging.com"
-```
-
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
-
-**Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
-
-### CLI Management
-
-```bash
-# Set
-netlify env:set API_KEY "value"
-netlify env:set API_KEY "value" --secret              # Hidden from logs
-netlify env:set API_KEY "value" --context production   # Context-specific
-
-# Get
-netlify env:get API_KEY
-
-# List
-netlify env:list
-netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
-
-# Import from file
-netlify env:import .env
-
-# Delete
-netlify env:unset API_KEY
-```
-
-**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
-
-### Context Scoping
-
-Variables set via the CLI can also be scoped to deploy contexts:
-
-```bash
-netlify env:set API_URL "https://api.prod.com" --context production
-netlify env:set API_URL "https://api.staging.com" --context deploy-preview
-netlify env:set DEBUG "true" --context branch:feature-x
-```
-
-This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
-
-When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
-
-For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-frameworks** skill; for function-side details, see **netlify-functions**.
-
-## Functions Configuration
+## Functions config
 
 ```toml
 [functions]
-directory = "netlify/functions"   # Default
-node_bundler = "esbuild"
+  directory = "functions/"           # default: YOUR_BASE_DIR/netlify/functions
+  node_bundler = "esbuild"           # prefer esbuild; zisi is the JS default
+  external_node_modules = ["package-1"]
+  included_files = ["files/*.md", "!files/skip.md"]
 
-# Scheduled function
-[functions."cleanup"]
-schedule = "@daily"
+[functions."api_*"]                  # glob filter; values CONCATENATE across matches
+  external_node_modules = ["package-2"]
 ```
 
-Use the single-table `[functions]` form for global settings and `[functions."name-or-glob"]` for per-function overrides. There is **no** `[[functions]]` array-of-tables and no path-based function routing table in `netlify.toml` — functions are routed by file (served at `/.netlify/functions/{name}`) or by an in-code `path`/`config` export, not by config.
+- `esbuild` = smaller/faster artifacts; TypeScript functions **always** use `esbuild`.
+- `external_node_modules` applies only with `esbuild`. `included_files`: `*` wildcard, `!` excludes; paths absolute to base.
 
-## Edge Functions Configuration
+## Environment variables
+
+Set runtime/scoped vars via CLI/UI/API (not `netlify.toml`):
+
+```sh
+netlify env:set MY_KEY value --secret     # --secret marks an env var secret
+netlify env:import .env                    # site-level, all scopes, all contexts
+netlify env:list --plain --context production > .env
+netlify env:unset MY_KEY
+```
+
+**Keep any `.env` snapshot gitignored — never commit it.**
+
+**Types:** site vars (one site) vs shared vars (whole team; Pro/Enterprise; Team Owners only).
+
+**Scopes** (Pro/Enterprise; default = all): **Builds**, **Functions** (also Edge Functions + On-demand Builders), **Runtime** (forms, signed proxy redirects), **Post processing** (snippet injection). Vars from `netlify.toml` are locked to **Builds** + **Post processing**.
+
+**Scope precedence is independent per scope:** a site variable scoped only to Builds does NOT shadow a shared variable for the Functions scope — the shared value still applies there. Site beats shared only within the scopes the site variable actually carries.
+
+**Deploy-context values:** `Production`, `Deploy Previews`, `Branch deploys` (override per-branch with a `Branch` value, wildcard suffix `release/*`), `Preview server`, `Local development`.
+
+**Overrides:** `netlify.toml` vars override same-key UI/CLI/API vars. Site var beats shared var per its scopes/contexts.
+
+**Limits:** keys ≤ 255 chars, alphanumeric + underscore, first char a letter (`KEY1` ok; `1KEY`/`_KEY1` invalid). Values ≤ 5,000 chars (functions within AWS limits). Reserved read-only names can't be overridden.
+
+### Build variables
+
+Settable in `netlify.toml` `[build.environment]`: `NODE_VERSION`, `NODE_ENV`, `NPM_VERSION`, `NPM_FLAGS`, `NPM_TOKEN`, `YARN_VERSION`, `PNPM_FLAGS`, `BUN_VERSION`, `RUBY_VERSION`, `PHP_VERSION`, `PYTHON_VERSION`, `GO_VERSION`, `HUGO_VERSION`, `NETLIFY_USE_YARN`, `CI`, etc.
+
+**Set in UI/CLI only (NOT `netlify.toml`, which is read after clone):** `AWS_LAMBDA_JS_RUNTIME`, `GIT_LFS_ENABLED`, `GIT_LFS_FETCH_INCLUDE`, `NETLIFY_BUILD_DEBUG`.
+
+Read-only build metadata (examples): `NETLIFY`, `BUILD_ID`, `CONTEXT` (`production`/`deploy-preview`/`branch-deploy`/`dev`), `BRANCH`, `HEAD`, `COMMIT_REF`, `CACHED_COMMIT_REF`, `PULL_REQUEST`, `REVIEW_ID`, `URL`, `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `DEPLOY_ID`, `SITE_NAME`, `SITE_ID`, `ACCOUNT_ID`.
+
+Access: Bash `$VAR_NAME` in build/ignore commands; `process.env.VAR_NAME` in Node scripts and plugins. Scope must include **Builds**.
+
+### Inject env values into headers/redirects
 
 ```toml
-[[edge_functions]]
-path = "/admin/*"
-function = "auth"
-excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
-
-# Import map for Deno URL imports
-[functions]
-deno_import_map = "./import_map.json"
+[build]
+  command = "sed -i \"s|HEADER_PLACEHOLDER|${PROD_API_LOCATION}|g\" netlify.toml && yarn build"
 ```
 
-## Dev Server
+Substitution only reaches `[[headers]]`/`[[redirects]]` (read after build); NOT available to build plugins. Alternatively mutate `netlifyConfig` in a local build plugin.
+
+## Redirects & rewrites
+
+`_redirects` (one rule per line) or `[[redirects]]`. Rules process top-down; first match wins. `_redirects`/file rules run before `netlify.toml`.
+
+```
+/home            /                301
+/my-redirect     /                302
+/store id=:id    /blog/:id        301
+/news/*          /blog/:splat
+/*               /index.html      200          # SPA fallback
+```
 
 ```toml
-[dev]
-command = "npm start"       # Dev server command
-port = 8888                 # Netlify Dev port
-targetPort = 3000           # Your app's dev server port
-framework = "#auto"         # "#auto", "#static", "#custom"
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 302              # default 301
+  force = true             # default false; shadow an existing URL
+  query = { id = ":id" }
+  conditions = { Language = ["en"], Country = ["US"], Role = ["admin"] }
+  [redirects.headers]
+    X-From = "Netlify"
 ```
 
-**If you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`.** With `framework = "#auto"` (the default) Netlify Dev runs its own detector and ignores your custom `command`; `"#custom"` tells it to run your `command` as the app server and connect to `targetPort`. Setting `command` + `targetPort` while leaving `framework` at `#auto` (or omitting it) is a silent misconfiguration.
+- **Force/shadow:** you can't shadow an existing URL by default — append `!` in `_redirects` or `force = true` in toml.
+- **Splats** (`*`) only at the end of a path segment (`/jobs/*.html` won't work). Can't exclude a path from a splat — order a more specific rule first.
+- **Query:** `id=:id` matches URLs with *only* `id` and no other params. List optional-param variants most-general-last.
+- **Trailing slash:** URLs are normalized before rules run; you cannot add/remove a trailing slash via a redirect (infinite loop). Pretty URLs (on by default) handle standardization.
+- **Country/Language conditions:** no spaces (`Country=au,nz`). `Country` = ISO 3166-1 alpha-2; `Language` = browser/locale codes, matches the FIRST `Accept-Language` entry. `nf_country`/`nf_lang` cookies override.
+- **Domain redirects:** HTTP and HTTPS need separate rules unless forcing SSL; the domain must be assigned to the site.
+- Role-based redirects with external auth: Enterprise only. HTTP `307` unsupported → use `302`.
+- **10,000+ redirects:** favor wildcards/placeholders; serialization across `_redirects` + `netlify.toml` can fail the deploy if too large — consider Edge Functions.
 
-## Plugins
+### Rewrites & proxies (status 200)
+
+```
+/api/*            https://api.example.com/:splat        200
+/netlify-site/*   https://my-other-site.netlify.app/:splat  200
+```
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  headers = { X-From = "Netlify" }
+```
+
+- No cross-team rewrites between Netlify sites. Infinite-loop rules (from == to) are ignored.
+- Internal rewrites limited to one hop. Proxy timeout **26s** — use async for longer. Rewrites break relative-path assets — use absolute paths or `<base>`.
+- Proxy to another Netlify site: use its `.netlify.app` subdomain. Rewrites into a separate password-protected site are not allowed.
+
+### Signed proxy redirects (`netlify.toml` only)
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  signed = "API_SIGNATURE_TOKEN_PLACEHOLDER"
+```
+
+Must be in `netlify.toml`; env var scope must include **Runtime**; not supported proxying Netlify→Netlify. Netlify sends the JWS as HMAC HS256 in the `x-nf-sign` header. (This is the one place `$VAR`-style env injection is allowed.)
+
+## Custom headers
+
+```
+/*
+  X-Frame-Options: DENY
+  cache-control: max-age=0
+  cache-control: no-cache          # multi-value collapses comma-joined
+```
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Basic-Auth = "someuser:somepassword anotheruser:anotherpassword"
+    cache-control = '''
+    max-age=0,
+    no-cache,
+    no-store'''
+```
+
+- **Headers apply only to files Netlify serves from its own store** — proxied content, functions, and edge/SSR pages must return their own headers.
+- Reserved header names Netlify controls (ignored if you set them): `Content-Length`, `Content-Encoding`, `Location` (use redirects), `Set-Cookie` (may be overridden), `Server`, `Date`, `Age`, `Connection`, `Transfer-Encoding`, etc.
+- Basic-Auth headers: Pro/Enterprise. Cross-subdomain cookies impossible on `*.netlify.app` (Public Suffix List) — needs a custom domain.
+- Global only; per-branch via the build-command copy workaround.
+
+## Secrets Controller
+
+Mark a var secret via `--secret` (CLI), `is_secret: true` (API), or the UI. Enforced, non-customizable policy:
+
+- Values are **write-only** — no readable version after setting; the flag can't be removed to reveal a value.
+- Must be set to explicit deploy contexts and scopes; **cannot** have the `post processing` scope.
+- Only code on Netlify reads unmasked values; outside code gets masked. The `dev` context value is unmasked and exempt.
+- Secret scanning (smart detection: Personal/Pro/Enterprise) runs on the next build after marking a var secret. Resolve a detection by removing the value at the location in the deploy log, then redeploy. Safelist false positives via `SECRETS_SCAN_SMART_DETECTION_OMIT_VALUES` (comma-separated), then redeploy.
+
+**Sensitive variable policy (public repos only):** untrusted deploys (unrecognized authors) default to **Require approval**; alternatives are **Deploy without sensitive variables** or **Deploy without restrictions**. Not available for GitHub Enterprise Server / GitLab self-managed (treated as private).
+
+## Ignore builds
+
+```toml
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/blog"
+```
+
+- Exit `0` = no changes, **build stops**; exit `1` = changed, build continues.
+- Runs from base directory; uses fixed **Node.js 18** (not customizable); site `package.json` deps unavailable. Referenced file paths must start with `./`.
+- Won't cancel a build triggered by a build hook, regardless of exit code.
+
+Node.js variant:
+```js
+// ignore_build.js — build only non-debug branches
+process.exitCode = process.env.BRANCH.includes("debug") ? 0 : 1
+```
+
+## JavaScript SPAs
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"        # varies by framework
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200            # required for pushState routing to avoid 404s
+```
+
+Hashed/code-split filenames + atomic deploys can break asset refs (`Uncaught SyntaxError: Unexpected token`) — disable hashed filenames, use permalinks, or a service worker.
+
+## Monorepos
+
+Recommended: set the site's subdirectory as the **package directory** (keep `netlify.toml` there), leave base directory at repo root `/`, declare deps at the subdirectory level.
+
+- **Package directory is UI-only** (Build settings > Configure) — it cannot be set in `netlify.toml`. Base directory can be set in root-level `netlify.toml` (`[build] base`) and overrides the UI.
+- Use absolute paths relative to base: base `/frontend` + plugin at `/frontend/packages/my-app/plugins` → specify `/packages/my-app/plugins/...`.
+- Build only on subdirectory changes with an `ignore` command. CLI: `--filter <site>`. Netlify caches all `node_modules` regardless of where deps are declared.
+
+## Plugins, extensions, dev, templates
 
 ```toml
 [[plugins]]
-package = "@netlify/plugin-lighthouse"
-[plugins.inputs]
-  audits = ["performance", "accessibility"]
+  package = "@netlify/plugin-lighthouse"
+  [plugins.inputs]
+    breeds = ["pomeranian"]
+
+[[integrations]]           # extensions; install on team first
+  name = "abc-performance-extension"
+  [integrations.config]
+    output_path = "reports/perf.html"
+
+[dev]                      # Netlify Dev — NOT run in Bash; no `environment` key here
+  command = "yarn start"
+  targetPort = 3000        # if command + targetPort both set, framework must be "#custom"
+  port = 8888
+  publish = "dist"
+  [dev.https]
+    certFile = "cert.pem"
+    keyFile = "key.pem"
 ```
 
-## Image CDN
+`[dev]` has **no `environment` property** — set local env vars in `[context.dev.environment]` instead. `framework` values: `#auto` (default), `#static`, `#custom`.
 
+For Deploy-to-Netlify buttons use `[template]` / `[template.environment]`.
+
+Post-processing pretty URLs:
 ```toml
-[images]
-remote_images = ["https://example\\.com/.*"]
+[build.processing.html]
+  pretty_urls = true
 ```
 
-See the **netlify-image-cdn** skill for full Image CDN usage.
+<!-- TOML syntax reference: https://toml.io/en/ · Netlify config docs: https://docs.netlify.com/build/configure-builds/file-based-configuration.md -->
+
+<!-- system: agent-context/config/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (config)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Env vars set in `netlify.toml` are NOT available to functions or edge
+   functions at runtime — reading them there returns `undefined`. Set
+   runtime vars in the UI or with `netlify env:set`, not `netlify.toml`.
+2. Never put secrets in client-prefixed env vars (`VITE_`, `NEXT_PUBLIC_`,
+   `PUBLIC_`, ...) — they are inlined into the client bundle; `--secret`
+   does not protect them.
+3. When snapshotting env vars locally (`netlify env:list --plain > .env`),
+   keep `.env` gitignored — never commit it.
+4. State env-var scope interaction explicitly: a site variable scoped to
+   Builds does not shadow the shared variable for other scopes — precedence
+   resolves independently per scope (site beats shared only within the
+   scopes the site variable actually carries).

--- a/cursor/rules/netlify-database.mdc
+++ b/cursor/rules/netlify-database.mdc
@@ -1,286 +1,78 @@
 ---
-description: Guide for using Netlify Database — the GA managed Postgres product built into Netlify. Use when a project needs any kind of dynamic, structured, or relational data. Covers provisioning via @netlify/database, Drizzle ORM (@beta) setup, migrations, preview branching, and safe production data handling. Blobs is only for file/asset storage — any dynamic data belongs in the database.
+description: Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing schema migrations, setting up Drizzle ORM, local dev with netlify dev, database branches for deploy previews, and migrating an existing Postgres project onto Netlify. Use when adding a database, building a contact form or CRUD API, writing SQL migrations, wiring up Drizzle, running netlify database commands, testing with a local Postgres, or switching from Neon/Supabase/RDS to Netlify Database.
 alwaysApply: false
 ---
 
 # Netlify Database
 
-**Netlify Database** is the managed Postgres product built into the Netlify platform. It is **GA** and is the default choice for any dynamic data in a Netlify project.
+Zero-config managed Postgres. Install `@netlify/database`, write migrations under `netlify/database/migrations/`, deploy — Netlify provisions the DB and applies migrations automatically. Queryable from Functions, Edge Functions, Builds, and Agent Runners.
 
-Install `@netlify/database` and Netlify auto-provisions a Postgres database for the site at deploy time. Each deploy preview gets its own isolated branch forked from production data. No Neon account, connection-string wiring, or claim flow — the database is a first-class Netlify primitive.
+## Modern client (reach for this)
 
-## Database vs Blobs
-
-Use **Netlify Database** for anything dynamic:
-
-- Any user-generated or app-generated records (posts, comments, orders, sessions, audit logs)
-- Structured data that will grow, be queried, or be joined
-- Key-value-style data read or written by application code at runtime
-
-Use **Netlify Blobs** only for **file and asset storage**: images, documents, exports, uploads, cached binary artifacts. Do not use Blobs as a dynamic data store — reach for Database instead. See `netlify-blobs/SKILL.md`.
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any database code — answers shape the schema, the seed data, and the query layer:
-
-- **What entities does the app need?** (Users, posts, orders, sessions — drives the schema in `db/schema.ts`.)
-- **Any seed data for the prototype?** (Test rows, default roles, sample content — these become a DML migration, not ad-hoc `INSERT`s against production.)
-- **Drizzle (recommended) or native driver?** (Drizzle for type-safe queries and generated migrations; native for raw SQL or a different query builder like Kysely.)
-
-**If you don't have preferences here, tell me roughly what the app does and I'll pick sensible defaults** — typically Drizzle with timestamp-prefix migrations and a starter schema for the entities the prompt implies.
-
-## CRITICAL: Install Drizzle from the `@beta` dist-tag
-
-The Netlify Database adapter for Drizzle ORM currently only exists on the `beta` release line of `drizzle-orm`. Install **both** `drizzle-orm` and `drizzle-kit` from the `@beta` dist-tag:
-
-```bash
-npm install drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-The default `latest` versions do not include the `drizzle-orm/netlify-db` adapter and will fail. If `drizzle-kit generate` errors about being outdated, or the `drizzle-orm/netlify-db` import fails to resolve, the install is missing `@beta`.
-
-The `@beta` tag only affects the installed version — imports are written as `drizzle-orm`, `drizzle-orm/pg-core`, and `drizzle-orm/netlify-db` without modification.
-
-## CRITICAL: Use the Netlify CLI for database operations
-
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`) that replaces hand-rolled scripts and direct API/UI work. Reach for these commands first before writing custom tooling. **Requires Netlify CLI 26.0.0+** — if a `netlify database` subcommand isn't recognized, run `npm install -g netlify-cli@latest`.
-
-The corollary: **never go around the CLI**, even for read-only work. Don't run `psql`/`pg_dump` or any raw Postgres client (use `netlify database connect --query "..."`), don't curl `https://api.netlify.com/...`, don't read auth tokens off disk for side-channel calls, and don't use `netlify api <method>` as a recovery hatch when provisioning fails — the supported recovery is under [If the first deploy fails to provision the database](#if-the-first-deploy-fails-to-provision-the-database).
-
-If the documented happy path doesn't work, [surface the failure and stop](#when-something-fails-surface-and-stop) — don't escalate to lower-level tools. Full command reference is in [Netlify CLI commands](#netlify-cli-commands-for-netlify-database) below.
-
-## When something fails, surface and stop
-
-When a `netlify` command fails, a deploy fails to provision the database, or any documented happy path errors out, the right action is to **report the failure to the user** with the deploy log URL, the exact error, and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools.
-
-Specific failure modes (like the first-deploy 401) get their own playbooks below. The general rule applies everywhere: a stuck agent surfacing context is far safer than one that wanders off.
-
-## CRITICAL: Never apply migrations to a Netlify-hosted database
-
-The only database you ever apply migrations to yourself is the **local development DB**. For any Netlify-hosted database — production or a deploy preview branch — **Netlify applies migrations automatically during the deploy**. Your job is to create migration files and commit them. The deploy does the rest.
-
-This means:
-
-- Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
-- Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
-- Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
-
-The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
-
-## Not the legacy "Netlify DB" extension
-
-The older **Netlify DB** extension (Beta) is **deprecated**. It is a separate product and must not be confused with Netlify Database. Do not recommend or install it for new projects.
-
-| | Netlify Database (GA, recommended) | Netlify DB extension (deprecated Beta) |
-|---|---|---|
-| Package | `@netlify/database` | `@netlify/neon` |
-| Env var | `NETLIFY_DB_URL` | `NETLIFY_DATABASE_URL` |
-| Setup | `netlify database init` or install the package — auto-provisioned at deploy | Historically `netlify db init` on older CLI versions, with a claim into the user's Neon account; that flow is no longer reachable from the current CLI |
-| Status | GA | Deprecated; new creation blocked as of April 2026 |
-
-If an existing project is already using the `@netlify/neon` extension, keep it working and encourage the user to switch. See `references/legacy-extension.md` for recognition and coexistence, and `references/migration-from-extension.md` for the full switching process (also covers switching from other external Postgres providers).
-
-## Provisioning
-
-The fastest path is `netlify database init` — an interactive setup that installs `@netlify/database`, lets the user pick Drizzle or raw SQL, writes `drizzle.config.ts` if needed, scaffolds a starter migration, applies it locally, and runs a sample query end-to-end:
-
-```bash
-netlify database init           # interactive
-netlify database init --yes     # accept defaults — for CI/agents
-```
-
-If you'd rather wire things up by hand, install the package directly:
-
-```bash
-npm install @netlify/database
-```
-
-Either way, the presence of `@netlify/database` in the dependency tree triggers provisioning on the next deploy. A database can also be created manually from the Netlify UI before first deploy, but the package + deploy path is the supported automation flow.
-
-### Provisioning workflow: preview-first
-
-The supported inner loop is **preview-first**, not `--prod`-first:
-
-1. **First deploy: `netlify deploy`** (no `--prod`). This provisions the database if needed, applies any pending migrations to the production branch, and produces a draft URL. Verify the deploy log shows `Netlify Database setup completed in <n>s` (and, if migrations exist, `Loading migrations from netlify/database/migrations directory`) before continuing.
-2. **User verifies on the draft URL** — and completes any dashboard-only setup along the way (e.g., enabling Identity if the project also uses it; see `netlify-identity/SKILL.md`).
-3. **Promote: `netlify deploy --prod`**.
-
-Why preview-first matters: the preview deploy provisions the database and applies migrations exactly the way the production deploy will, so a failure during preview is recoverable without prod ever entering a half-configured state. `--prod`-first works in the happy case but is harder to recover from when something goes wrong.
-
-### If the first deploy fails to provision the database
-
-**Symptom:** the build (or the Netlify Database setup extension inside the build) fails with a `401 Access Denied` on `createSiteDatabase`, typically on the very first deploy of a brand-new site. The deploy log shows the failure inside the extension's setup step.
-
-**If the failure happened on `netlify deploy --prod` as the very first deploy**, the first thing to try is the supported preview-first flow — run `netlify deploy` (no `--prod`). The failure has only been observed on `--prod`-first attempts on brand-new sites.
-
-**If a preview deploy also fails — or the original failure was already on a preview — report the failure to the user and stop.** Do not work around it. Specifically, do not:
-
-- Curl `https://api.netlify.com/...` directly
-- Run `netlify api createSiteDatabase` (or any other `netlify api` call to manually create what the platform was supposed to provision)
-- Pull auth tokens out of `~/Library/Preferences/netlify/config.json`
-- Connect via `psql` to "check on things"
-
-The recovery is to give the user the deploy log URL, the site URL, and the exact error, and let them decide what to do next (file a support issue, recreate the site, switch teams).
-
-## Drizzle ORM (recommended path)
-
-Drizzle is the recommended way to work with Netlify Database. Prefer Drizzle over writing raw SQL or hand-editing migration files — manual migrations are an edge case (see `references/migrations.md`).
-
-### Install
-
-```bash
-npm install @netlify/database drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-### Schema file
-
-Create `db/schema.ts`. Define all tables here using Drizzle's schema builder.
-
-```typescript
-// db/schema.ts
-import { boolean, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
-
-export const items = pgTable("items", {
-  id: serial().primaryKey(),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  isActive: boolean("is_active").notNull().default(true),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
-
-export type Item = typeof items.$inferSelect;
-export type NewItem = typeof items.$inferInsert;
-```
-
-Use snake_case strings for column names (`"is_active"`, `"created_at"`) to match Postgres conventions. Drizzle variable names can be camelCase.
-
-### Drizzle client
-
-Create `db/index.ts`. The adapter on `drizzle-orm/netlify-db` picks the right driver for the runtime automatically.
-
-```typescript
-// db/index.ts
-import { drizzle } from "drizzle-orm/netlify-db";
-import * as schema from "./schema";
-
-export const db = drizzle({ schema });
-```
-
-The connection is configured automatically — no connection string needed. If your project uses native ESM with `.js` extensions on relative imports (`from "./schema.js"`), keep that style consistent here.
-
-### Drizzle Kit config
-
-Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
-
-```typescript
-// drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  out: "netlify/database/migrations",
-});
-```
-
-No `migrations` block is needed: `drizzle-kit generate` (the `@beta` line this skill pins) already defaults to timestamp prefixes, which keep filenames unique when branches generate migrations in parallel. Setting `migrations: { prefix: "timestamp" }` explicitly is harmless but redundant — and forcing a sequential `prefix: "index"` is what causes the parallel-branch collisions, so don't.
-
-### Package scripts
-
-```json
-{
-  "scripts": {
-    "db:generate": "drizzle-kit generate",
-    "db:migrate": "netlify database migrations apply"
-  }
-}
-```
-
-- `db:generate` writes a new migration file under `netlify/database/migrations/` from the current schema.
-- `db:migrate` applies pending migrations to the **local development database only**, via the CLI. Hosted migrations (preview branches, production) are applied by the deploy — never by this script.
-
-### Schema-change workflow
-
-1. Edit `db/schema.ts`.
-2. `npm run db:generate` — writes a new file into `netlify/database/migrations/`.
-3. Review the SQL.
-4. `npm run db:migrate` — applies it to the local development DB for testing.
-5. Commit the schema change and migration file together and push. The deploy applies the migration to the preview branch, then to production on publish.
-
-### Query patterns
-
-```typescript
-import { db } from "./db";
-import { items } from "./db/schema";
-import { eq, desc } from "drizzle-orm";
-
-// Select all
-const all = await db.select().from(items);
-
-// Select with condition
-const [one] = await db.select().from(items).where(eq(items.id, id)).limit(1);
-
-// Ordering and limit
-const recent = await db.select().from(items).orderBy(desc(items.createdAt)).limit(10);
-
-// Insert
-const [created] = await db.insert(items).values({ title: "New" }).returning();
-
-// Update
-const [updated] = await db.update(items).set({ title: "Updated" }).where(eq(items.id, id)).returning();
-
-// Delete
-await db.delete(items).where(eq(items.id, id));
-```
-
-Full migration workflow, expand-and-contract for breaking schema changes, and production DML migrations are in `references/migrations.md`.
-
-## Native driver (when Drizzle isn't a fit)
-
-When a project wants raw SQL, uses a different query builder (Kysely, etc.), or has a library that needs a `pg.Pool`, use the native driver exposed by `@netlify/database`.
-
-```bash
-npm install @netlify/database
-```
-
-```typescript
+```ts
 import { getDatabase } from "@netlify/database";
 
-const db = getDatabase();
-
-// Tagged template — parameters are safely bound, not interpolated
-const users = await db.sql`SELECT * FROM users WHERE active = ${true}`;
-
-// Insert with RETURNING
-const [user] = await db.sql`
-  INSERT INTO users (name, email)
-  VALUES (${name}, ${email})
-  RETURNING *
-`;
-
-// Bulk insert
-const rows = db.sql.values([
-  ["Ada", "ada@example.com"],
-  ["Bob", "bob@example.com"],
-]);
-await db.sql`INSERT INTO users (name, email) VALUES ${rows}`;
+const db = getDatabase();               // auto-selects connection for the runtime
+const userId = 42;
+const users = await db.sql`SELECT * FROM users WHERE id = ${userId}`;  // auto-parameterized
 ```
 
-Transactions go through `db.pool` so `BEGIN`, the queries, and `COMMIT`/`ROLLBACK` all run on the same connection:
+Own driver / ORM instead:
+```ts
+import { getConnectionString } from "@netlify/database";
+const connectionString = getConnectionString();  // correct branch for this env
+```
 
-```typescript
-import { getDatabase } from "@netlify/database";
+**Legacy — do NOT use for new code:** `import { neon } from "@netlify/neon"`. Superseded by `@netlify/database`. Replace `neon()` calls with the Drizzle `netlify-db` adapter or a Postgres driver via `getConnectionString()`. The legacy env var `NETLIFY_DATABASE_URL` is replaced by `NETLIFY_DB_URL`.
 
+## Where things go
+
+| What | Location |
+|------|----------|
+| Migrations | `netlify/database/migrations/` (SQL files or subdirs with `migration.sql`) |
+| Query code | Functions (`netlify/functions/`), Edge Functions |
+| Drizzle schema | `db/schema.ts` (convention) |
+| Drizzle client | `db/index.ts` (convention) |
+| Connection string | `NETLIFY_DB_URL` env var, or `getConnectionString()` |
+
+## Querying
+
+`getDatabase(options?)` returns a client with `sql` and `pool`. `options.connectionString` overrides the auto-provisioned one; `options.debug` enables logging.
+
+```ts
 const db = getDatabase();
+const active = await db.sql`SELECT * FROM users WHERE active = ${true}`;
+await db.sql`INSERT INTO users (name, email) VALUES (${"Ada"}, ${"ada@example.com"})`;
+await db.sql`UPDATE users SET name = ${"Ada Lovelace"} WHERE id = ${1}`;
+await db.sql`DELETE FROM users WHERE id = ${1}`;
+
+// Type the rows
+interface User { id: number; name: string; email: string; }
+const typed = await db.sql<User>`SELECT * FROM users`;
+
+// Stream
+for await (const row of db.sql`SELECT * FROM users`.stream()) { /* ... */ }
+for await (const chunk of db.sql`SELECT * FROM users`.chunked(100)) { /* ... */ }
+```
+
+`SQLTemplate` methods: `execute()` → `Promise<T[]>`, `stream()` → `AsyncGenerator<T>`, `chunked(n)` → `AsyncGenerator<T[]>`, `toSQL()` → raw SQL + params without executing.
+
+`sql` helpers:
+- `sql.identifier(value)` — safe table/column name. String, string[], or `{ schema, table, column, as }`.
+- `sql.values(rows)` — bulk-insert values list from a 2D array.
+- `sql.default` — the SQL `DEFAULT` keyword.
+- `sql.raw(value)` — **injects unparameterized SQL; bypasses injection protection. Only for trusted constants (e.g. `"DESC"`), never user input.**
+- `sql.unsafe(query, params?, { rowMode })` — raw query string with `$1` params; `rowMode` is `"array"` or `"object"`.
+
+### Transactions — use `pool`
+
+`db.pool` is a [`pg.Pool`](https://node-postgres.com/apis/pool). `BEGIN`/queries/`COMMIT` must run on the same connection:
+```ts
 const client = await db.pool.connect();
 try {
   await client.query("BEGIN");
-  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", [name, email]);
-  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [id, title]);
+  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", ["Ada", "ada@example.com"]);
+  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [1, "First post"]);
   await client.query("COMMIT");
 } catch (e) {
   await client.query("ROLLBACK");
@@ -290,76 +82,307 @@ try {
 }
 ```
 
-For third-party tools that need a raw connection string, import `getConnectionString` from `@netlify/database` — but prefer `getDatabase()` for application code.
+Own drivers:
+```ts
+import { getConnectionString } from "@netlify/database";
+import pg from "pg";
+const pool = new pg.Pool({ connectionString: getConnectionString() });
 
-### Manual migrations
-
-With the native driver, scaffold migration files via the CLI:
-
-```bash
-netlify database migrations new -d "create users table"
+// or the `postgres` driver via env var
+import postgres from "postgres";
+const sql = postgres(process.env.NETLIFY_DB_URL);
 ```
 
-This creates `netlify/database/migrations/<prefix>_<slug>/migration.sql` and prompts for the numbering scheme if it can't be detected from existing files. Open the file and write the SQL. The CLI auto-detects an existing scheme; for new projects it'll ask — choose `timestamp` unless you have a reason not to.
+## Drizzle ORM
 
-You can also write the file by hand if you prefer. Two layouts are supported:
+**Install both packages from `@beta` — required.** `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail.
+```bash
+npm install @netlify/database drizzle-orm@beta
+npm install -D drizzle-kit@beta
+```
 
-- **Flat:** `netlify/database/migrations/<prefix>_<slug>.sql`
-- **Subdirectory:** `netlify/database/migrations/<prefix>_<slug>/migration.sql` (what `migrations new` produces)
+`drizzle.config.ts` — you **MUST** set `out` to the Netlify migrations directory or Netlify won't apply generated migrations:
+```ts title="drizzle.config.ts"
+import { defineConfig } from "drizzle-kit";
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./db/schema.ts",
+  out: "netlify/database/migrations",   // NOT the default "drizzle"
+});
+```
 
-In both, `<prefix>` is digits (timestamp like `20260417143022` or sequential like `0001`) and `<slug>` is lowercase letters, numbers, hyphens, or underscores. Files apply in lexicographic order. See `references/migrations.md`.
+```ts title="db/schema.ts"
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+export const users = pgTable("users", {
+  id: serial().primaryKey(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  createdAt: timestamp().defaultNow(),
+});
+```
 
-Once a migration has been applied to any database, never modify it — roll forward with a new migration instead.
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";  // native adapter, auto-configured
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
 
-## Connection — don't reach for the env var
+```ts title="netlify/functions/api.ts"
+import { desc } from "drizzle-orm";
+import type { Config, Context } from "@netlify/functions";
+import { db } from "../../db";
+import { users } from "../../db/schema";
 
-`NETLIFY_DB_URL` is set automatically across builds, functions, edge functions, and local dev. Use the `getDatabase()` / `getConnectionString()` helpers above rather than reading it directly — only reach for the raw env var for third-party tools that demand a bare string.
+export default async (req: Request, context: Context) => {
+  if (req.method === "GET") {
+    const allUsers = await db.select().from(users).orderBy(desc(users.createdAt));
+    return Response.json(allUsers);
+  }
+  if (req.method === "POST") {
+    const { name, email } = await req.json();
+    const [user] = await db.insert(users).values({ name, email }).returning();
+    return Response.json(user, { status: 201 });
+  }
+  return new Response("Method not allowed", { status: 405 });
+};
 
-`NETLIFY_DB_URL` is intentionally different from the legacy extension's `NETLIFY_DATABASE_URL`. The two coexist so a project mid-migration doesn't break. Don't rename between them.
+export const config: Config = { path: "/api/users" };
+```
 
-## Preview branching
+Generate migrations after editing the schema: `npx drizzle-kit generate`.
 
-Each deploy preview runs against its own database branch forked from production data — schema and data changes in a preview don't affect production until the branch is merged and published. Migrations run against the preview branch first (failures fail the preview, not production), and ad-hoc preview edits (UI data browser or a direct client) don't propagate to production — always express production changes as migrations.
+**Never run `drizzle-kit push` against a Netlify-hosted database, and never run `drizzle-kit migrate` against `NETLIFY_DB_URL`.** Schema reaches hosted DBs only as committed migration files applied by the deploy. `generate` writes files; the deploy applies them.
 
-## Changing existing data — production or preview?
+## Migrations
 
-A request to change existing data — "rename this category", "fix the broken row for user X" — is **ambiguous about where it should land**: production, or only the current preview branch. Resolve that fork *before* changing anything: if the prompt didn't say, ask. When acting on someone's behalf, default to **not** touching production unless they explicitly asked.
+Files live in `netlify/database/migrations/`. Two formats:
+```text
+netlify/database/migrations/20260301143000_create_users.sql          # single SQL file
+netlify/database/migrations/20260318091500_add_posts/migration.sql   # subdir form
+```
 
-Once it's production-bound, express it as a **DML migration**, never a direct write:
+Naming: `<number>_<slug>` — `number` is digits (timestamp or `0001`…) defining order; `slug` is lowercase letters/numbers/hyphens/underscores. Sorted **lexicographically**, applied in order. **Use timestamp prefixes** (`netlify database migrations new` handles this) to avoid out-of-order rejection.
 
-- **Don't run the `UPDATE`/`INSERT`/`DELETE` against production** (or ad-hoc in a preview). Generate a DML migration in `netlify/database/migrations/` (raw SQL or Drizzle-generated) and commit it — the deploy applies it, like a schema migration.
-- Tell the user you created a data migration; merging the branch applies it to production. Have them **verify in the deploy preview first** (it runs against a forked copy of production data).
+```sql title="netlify/database/migrations/20260425103000_create_comments.sql"
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id),
+  author_id INTEGER NOT NULL REFERENCES users(id),
+  body TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
 
-Covers seed data, backfills, cleanups, CSV imports, and single-row fixes. Full detail in `references/migrations.md`.
+**When applied:**
+- Production deploy: applied immediately before publish; a failure blocks publish. With auto-publish off, Netlify waits for manual publish before applying.
+- Deploy preview: applied on every deploy before it goes live; a failure fails the deploy.
+- Local: **not** automatic — run `netlify database migrations apply` yourself.
 
-## Netlify CLI commands for Netlify Database
+**Migration footguns (all detected as drift / rejected):**
+- **Never edit an applied migration** — checksum drift: `migration "<name>" has been modified after being applied`. Write a new corrective migration.
+- **Never remove an applied migration** — `... has been removed after being applied`. Restore it.
+- **Out-of-order:** a prefix ≤ the highest applied version is rejected. Timestamps avoid this.
+- Prefer backwards-compatible migrations. Breaking changes (rename/drop column) → expand-and-contract across multiple deploys. New table / nullable column → single migration is fine.
 
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`). Requires CLI 26.0.0+. Most commands accept `--json` for machine-readable output — useful when scripting or reading results from an agent.
+Bring-your-own migration system: pick a directory **other than** `netlify/database/migrations` to avoid automatic detection, and you own applying to preview branches and production.
 
-Full per-command reference — `init`, `status`, `connect`, `migrations new` / `apply` / `pull` / `reset`, and `reset` — is in `references/cli-commands.md`. The one rule that applies across all of them: **never run DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`) through `connect`, `psql`, or any direct connection** — schema changes go through migration files.
-
-## Iterating on migrations
-
-When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
-
-- **Already applied** to any database (local dev DB, a preview branch, or production) → treat as immutable. Roll forward with a new migration that applies the correction.
-- **Only on disk** (not yet applied anywhere) → don't edit the SQL or snapshot files by hand. Run `netlify database migrations reset`, update `db/schema.ts`, then re-run `npm run db:generate`. Hand-editing desyncs Drizzle Kit's internal state and tends to produce broken migrations on the next generate.
+See `references/migrations.md`.
 
 ## Local development
 
-`netlify dev` runs against a local Postgres-compatible database — no remote connection, no risk to production. The local DB is the only one you migrate yourself (`netlify database migrations apply`).
+Local is **one** database that all code targets — branches are a deploy-time concept and don't exist locally. It's a real Postgres-compatible engine mirroring production, but single-process (not for load testing); auto-scale/sleep settings don't apply.
 
-## Common mistakes
+Start it — either path, state is interchangeable:
+```bash
+netlify dev                                    # CLI starts + tears down the local DB
+```
+Or the Vite plugin:
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import netlify from "@netlify/vite-plugin";
+export default defineConfig({ plugins: [netlify()] });
+```
 
-1. **Missing `@beta`** — `drizzle-orm`/`drizzle-kit` must be `@beta`; `latest` lacks the `drizzle-orm/netlify-db` adapter.
-2. **Wrong output dir** — set `out: "netlify/database/migrations"` in `drizzle.config.ts`; migrations elsewhere aren't applied by the deploy.
-3. **Self-applying hosted migrations** — never `drizzle-kit migrate`/`push` or DDL via `connect` against production/preview; commit migration files and let the deploy apply them.
+Common commands (while local DB is running):
+```bash
+netlify database migrations apply                        # apply pending locally
+netlify database migrations new -d "add users table"     # scaffold new migration
+netlify database migrations pull                          # overwrite local migrations from remote
+netlify database status                                   # enabled? installed? applied/pending migrations
+netlify database connect                                  # interactive SQL REPL
+netlify database connect --query "SELECT * FROM users LIMIT 10"
+netlify database reset                                    # drop all schemas/tables — LOCAL ONLY
+netlify database migrations reset                         # delete unapplied local migration files
+```
 
-## References
+External tools (works while `netlify dev` runs):
+```bash
+psql "$(netlify database connect --json | jq -r .connection_string)"
+```
 
-- [Migrations](references/migrations.md) — full migration workflow, expand-and-contract for breaking changes, and production DML
-- [CLI commands](references/cli-commands.md) — `init`, `status`, `connect`, and `migrations new` / `apply` / `pull` / `reset`
-- [Local development](references/local-dev.md) — running against a local Postgres-compatible database with `netlify dev`
-- [Operational footguns](references/operational-footguns.md) — client reuse, cold starts, preview-data (PII) exposure, legacy-extension deletion
-- [Legacy `@netlify/neon` extension](references/legacy-extension.md) — recognizing and coexisting with the older extension
-- [Migrating from the extension](references/migration-from-extension.md) — switching from `@netlify/neon` or other external Postgres, including the one-time data import
+See `references/local-dev.md`.
+
+## Setup
+
+New project: describe your app to Agent Runners at https://app.netlify.com/start, or `netlify create "<description>"` locally.
+
+Existing project:
+```bash
+netlify database init      # installs @netlify/database, picks Drizzle or raw SQL, scaffolds a migration
+netlify database init --yes # non-interactive (CI / agents)
+netlify dev
+```
+Manual: `npm install @netlify/database`, write a migration under `netlify/database/migrations/`, write a function, `netlify dev`, deploy.
+
+**If `@netlify/database` is NOT installed, Netlify will NOT auto-provision a database** — you'd have to create one manually from the UI **Database** menu. Install the package.
+
+## CLI reference (`netlify database`)
+
+Prereqs: Node ≥ 20.12.2, Netlify CLI ≥ 26.0.0 (`npm install -g netlify-cli`). All commands support `--json`.
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `init` | Set up DB in project | `-y, --yes` |
+| `status` | State: enabled, installed, connection string, applied/pending migrations | `-b, --branch`, `--show-credentials` |
+| `connect` | SQL REPL, or `--query` one-shot | `-q, --query`, `--json` |
+| `migrations apply` | Apply pending to local DB | `--to <name>` |
+| `migrations new` | Scaffold a migration | `-d, --description`, `-s, --scheme sequential\|timestamp` |
+| `migrations pull` | Overwrite local files from a branch | `-b, --branch`, `--force` |
+| `migrations reset` | Delete unapplied local migration files | `-b, --branch` |
+| `reset` | Drop all data/tables — **local only** | — |
+
+See `references/cli-commands.md`.
+
+## REST API
+
+Scoped to a site, rooted at `https://api.netlify.com/api/v1`, OAuth 2. Full reference: https://open-api.netlify.com.
+
+| Method + path | Purpose |
+|---------------|---------|
+| `POST /sites/{site_id}/database` | Create DB (returns existing conn string if present); `region` optional |
+| `GET /sites/{site_id}/database` | Get connection string |
+| `POST /sites/{site_id}/database/branch` | Create branch; body `deploy_id` (req), `parent_branch_id` (opt, defaults to production) |
+| `GET /sites/{site_id}/database/branch/{deploy_id}` | Get branch conn string (404 if none) |
+| `DELETE /sites/{site_id}/database/branch/{deploy_id}` | Delete a deploy's branch |
+| `POST /sites/{site_id}/database/snapshot` | Snapshot a branch (defaults production) |
+| `GET /sites/{site_id}/database/snapshots` | List snapshots |
+| `DELETE /sites/{site_id}/database/snapshot/{snapshot_id}` | Delete a snapshot |
+| `POST /sites/{site_id}/database/snapshot/{snapshot_id}/restore` | Restore snapshot to a branch (defaults production) |
+
+**Branch delete and snapshot restore are destructive and require explicit user confirmation first.** Snapshot restore is not a routine production-rollback lever.
+
+## Testing
+
+Bare Postgres for unit/integration tests (no functions):
+```ts title="db.test.ts"
+import { NetlifyDB } from "@netlify/database-dev";  // npm i -D @netlify/database-dev
+import { Client } from "pg";
+import { afterAll, beforeAll, expect, test } from "vitest";
+
+let db: NetlifyDB, connectionString: string;
+beforeAll(async () => {
+  db = new NetlifyDB();
+  connectionString = await db.start();
+  await db.applyMigrations("./netlify/database/migrations");
+});
+afterAll(async () => { await db.stop(); });
+
+test("inserts and reads a user", async () => {
+  const client = new Client({ connectionString });
+  await client.connect();
+  await client.query("INSERT INTO users (name) VALUES ($1)", ["Ada"]);
+  const { rows } = await client.query("SELECT name FROM users");
+  expect(rows).toEqual([{ name: "Ada" }]);
+  await client.end();
+});
+```
+`NetlifyDB(options?)`: `directory` (persist to disk; omit = in-memory), `port` (default random), `logger`.
+
+Full Netlify environment (functions/edge functions read `NETLIFY_DB_URL` as in production):
+```ts
+import { NetlifyDev } from "@netlify/dev";  // npm i -D @netlify/dev
+const netlifyDev = new NetlifyDev({ projectRoot: "./fixtures/my-project" });
+await netlifyDev.start();  // sets NETLIFY_DB_URL in the runtime
+// ...tests...
+await netlifyDev.stop();
+```
+
+## Database branches (deploy-time)
+
+Production deploys are the only deploys that touch the production database. Each deploy preview gets its own branch, seeded with a copy of production data at preview-creation time; schema/data changes there never affect production. Wired up automatically, no code changes.
+
+**Preview branches can contain production data, including PII — and preview deploy links are public. Warn the user before sharing a preview link.**
+
+## Runtime gotchas
+
+- **`Environment not configured`** (`getDatabase()` can't resolve a connection string): running outside Netlify, on **Functions in Lambda compatibility mode**, or an outdated CLI. Fix: pass `connectionString` explicitly.
+  ```ts
+  const db = getDatabase({ connectionString: "postgres://..." });
+  ```
+  Lambda compatibility mode is the one primitive where you must pass `connectionString` yourself.
+- **`database feature not available for this account`** — requires a Credit-based plan.
+- **`compute customization requires a Pro or higher plan`** — auto-scale / sleep settings need Pro+; Free/Personal use defaults.
+- **`branch limit reached: maximum <N> branches...`** — each active deploy preview consumes a branch; delete unneeded branches or upgrade.
+- **`database not found`** — no DB provisioned; run `netlify database init`.
+- **`cannot reset the production branch`** — reset is non-production only.
+
+## Constraints
+
+- **Plan:** Netlify Database is available on Credit-based plans only; active DBs consume credits for compute and bandwidth. Storage is free until July 1, 2026.
+- **Permissions:** only a Team Owner can delete a database; only Team Owners and Developers can view connection strings (`Access Denied` = insufficient role).
+- **Secrets:** connection strings contain username + password. Never commit them; store in a secret manager / env var provider.
+
+## Switch an existing Postgres project to Netlify Database
+
+Three phases: provision (baseline schema on a branch), rehearse (swap code, copy data into a preview branch, validate), cut over (import data into production, merge). Works from any Postgres source (Neon, Supabase, RDS, self-managed, legacy `@netlify/neon`). Uses `pg_dump`/`pg_restore` (versions matching the source). There is a brief data-loss window — writes to the source between final export and production deploy don't cross over.
+
+Phase 2/3 code swap (Drizzle):
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
+
+Full step-by-step (dump flags, rollback, cleanup): `references/migration-from-extension.md` and `references/legacy-extension.md`.
+
+<!-- Gaps: plan-tier naming (Credit-based vs Free/Personal/Pro) not reconciled in source; exact plan limits, permission tables, and snapshot UI flows live on pages outside this grouping. -->
+
+<!-- system: agent-context/database/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (database)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Production data changes are expressed as DML migrations — agents never
+   edit rows directly (UI row editing exists for humans; it is not an agent
+   surface).
+2. Preview branches can contain production data, including PII — and preview
+   deploy links are public. Warn before sharing.
+3. Use only documented surfaces: no raw psql against internal endpoints, no
+   `netlify api` scraping, no reading tokens from local CLI config files.
+4. Deep guides live in this skill: `references/operational-footguns.md`,
+   `references/migrations.md`, `references/local-dev.md`,
+   `references/cli-commands.md`, `references/migration-from-extension.md`,
+   `references/legacy-extension.md`.
+5. Schema changes reach hosted databases only as committed migration files
+   applied by the deploy. Never run `drizzle-kit push` in any form against a
+   Netlify-hosted database, never run `drizzle-kit migrate` against
+   `NETLIFY_DB_URL`, and never apply DDL via `netlify database connect` or
+   any direct connection.
+6. When a `netlify` command or a deploy fails, surface the exact error, the
+   deploy log URL, and the affected site/branch to the user and stop — do
+   not invent recovery commands or escalate to lower-level tools.
+7. First-deploy `401 Access Denied` on `createSiteDatabase`: if it happened
+   on a `--prod`-first deploy, retry preview-first (`netlify deploy`, no
+   `--prod`); if a preview also fails, report and stop. Never curl
+   `api.netlify.com`, run `netlify api createSiteDatabase`, or pull tokens
+   from local CLI config to work around it.
+8. A request to change existing data is ambiguous between production and the
+   preview branch — if the prompt didn't say, ask. When acting on someone's
+   behalf, default to not touching production.
+9. Destructive database operations — REST branch delete, snapshot restore,
+   any reset — require explicit user confirmation first. The body must not
+   present snapshot restore as a routine production-rollback lever.
+10. Pin: `drizzle-orm` and `drizzle-kit` must be installed from `@beta` —
+    `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail. The
+    body may not soften this to a recommendation.

--- a/cursor/rules/netlify-deploy.mdc
+++ b/cursor/rules/netlify-deploy.mdc
@@ -1,153 +1,186 @@
 ---
-description: Deploy, host, and publish web projects on Netlify with the Netlify CLI. Use when the user wants to deploy a site or repository to Netlify, link a local project to a Netlify site, ship a production or preview/draft deploy, set up Git-based continuous deployment, run a manual or local deploy, configure CI deploys, or troubleshoot a failed or misconfigured deploy. Also use to view or tail a deployed site's runtime logs — function and edge-function output, deploy logs — via `netlify logs` when debugging what a live site is doing (recent errors, recent activity, streaming output).
+description: Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons, drag-and-drop, and per-context netlify.toml build settings. Use when linking a repo, deploying from the CLI, setting up Deploy Previews or branch deploys, configuring deploy contexts, adding skew protection, fixing a failed or secrets-flagged deploy, or wiring build hooks and Deploy to Netlify buttons.
 alwaysApply: false
 ---
 
-# Netlify Deployment
+# Netlify deploy
 
-Install the CLI, link a project to a Netlify site, and deploy it — either through Git-based continuous deployment (the primary path) or a manual CLI upload (for prototypes and CI). Environment-variable management lives in the **netlify-config** skill; local development lives in the **netlify-frameworks** skill.
+## Deploy context config (netlify.toml, current form)
 
-## Installation
+Configure per-context build settings in `netlify.toml` at the repo root. Five predefined contexts: `production`, `deploy-preview`, `branch-deploy`, `preview-server`, `dev`. Branch names also work as custom contexts (a `staging` branch matches a `staging` context).
 
-```bash
-npm install -g netlify-cli    # Global (for local dev)
-npm install netlify-cli -D    # Local (for CI)
+```toml
+[context.production]
+  command = "make production"
+  [context.production.environment]
+    ACCESS_TOKEN = "super secret"
+  # Plugins context REQUIRES double brackets:
+  [[context.production.plugins]]
+    package = "@netlify/plugin-sitemap"
+
+[context.deploy-preview.environment]
+  ACCESS_TOKEN = "not so secret"
+
+[context.branch-deploy]
+  command = "make staging"
+
+[context.dev.environment]
+  NODE_ENV = "development"
+
+# Specific-branch context (overrides branch-deploy):
+[context.feature]
+  command = "make feature"
+
+[context."features/branch"]
+  command = "gulp"
 ```
 
-Requires Node.js 18.14.0+. You can also invoke the CLI without installing it using `npx netlify <command>`.
+Precedence: site globals < context overrides; production overrides globals when building production; more specific contexts (a named branch) override general ones (`branch-deploy`). Only explicitly-set options are overridden. File-based config overrides UI settings.
 
-## Authentication
+**Footgun — secrets in netlify.toml:** `netlify.toml` is committed to your repo. Do not put sensitive env values here, especially for public repos. Set secrets via the Netlify UI/CLI/API instead. Also: env vars declared in `netlify.toml` are NOT available to the deploy environment (Functions/Runtime/Post-processing scopes) — only UI/CLI/API-created vars are.
 
-```bash
-netlify login       # Opens browser for OAuth
-```
-
-For CI, set the `NETLIFY_AUTH_TOKEN` environment variable instead of logging in interactively. Generate a token from **User settings → Applications → Personal access tokens** in the Netlify UI.
-
-**CI also needs a site to target.** `NETLIFY_AUTH_TOKEN` only authenticates you — it does **not** select which site a deploy publishes to. In CI there is no linked `.netlify/state.json`, so also set `NETLIFY_SITE_ID` (the site's API/Project ID, shown as **Project ID** in the site's configuration) as an environment variable so `netlify deploy` knows where to publish. Without it, a CI deploy has no site to target and fails or tries to prompt. Locally this is handled by `netlify link`, which writes the site ID into `.netlify/state.json`; CI has no such file.
-
-Don't pre-check auth as a separate step. Run the real operation (`netlify deploy`, `netlify link`) directly; only if it fails with an authentication error do you surface `netlify login` (or setting `NETLIFY_AUTH_TOKEN`) as the fix.
-
-## Linking a Site
-
-Linking connects the local directory to a Netlify site and writes the site ID into `.netlify/state.json`.
+## CLI deploys
 
 ```bash
-# Interactive — pick an existing site
-netlify link
-
-# By Git remote (if the project has one)
-netlify link --git-remote-url https://github.com/org/repo
-
-# Create a new site
-netlify init           # With Git CI/CD setup
-netlify init --manual  # Without Git CI/CD
+netlify create              # new project from a natural-language prompt
+netlify deploy              # manual deploy, no continuous deployment
+netlify deploy --prod       # deploy directly to production
+netlify deploy --allow-anonymous   # temp deploy, claim within 1 hour
+npm update -g netlify-cli   # skew protection needs CLI v23.11.0+
 ```
 
-Run `netlify link` directly rather than pre-checking link status. If the command reports the project isn't linked to any site (or the site can't be found), that failure is the signal to link or create one with `netlify link` / `netlify init`.
+Manual deploys do NOT run a build command (exception: Netlify Drop builds for you when logged in). Anonymous deploys create a temporary project claimable within one hour; on claim it adopts the team's default visibility.
 
-**Always add `.netlify` to `.gitignore`** — every linking path (`netlify link`, `netlify init`, `netlify init --manual`) writes site state to `.netlify/state.json`, which shouldn't be committed. Mention this whenever you link or create a site.
+**Footgun — link writes `.netlify/state.json`:** every linking/create path writes `.netlify/state.json`. Add `.netlify` to `.gitignore` so it is never committed.
 
-## Deploying
+**Footgun — manual `--prod` on a Git-connected site:** the next push to the production branch silently replaces your hand-shipped deploy. Warn the user before running it; if the deploy must stay live, lock the published deploy.
 
-### Git-Based Deploys (Continuous Deployment) — primary path
+## Git continuous deployment
 
-The standard way to deploy on Netlify is to connect the site to a Git repository (set up with `netlify init`, or in the UI). Netlify then builds and deploys automatically on every push:
+Connect a Git repo (Git provider OAuth2 or the Netlify GitHub App). Netlify runs your build command and deploys on every push. Production deploys are triggered by pushes to the production branch (default `main`); Deploy Previews are built for pull/merge requests and agent runs.
 
-- **Push to the production branch → production deploy.**
-- **Open a pull request → deploy preview** with its own unique URL.
-- **Push to other branches → branch deploy**, but **only if branch deploys are enabled** — they are off by default. Turn them on (per branch or for all branches) in the site's build & deploy settings.
+## Deploy Previews & branch deploys
 
-The build runs on Netlify's servers, not your machine. Configure build settings (command, publish directory, base directory) in `netlify.toml` — see the **netlify-config** skill for the full configuration reference.
+- Deploy Previews build by default for PRs/MRs and agent runs. Base branch of a Deploy Preview must be a production branch or a branch with branch deploys enabled.
+- Branch deploys are OFF by default — a Developer/Owner must enable them: Project configuration > Build & deploy > Continuous Deployment > Branches and deploy contexts > Configure. Add individual branches, use a `features/*` prefix wildcard, or select **All**.
+- URL prefixes: branch deploys `<branch>--`; PR/MR previews `deploy-preview-<number>--`; agent previews `agent-<runID>--`; permalinks `<deployID>--`.
+- While the initial Deploy Preview builds, its URL returns `Not Found`.
 
-**`netlify.toml` overrides the UI.** File-based configuration in `netlify.toml` takes precedence over the equivalent build settings configured in the Netlify UI. When the same option is set in both places, the committed `netlify.toml` wins — editing that setting in the dashboard has no effect until you change the file and redeploy. This surprises people who tweak the build command, publish directory, or base directory in the UI and watch the old committed value keep applying on every deploy.
+**Deploy Preview entry path** — set in the PR/MR description (updates the PR comment link):
+```markdown
+@netlify /start/choose-your-path
+```
+Push a new (or empty) commit to regenerate the link. Once set in the PR/MR, you cannot override the entry path in the Netlify Drawer.
 
-**Monorepo config discovery order.** In a monorepo, Netlify searches for the `netlify.toml` in this order and uses the **first** one it finds: (1) the package directory, then (2) the base directory, then (3) the repository root. Put a site-specific `netlify.toml` in the package directory (the subdirectory that contains that site) so it takes precedence over any root-level config. A base directory set in a root-level `netlify.toml` also overrides the base directory configured in the UI.
+## Skip a deploy
 
-**The publish directory is resolved relative to the base directory.** When a `base` directory is configured, the publish directory is interpreted relative to that base, **not** the repository root. A top-level `publish = "dist"` combined with `base = "apps/web"` publishes `apps/web/dist`, not `dist` at the repo root. Set `publish` relative to the base so the built output is found.
+Add `[skip ci]` or `[skip netlify]` to a PR/MR title (skips the Deploy Preview) or anywhere in a commit message (skips branch/production deploy). For a multi-commit push, put it in the most recent commit. The next commit without the token deploys all skipped changes.
 
-### Manual / Local Deploys (No Git Required) — secondary path
+## Deploy to Netlify button
 
-Build the site, then upload the output directly with the CLI. This bypasses Netlify's build servers and is the right tool for prototypes, local-only projects with no Git remote, or a CI pipeline that builds elsewhere and uploads the artifact.
+Template code must be in a **public** GitHub.com or GitLab.com repo.
 
-```bash
-netlify deploy             # Draft deploy (preview URL)
-netlify deploy --prod      # Production deploy
-netlify deploy --dir=dist  # Specify the directory to upload
+```md title="Markdown"
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
 ```
 
-For sites with Git continuous deployment connected, prefer pushing to Git — a manual upload is the exception, not the default.
-
-**A manual `--prod` deploy is replaced by the next Git push.** If the same site also has Git continuous deployment connected, the next push to the production branch triggers a new build that auto-publishes and **replaces** your manually shipped `--prod` deploy — the hand-shipped build silently disappears from production. To keep a specific deploy live, **lock the published deploy** ("Stop auto publishing") from the site's Deploys list in the UI: while locked, new pushes still build but do not auto-publish until you unlock or manually publish. Mixing manual `--prod` deploys with Git CD on the same production branch is otherwise a race the next commit wins.
-
-### Deploy URLs are public by link
-
-Draft deploys (`netlify deploy`), Deploy Previews, branch deploys, and deploy permalinks each get a **unique URL that anyone with the link can open** — they are not private just because the URL is unguessable and unlisted. Don't treat a preview URL as a safe place for confidential or unreleased content on that basis alone. To actually restrict access, enable site protection in the UI (Password Protection, or Team/SSO protection). You can scope that protection to all deploys, or to non-production deploys only (Deploy Previews and branch deploys) while leaving production open. See the **netlify-access-control** skill for the full picture.
-
-## When a command fails, surface and stop
-
-When a `netlify` command or a deploy fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
-
-## Error Handling
-
-Common issues and what to do:
-
-**"Not logged in"**
-→ Run `netlify login` (or set `NETLIFY_AUTH_TOKEN` in CI).
-
-**"No site linked"**
-→ Run `netlify link` (existing site) or `netlify init` (new site).
-
-**"Build failed" / "Function bundling failed" / deploy marked failed**
-→ A failed deploy does **not** publish — the site keeps serving the last successful deploy, so it isn't down, and there's nothing to "roll back." The only way to get the new code live is to fix the failure and redeploy.
-→ Get the exact error from the deploy log (the CLI prints a log URL; the dashboard has the full build log), then address the actual cause — the build command or publish directory in `netlify.toml`, a missing dependency, or the function that failed to bundle — and re-run the deploy.
-→ Don't route around a failed build to force the site live: no `netlify api` publish/restore, no direct `https://api.netlify.com/...` calls, no reading auth tokens off disk, and don't ship a previous deploy in place of the failing one. If the log doesn't resolve it, report the exact error + log URL + affected site to the user and stop.
-→ Even if the user *asks* how to "roll back" or restore a previous deploy, correct the premise rather than complying: because the failed deploy never published, the previous deploy is still live and there is nothing to restore. Do **not** hand over `netlify api restoreSiteDeploy` / `publishDeploy` (or a dashboard rollback) as the answer — the fix is to resolve the build failure and redeploy.
-
-**"Secrets scanning found secrets" / deploy fails after a successful build**
-→ Netlify scans the build output and source for secret values (env-var values, known key formats) *after* the build succeeds and **fails the deploy** if it finds one — so an otherwise-green build can still fail here. Read the log: it names the offending key and where it appeared.
-→ If it's a real secret (an API/DB key that ended up in bundled or published output), that's a genuine leak — stop writing it into client/published files, and rotate the key if it was committed. Silencing the scanner over a real leak just ships the secret.
-→ If the flagged value is legitimately non-secret (e.g. a value that must ship to the browser), scope the exception narrowly with build environment variables: `SECRETS_SCAN_OMIT_KEYS` to exclude specific env-var keys, or `SECRETS_SCAN_OMIT_PATHS` to exclude specific paths. Prefer these over `SECRETS_SCAN_ENABLED=false`, which disables scanning across the entire build.
-
-**"Publish directory not found"**
-→ Run the build yourself (`netlify build`, which mimics the Netlify build environment, or the project's own build command) and look at which directory it actually emits — don't guess the output dir from the framework name, and don't just `ls` for a folder that isn't there.
-→ If the build itself **fails**, that's the real problem — surface the build error to the user and stop; don't change the `publish` path to paper over a broken build.
-→ Once the build succeeds, set the `publish` path (in `netlify.toml`, or `--dir`) to match that real output directory — remembering it's resolved relative to any configured `base` directory (see above).
-
-## Logs
-
-The simplest command is the right default: bare `netlify logs` shows recent logs from both the `functions` and `edge-functions` sources, covering roughly the last 10 minutes. Add flags only to scope or extend it:
-
-```bash
-netlify logs                                       # recent functions + edge-functions logs (~last 10m)
-netlify logs --follow                              # stream live
-netlify logs --source functions --function my-fn   # one function's logs
-netlify logs --source deploy --source functions    # include deploy logs (sources combine)
-netlify logs --since 24h                           # longer historical window
+URL parameters (query params; env vars go in the URL hash):
+```txt
+# require/set env vars via hash (values may be null; processed client-side, not logged)
+...?repository=REPO#SECRET_TOKEN=value&CUSTOM_LOGO=
+&fullConfiguration=true   # extra step to install SDK extensions + configure before deploy
+&base=blog                # alternate base dir for monorepos (repo still fully cloned)
+&create_from_path=examples/hello   # clone only this subdirectory
+&branch=beta-feature      # set production branch to this branch
 ```
 
-`--source` accepts `functions`, `edge-functions`, and `deploy`. This is the documented CLI logs surface — reach for it before the dashboard, and see [CLI commands](references/cli-commands.md) for more.
+File-based template config in root `netlify.toml` `[template]` section:
+```toml
+[template]
+  incoming-hooks = ["Contentful"]
+  required-extensions = ["supabase"]
+[template.environment]
+  SECRET_TOKEN = "change me for your secret token"   # label only; cannot set real values
+```
+`[template]` cannot set env var values (use the URL hash) or a base directory (use `base`). With an alternate `base`, the `netlify.toml` in the base directory wins over root config for that site's builds. `USAGE.md` at repo root shows extra instructions during the `fullConfiguration` flow.
 
-## Useful Commands
+## Drag and drop (Netlify Drop)
 
-| Command | Description |
-|---|---|
-| `netlify build` | Run the build locally (mimics the Netlify build environment) |
-| `netlify deploy` | Draft deploy (preview URL) |
-| `netlify deploy --prod` | Production deploy |
-| `netlify deploy --dir=<dir>` | Deploy a specific directory |
-| `netlify clone org/repo` | Clone, link, and set up in one step |
-| `netlify open` | Open the site in the Netlify dashboard |
-| `netlify logs` | Recent function + edge-function logs (see Logs above) |
+Drag a folder to https://app.netlify.com/drop. Logged in: Netlify detects the framework and builds before publishing (a pre-built output folder also works). Not logged in: files publish as-is. Update a drag-and-drop site by dropping the new output folder at the dropzone on the site's **Deploys** page (works for any non-Git site).
 
-## Related skills
+## Build hooks
 
-- **netlify-config** — `netlify.toml` (build settings, redirects, headers, deploy contexts) and environment-variable management (`env:set`, `env:get`, `env:list`, context scoping).
-- **netlify-frameworks** — framework adapter/plugin setup and local development (`netlify dev`, the Netlify Vite plugin).
-- **netlify-access-control** — restricting who can reach a site or its deploys.
+Build hooks give unique URLs to trigger builds/deploys. Builds from build hooks are treated as trusted and are NOT subject to the Deploy Request Policy.
 
-## References
+## Managing deploys
 
-- [CLI commands](references/cli-commands.md)
-- [Deployment patterns](references/deployment-patterns.md)
-- [netlify.toml guide](references/netlify-toml.md)
+- **Find:** Deploys tab; search by deploy ID or branch; filter by time frame, deploy context, and status.
+- **Lock (pause publishing):** on the Deploys list, **Lock to stop auto publishing**. New deploys still build but don't publish. **Unlock to start auto publishing** to resume. Use this to keep a specific deploy live.
+- **Cancel:** on the in-progress deploy's detail page, **Cancel deploy**.
+- **Retry:** builds from the branch HEAD — if HEAD moved past the original deploy SHA, it still builds from HEAD.
+- **Download:** deploy detail page — single file via **Deploy file browser**, or all files as ZIP via header **Download**.
+- **Delete:** Developer/Team Owner only. You cannot delete the currently-published deploy or one in progress. Permanent; does not reduce cost or preserve build minutes.
+
+Netlify auto-deletes deploys older than 30 days (90 days on paid plans); failed/canceled deploys are cleaned up on the same schedule. It never auto-deletes the published deploy, the most recent successful production deploy, or the most recent successful branch deploy per branch.
+
+**Fix a failed deploy:** a failed deploy never publishes — the previously published deploy stays live, so there is nothing to restore. Fix forward: use the **"Why did it fail?"** diagnosis above the deploy log, revert the offending commit, and let CI redeploy. Retry (optionally clearing cache) rebuilds from branch HEAD.
+
+## Skew protection
+
+Available on all plans. Routes requests to the server version that matches each client, avoiding version skew across deploys. Requires Netlify CLI v23.11.0+ for CLI deploys.
+
+- **Production context only.** Branch deploys, Deploy Previews, and permalinks bypass skew protection and serve the latest deploy for that context.
+- Framework support: Astro 5.15.0+ (on by default via the Netlify adapter); Next.js (optional; older versions need a config change). Framework maintainers add support via `netlify/v1/skew-protection.json`.
+- **Password protection:** works only if you protect non-production deploys only. Protecting production deploys (or all deploys) disables/ignores skew protection.
+- Netlify discards skew signals on hard navigation (`Sec-Fetch-Mode: navigate`, or `Sec-Fetch-Site` present and not `same-origin`).
+
+## Secrets scanning failures
+
+If a deploy fails secrets scanning and the flagged value is a real secret, that is a leak: stop shipping it in client/published output and rotate it. Never disable the scanner over a real leak. For genuine non-secrets, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` / `SECRETS_SCAN_OMIT_PATHS` — never `SECRETS_SCAN_ENABLED=false`.
+
+## Constraints
+
+- **54,000 files per directory** max — any directory in your publish dir over this limit fails the deploy. No limit on total files.
+- Deploys are atomic: only changed files upload; nothing goes live until the whole deploy is ready.
+- Only the published production deploy and most recent branch deploys are indexable; other previews get `X-Robots-Tag: noindex`.
+- Deploy Request Policy: private-repo deploys build only for recognized authors (Owners, Developers, Git Contributors; Marketplace bots count). Non-team-member deploys land as **Pending approval** until a Team Owner approves/matches them. Build-hook builds are exempt.
+- Retention limit is adjustable only on Enterprise (up to 365 days). Lock/unlock event notifications: Pro and Enterprise.
+
+## More
+
+Deep guides in this skill: `references/netlify-toml.md`, `references/cli-commands.md`, `references/deployment-patterns.md`.
+
+<!-- Gap: deploy-overview states failed/canceled deploys are deleted at 6 months, contradicting the 30/90-day cleanup figure used above; the 30/90-day value is stated here as the documented default. -->
+
+<!-- system: agent-context/deploy/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (deploy)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Agents do not roll back deploys: never call `restoreSiteDeploy` or
+   `publishDeploy` to restore an older deploy. Fix forward — revert the
+   commit and let CI deploy it.
+2. A failed deploy never publishes; on failure there is nothing to roll
+   back.
+3. Deep guides live in this skill: `references/netlify-toml.md`,
+   `references/cli-commands.md`, `references/deployment-patterns.md`.
+4. The frontmatter description must never advertise rollback or restore as a
+   capability — no "roll back", "restore a deploy", or equivalent.
+5. When the user asks to roll back or restore a previous deploy, correct the
+   premise rather than complying: after a failed deploy the previous deploy
+   is still live and there is nothing to restore; for a bad published deploy,
+   fix forward per rule 1. Do not hand over `restoreSiteDeploy` /
+   `publishDeploy` or a dashboard rollback as the answer.
+6. Always add `.netlify` to `.gitignore` when linking or creating a site —
+   every linking path writes `.netlify/state.json`, which must not be
+   committed. Mention it whenever you link.
+7. Secrets-scanning deploy failures: if the flagged value is a real secret,
+   that is a leak — stop shipping it in client/published output and rotate
+   it; never silence the scanner over a real leak. For genuinely non-secret
+   values, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` /
+   `SECRETS_SCAN_OMIT_PATHS`, never `SECRETS_SCAN_ENABLED=false`.
+8. Before running a manual `netlify deploy --prod` on a site with Git CD
+   connected, warn the user that the next push to the production branch
+   silently replaces the hand-shipped deploy; suggest locking the published
+   deploy if it must stay live.

--- a/cursor/rules/netlify-edge-functions.mdc
+++ b/cursor/rules/netlify-edge-functions.mdc
@@ -1,180 +1,259 @@
 ---
-description: Guide for writing Netlify Edge Functions. Use when building middleware, geolocation-based logic, request/response manipulation, authentication checks, A/B testing, or any low-latency edge compute. Covers Deno runtime, context.next() middleware pattern, geolocation, and when to choose edge vs serverless.
+description: Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use when adding request/response manipulation at the edge — auth middleware, geolocation redirects, A/B testing and personalization, content localization, redirects/rewrites, SSR at the edge, or transforming responses — or when configuring path routing, response caching, or edge error handling. Triggers on tasks like "add auth middleware", "geo-based redirect", "A/B testing at the edge", "rewrite requests", or editing files in netlify/edge-functions.
 alwaysApply: false
 ---
 
 # Netlify Edge Functions
 
-Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
+**Reach for this (modern):** default-export handler + inline `config` export with a narrowly-scoped `path`. Import types from `@netlify/edge-functions`.
 
-## Check the framework adapter first
+```ts
+import type { Config, Context } from "@netlify/edge-functions";
 
-For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+export default async (request: Request, context: Context) => {
+  // return Response | URL (rewrite) | undefined (continue chain)
+};
 
-## Syntax
+export const config: Config = { path: "/products/*" };
+```
 
-```typescript
+**Avoid:** import maps in `deno.json` (unsupported — use a separate file via `deno_import_map`). Do not hand-write a function your framework's adapter already generates (Next.js, Astro, Remix, SvelteKit, Nuxt, etc.) — check the framework adapter/reference first; duplicating adapter middleware causes conflicts.
+
+## File location
+
+- Default directory: `YOUR_BASE_DIRECTORY/netlify/edge-functions`.
+- Custom directory: `edge_functions` key under `[build]` in `netlify.toml`. Keep it **outside** the publish directory so source files aren't deployed.
+- `.js`/`.ts`/`.jsx`/`.tsx` all supported. If a `.ts` and `.js` file share a name, the `.ts` is ignored and the `.js` deploys.
+
+## ⚠️ A function without a route silently never runs
+
+Edge functions are **not** auto-assigned a URL. No `config` export and no `netlify.toml` declaration = deploys clean, no build error, no warning, never executes. If "my edge function does nothing," check the route first.
+
+## Request handling patterns
+
+Handler receives `(request: Request, context: Context)`. Return one of:
+- `Response` — respond directly (ends the chain; declared redirects for the path do not run)
+- `URL` — rewrite to a **same-site** URL with 200 status (address bar unchanged)
+- `undefined` / empty `return;` — bypass this function, continue the chain
+
+Netlify adds no headers to edge requests — use `context` for client info.
+
+### Redirect
+```ts
+export default async (req: Request, { cookies, geo }: Context) => {
+  if (geo.city === "Paris" && cookies.get("promo-code") === "15-for-followers") {
+    return Response.redirect(new URL("/subscriber-sale", req.url));
+  }
+};
+```
+
+### Rewrite (same-site only)
+```ts
+export default async (request: Request, { geo }: Context) => {
+  if (geo.city === "Paris") return new URL("/subscriber-sale", request.url);
+};
+```
+To reach another site or external content, use `fetch()` — rewrite via `URL` is same-site only.
+
+### Middleware transform
+```ts
+import type { Context } from "@netlify/edge-functions";
+
+export default async (request: Request, context: Context) => {
+  const response = await context.next();
+  const text = await response.text();
+  return new Response(text.toUpperCase(), response);
+};
+```
+`context.next()` runs the rest of the chain and returns the origin `Response`. Only call it if you need the response body (it costs latency otherwise).
+
+To transform a **different** path, use `fetch()` — but this starts a **new** request chain and re-runs any edge functions matching that path. Use `context.next()` to hit a static asset/serverless function at the same internal path without re-running edge functions.
+
+### Read the request body
+A body can only be read once. If you read it, pass a fresh request to `next()`:
+```ts
+export default async (req: Request, context: Context) => {
+  const body = await req.json();
+  if (!isValid(body.access_token)) return new Response("forbidden", { status: 403 });
+  return context.next(new Request(req, { body: JSON.stringify(body) }));
+};
+```
+
+### Conditional requests
+`next()` normally forces a full response. For client caching control:
+```ts
+const res = await next({ sendConditionalRequest: true });
+if (res.status === 304) return res;
+```
+
+## `Context` object
+
+- **`geo`** — `city`, `country {code,name}`, `subdivision {code,name}`, `latitude`, `longitude`, `timezone`, `postalCode`.
+- **`cookies`** — `get(name)`, `set(options)`, `delete(name|options)` (CookieStore web standard). ⚠️ Cross-subdomain cookies require a **custom domain** — `netlify.app` is on the Public Suffix List.
+- **`next(options?)` / `next(request, options?)`** — continue the chain; `options.sendConditionalRequest`.
+- **`params`** — path params, e.g. `/pets/:name` → `{ name: "winter" }`. Query string: use `request.url`.
+- **`ip`**, **`requestId`**, **`server.region`**.
+- **`site`** — `id`, `name`, `url`. **`account.id`**. **`deploy`** — `context`, `id`, `published`, `skewProtectionToken`.
+- **`waitUntil(promise)`** — run work after the response is sent (analytics, logs) without blocking it. Still subject to the CPU time limit.
+
+`Netlify.context` gives the same context inside the handler (`null` outside it).
+
+## Environment variables
+
+Access via `Netlify.env.get(name)` (also `has`, `set`, `delete`, `toObject`). `set`/`delete` are invocation-scoped only — they do **not** persist; use the Netlify env API to update.
+
+```ts
+const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
+```
+
+⚠️ **Gotchas:**
+- Variables in `netlify.toml` are **NOT** available to edge functions.
+- Scope must include **Functions** to reach runtime. **Build**-scoped vars are build-only — embed them at build time if needed.
+- Values are frozen at deploy time. Change a var → new deploy required. Deploy Previews/branch deploys use their deploy-time values.
+
+## Configuration / routing
+
+Config via inline `config` export or `netlify.toml`. Properties:
+- **`path`** — `URLPattern` string or array; must start with `/`. e.g. `["/", "/products/*"]`.
+- **`excludedPath`** — exclude routes from `path`; must start with `/`. e.g. `["/*.css", "/*.js"]`.
+- **`pattern`** / **`excludedPattern`** — regex alternatives to `path`/`excludedPath`.
+- **`method`** — string or array of HTTP methods (inline only).
+- **`header`** — object of header conditions: `true` (present), `false` (absent), or a regex string on the value. Names case-insensitive; multiple same-name values matched as comma-joined list.
+- **`cache`** — `"manual"` to opt into caching.
+- **`onError`** — error handling (see below).
+
+### ⚠️ Scope `path` narrowly
+
+`path: "/*"` intercepts **every** request including static assets — adds latency to each and **bills an edge invocation** for each. Match only the paths you need.
+
+### netlify.toml (for ordering / multiple functions on a path)
+```toml
+[[edge_functions]]
+  path = "/admin"
+  function = "auth"
+
+[[edge_functions]]
+  path = "/admin"
+  function = "injector"
+  cache = "manual"
+```
+Header matching uses an `[edge_functions.header]` sub-table.
+
+### Execution order
+Config-file declarations run before inline; framework-generated before user; non-cached before cached. Within `netlify.toml`: top-to-bottom. Within inline: **alphabetical by file name**. To control order, prefer `netlify.toml`. If the same function is declared both inline and in toml, they merge and inline fields win.
+
+Caveats: a function on the **target** of a static rewrite does **not** run for rewritten requests. If a function returns a `Response`, redirects for that path are skipped.
+
+## Response caching (opt-in)
+
+### ⚠️ Both parts or neither
+Cache headers on the `Response` do **nothing** without `cache: "manual"` in config — and `cache: "manual"` without headers still caches nothing. You need **both**:
+
+```ts
 import type { Config, Context } from "@netlify/edge-functions";
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello from the edge!");
+  return new Response("Hello world", {
+    headers: { "cache-control": "public, s-maxage=3600" },
+  });
 };
 
-export const config: Config = {
-  path: "/hello",
-};
+export const config: Config = { cache: "manual", path: "/hello" };
 ```
 
-Place files in `netlify/edge-functions/`. Uses `.ts`, `.js`, `.tsx`, or `.jsx` extensions.
+- Use caching only for endpoint-style responses reusable across clients (e.g. shared SSR HTML). **Never** for middleware, routing, or per-client personalization.
+- Cached responses do **not** count toward invocations.
+- ⚠️ A cached function **shadows real static files**: `cache:"manual"` on `/*` makes `/cat.png` serve the function, not the static file.
+- Supported headers: `Cache-Control`, `CDN-Cache-Control`, `Netlify-CDN-Cache-Control`, `Expires`, `Vary`, `Netlify-Vary`. Headers must be set inline in code.
+- New deploy in the same context voids `s-maxage`/`max-age`/`Expires` (atomic deploys).
+- No local caching — cache headers are ignored under `netlify dev`.
 
-## Config Object
+## Error handling (`onError`, inline only)
 
-```typescript
-export const config: Config = {
-  path: "/api/*",                    // URLPattern path(s)
-  excludedPath: "/api/public/*",     // Exclusions
-  method: ["GET", "POST"],           // HTTP methods
-  onError: "bypass",                 // "fail" (default), "bypass", or "/error-page"
-  cache: "manual",                   // Enable response caching
-};
+- **`"fail"`** (default) — generic error page, stops the chain.
+- **`"/custom-path"`** — rewrite to a same-site path (starts with `/`), served without invoking that path's edge functions.
+- **`"bypass"`** — skip the erroring function, continue the chain.
+
+Guidance: fail **closed** for critical logic (auth); fail **open** for progressive enhancement (localization → `bypass`).
+
+## Runtime & modules
+
+Deno runtime with many standard Web APIs (`fetch`/`Request`/`Response`/`URL`, `console`, `atob`/`btoa`, `TextEncoder`/`Decoder`(`Stream`), Web Crypto `crypto.randomUUID/getRandomValues/subtle`, `WebSocket`, timers, Streams API, `URLPattern`, `Performance`).
+
+- **Node built-ins:** `import { randomBytes } from "node:crypto"` (`node:` prefix).
+- **Deno modules:** URL import, e.g. `import React from "https://esm.sh/react"`.
+- **npm packages (beta):** `npm install` then import by name. ⚠️ Packages needing native binaries (Prisma) or runtime dynamic imports (cowsay) may fail — prefer `node:` built-ins / Deno URLs.
+- **Import maps:** separate file only (not `deno.json`), declared via `deno_import_map` in `[functions]`.
+
+### SSR at the edge (.tsx)
+```tsx
+import React from "https://esm.sh/react";
+import { renderToReadableStream } from "https://esm.sh/react-dom/server";
+import type { Config, Context } from "@netlify/edge-functions";
+
+export default async function handler(req: Request, context: Context) {
+  const stream = await renderToReadableStream(
+    <html><body><h1>Hello {context.geo.country?.name}</h1></body></html>
+  );
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/html" } });
+}
+
+export const config: Config = { path: "/hello" };
 ```
 
-**Scope `path` narrowly — `path: "/*"` intercepts every request, including static assets.** A `/*` match runs the edge function on every CSS, JS, image, and font request, not just your HTML pages — adding latency to each asset and billing an edge invocation for it. Match only the routes you need (e.g. `path: "/"`, `path: "/app/*"`), or keep a broad path but exclude static assets with `excludedPath` (e.g. `excludedPath: ["/*.css", "/*.js", "/*.png", "/*.woff2"]`).
+## Edge vs serverless
 
-**Cache headers on an edge response do nothing without `cache: "manual"`.** Setting `Cache-Control` (or any cache header) on the `Response` an edge function returns has no effect unless the function also opts in with `config.cache = "manual"`. It's both or neither: without the flag the response is never cached, no matter what headers you set.
-
-## Declaring edge functions: inline config vs netlify.toml
-
-An edge function runs only if it is bound to a path. Bind it either with an inline `export const config = { path: ... }` in the function file (shown above), or with an `[[edge_functions]]` entry in `netlify.toml` that names the file:
-
-```toml
-[[edge_functions]]
-  path = "/admin/*"
-  function = "auth"        # runs netlify/edge-functions/auth.ts
-```
-
-**A file in `netlify/edge-functions/` with no path binding still deploys, but silently never runs.** There is no build error and no warning — nothing routes a request to it, so it is never invoked. If an edge function "isn't doing anything," first confirm it declares a `path` inline or has a matching `[[edge_functions]]` entry.
-
-### Chaining multiple edge functions on one path
-
-When several edge functions match the same path, they run as a chain in this order:
-
-1. Functions declared in `netlify.toml` run first, **in the order they appear** in the file (top to bottom).
-2. Functions declared inline (via `export const config`) run next, **in alphabetical order by filename**.
-3. Functions configured for caching (`cache: "manual"`) always run after non-caching ones.
-
-To guarantee a specific order (e.g. an auth gate that must run before a personalization rewrite), declare the functions in `netlify.toml` in the order you want — don't depend on inline config, whose order is alphabetical by filename and easy to get wrong. Declaring the same function both inline and in `netlify.toml` merges them into an inline declaration (inline config wins), which forfeits the deterministic `netlify.toml` ordering.
-
-## Edge functions run before redirects
-
-In Netlify's request chain, edge functions execute **before** redirect and rewrite rules (`[[redirects]]`, `_redirects`). Two consequences bite often:
-
-- An edge function is matched against the **original** requested URL, not a redirect/rewrite destination. Scope its `path` to the URL the client actually requests — an edge function declared on the *target* of a rewrite will not fire for requests that only reach that target via the rewrite.
-- If an edge function returns a `Response`, the request chain stops there and redirect rules for that path **never run**. Return `context.next()` (or `undefined`) if you want redirects to still apply.
-
-## Middleware Pattern
-
-Use `context.next()` to invoke the next handler in the chain and optionally modify the response:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  // Before: modify request or short-circuit
-  if (!isAuthenticated(req)) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  // Continue to origin/next function
-  const response = await context.next();
-
-  // After: modify response
-  response.headers.set("x-custom-header", "value");
-  return response;
-};
-```
-
-Return `undefined` to pass through without modification:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  if (!shouldHandle(req)) return; // continues to next handler
-  return new Response("Handled");
-};
-```
-
-## Geolocation and IP
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const { city, country, subdivision, timezone } = context.geo;
-  const ip = context.ip;
-
-  if (country?.code === "DE") {
-    return Response.redirect(new URL("/de", req.url));
-  }
-};
-```
-
-Local dev with mocked geo: `netlify dev --geo=mock --country=US`
-
-## Cookies
-
-Read and write cookies through the `context.cookies` helper instead of hand-parsing the `Cookie` header or building `Set-Cookie` strings:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const bucket = context.cookies.get("bucket");            // read from the request
-  context.cookies.set({ name: "bucket", value: "a" });     // set on the response
-  context.cookies.delete("legacy_session");                // tell the client to delete it
-  return context.next();
-};
-```
-
-- `cookies.get(name)` — reads a named cookie from the incoming request.
-- `cookies.set(options)` — sets a cookie on the outgoing response (same option shape as the web `CookieStore.set` standard).
-- `cookies.delete(name)` — instructs the client to delete the cookie.
-
-## Environment Variables
-
-Use `Netlify.env` (not `process.env` or `Deno.env`):
-
-```typescript
-const secret = Netlify.env.get("API_SECRET");
-```
-
-## Module Support
-
-- **Node.js builtins**: `import { randomBytes } from "node:crypto";`
-- **npm packages**: Install via npm and import by name
-- **Deno modules**: URL imports (e.g., `import X from "https://esm.sh/package"`)
-
-For URL imports, use an import map:
-
-```json
-// import_map.json
-{ "imports": { "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts" } }
-```
-
-```toml
-# netlify.toml
-[functions]
-  deno_import_map = "./import_map.json"
-```
-
-## When to Use Edge vs Serverless
-
-| Use Edge Functions for | Use Serverless Functions for |
-|---|---|
-| Low-latency responses | Long-running operations (up to 15 min) |
-| Request/response manipulation | Complex Node.js dependencies |
-| Geolocation-based logic | Database-heavy operations |
-| Auth checks and redirects | Background/scheduled tasks |
-| A/B testing, personalization | Tasks needing > 512 MB memory |
+Edge for low-latency request/response manipulation, geolocation, auth checks/redirects, A/B personalization. Serverless for long-running work (up to 15 min), heavy Node deps, database-heavy operations, background/scheduled tasks, or memory above 512 MB.
 
 ## Limits
 
-| Resource | Limit |
-|---|---|
-| CPU time | 50 ms per request |
-| Memory | 512 MB per deployed set |
-| Response header timeout | 40 seconds |
-| Code size | 20 MB compressed |
+- Code size: **20 MB** compressed (bundle).
+- Memory: **512 MB** per deployed set.
+- CPU execution: **50 ms** per request (excludes waiting on resources; `waitUntil` work still counts).
+- Response header timeout: **40 s**.
+- Invocations/month vary by plan; cached responses don't count.
+
+## Local dev, deploy, monitor
+
+```bash
+npm install netlify-cli -g
+netlify dev      # runs edge functions on local requests at :8888
+```
+- Geo mocking: `--geo=mock` (San Francisco) or `--geo=mock --country=XX`. Debug: `--edge-inspect` / `--edge-inspect-brk`.
+- Manual deploys require CLI **12.2.8+** (older versions error). Deploys are atomic.
+- Logs: **Logs & Metrics > Edge Functions** in the UI; each `console` log names the emitting function. Filter by name/path (glob) and time. Retention ≥24h (7 days on some plans).
+
+## Feature limitations
+
+- Split Testing enabled → edge functions do **not** run.
+- Custom Headers (incl. basic auth headers) do **not** apply to edge functions.
+- Prerendering does **not** apply to paths served by an edge function.
+- Multiple framework plugins generating edge functions may collide.
+- Not part of Netlify's HIPAA-compliant offering.
+
+<!-- system: agent-context/edge-functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (edge-functions)
+
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-edge-functions skill; owned
+by the skills maintainer.
+
+1. Check the framework's adapter/reference first: a custom edge function that
+   duplicates adapter-generated middleware causes conflicts. Only hand-write
+   an edge function when the framework doesn't already generate one for the
+   job.
+2. Scope `path` narrowly. `path: "/*"` intercepts every request — including
+   static assets — adding latency to each one and billing an edge invocation
+   for it.
+3. An edge function without a route (no config export, no netlify.toml
+   declaration) still deploys, but silently never runs: no build error, no
+   warning. When "my edge function does nothing", check the route first.
+4. Choose edge vs serverless by workload shape: edge functions for low-latency
+   request/response manipulation, geolocation logic, auth checks/redirects,
+   and A/B personalization; serverless functions for long-running work (up to
+   15 min), heavy Node.js dependencies, database-heavy operations,
+   background/scheduled tasks, or memory needs above 512 MB.
+5. Cache headers on an edge response do nothing without `cache: "manual"` in
+   config — it's both or neither. Setting `Cache-Control` on the returned
+   `Response` has no effect unless the function also opts in.

--- a/cursor/rules/netlify-forms.mdc
+++ b/cursor/rules/netlify-forms.mdc
@@ -1,195 +1,196 @@
 ---
-description: Guide for using Netlify Forms for HTML form handling. Use when adding contact forms, feedback forms, file upload forms, or any form that should be collected by Netlify. Covers the data-netlify attribute, spam filtering, AJAX submissions, file uploads, notifications, and the submissions API.
+description: Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam, and sends notifications. Use when adding a contact form, lead-capture form, file-upload form, or newsletter signup to a Netlify site; wiring AJAX form submission; setting up a custom thank-you page; adding a honeypot or reCAPTCHA to a form; getting forms working in Next.js, Nuxt, SvelteKit, Astro, or Gatsby; reading form submissions via the Netlify API; or debugging missing submissions and forms that silently fail to register.
 alwaysApply: false
 ---
 
 # Netlify Forms
 
-Netlify Forms collects HTML form submissions without server-side code. Form detection must be enabled in the Netlify UI (Forms section).
+Mark a form for detection with `data-netlify="true"` (or the bare `netlify` attribute — equivalent) on the `<form>` tag. Forms are detected by **parsing the final built HTML at deploy time** — there is no runtime API call or backend code. Client-side/JS-rendered/SSR forms are NOT in the built HTML and are never detected on their own; they require a static skeleton file (see below).
 
-> **Enabling detection only affects future deploys.** Netlify scans for forms at deploy time, so turning on (or re-enabling) form detection does **not** rescan your current live deploy. After enabling detection you must trigger a new deploy/build before an already-published form is registered and starts collecting submissions.
+Prerequisite: form detection must be enabled once in the Netlify UI (Forms > **Enable form detection**). Takes effect on the next deploy.
 
-## Basic Setup
-
-Add `data-netlify="true"` and a unique `name` to the form:
+## Static HTML form
 
 ```html
 <form name="contact" method="POST" data-netlify="true">
-  <label>Name: <input type="text" name="name" /></label>
-  <label>Email: <input type="email" name="email" /></label>
-  <label>Message: <textarea name="message"></textarea></label>
-  <button type="submit">Send</button>
+  <p><label>Your Name: <input type="text" name="name" /></label></p>
+  <p><label>Your Email: <input type="email" name="email" /></label></p>
+  <p><label>Message: <textarea name="message"></textarea></label></p>
+  <p><button type="submit">Send</button></p>
 </form>
 ```
 
-Netlify's build system detects the form and injects a hidden `form-name` input automatically. For a custom success page, add `action="/thank-you"` to the form tag. Use paths without `.html` extension — Netlify serves `thank-you.html` at `/thank-you` by default, and the `.html` path returns 404.
+- `name` sets the form name in the UI and **must be unique per site**.
+- At deploy, Netlify strips the `data-netlify`/`netlify` attribute and injects `<input type="hidden" name="form-name" value="contact" />`.
+- Add an `<input name="email">` so the notification email's `Reply-to` is set to the submitter.
 
-## JavaScript-Rendered Forms (React, Vue, SSR Frameworks)
+## JS-rendered / SSR / framework forms (Next.js, Nuxt, SvelteKit, Astro, Gatsby)
 
-For forms rendered by JavaScript frameworks (React, Vue, Astro, TanStack Start, Next.js, SvelteKit, Remix, Nuxt), Netlify's build parser cannot detect the form in static HTML. You MUST create a static HTML skeleton file for build-time form detection:
+Two required pieces:
 
-> **Form detection parses prerendered HTML only.** A `data-netlify` form is registered only if it appears in HTML produced at build time. On an Astro route that is server-rendered on demand (`export const prerender = false`, or an `output: "server"` route), the form is generated per request and is never scanned at build — so it is never registered. Put the form on a prerendered page, or add the static skeleton file below.
-
-Create a static HTML file in `public/` (e.g. `public/__forms.html`) containing a hidden copy of each form:
+**1. Static skeleton file `public/__forms.html`** — a hidden copy of each form with `data-netlify="true"`, a hidden `form-name` input, and every field the component submits, with names matching **exactly** (Netlify validates field names against the registered form). Without this file, submissions silently fail.
 
 ```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" />
-      <input type="email" name="email" />
-      <textarea name="message"></textarea>
-      <input name="bot-field" />
-    </form>
-  </body>
-</html>
+<!-- public/__forms.html -->
+<form name="pizzaOrder" data-netlify="true" hidden>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" />
+</form>
 ```
 
-**Rules:**
-- The form `name` must exactly match the `form-name` value used in your component's fetch call
-- Include every field your component submits — Netlify validates field names against the registered form
-- Without this file, Netlify cannot detect the form and submissions will silently fail
-
-Your component must also include a hidden `form-name` input:
+**2. The rendered form** carries a matching hidden `form-name` input:
 
 ```jsx
-<form name="contact" method="POST" data-netlify="true">
-  <input type="hidden" name="form-name" value="contact" />
-  {/* ... fields ... */}
+<form name="pizzaOrder" method="post" data-netlify="true" onSubmit={handleSubmit}>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" onChange={handleChange} />
+  <input type="submit" />
 </form>
 ```
 
-## AJAX Submissions
+**⚠️ SSR POST target:** In SSR apps, `fetch("/")` is intercepted by the SSR catch-all function and never reaches form processing. POST to the static skeleton file itself — `/__forms.html` — not `/` or an arbitrary path.
 
-> **Netlify Forms does not accept JSON.** The submission body must be `application/x-www-form-urlencoded` (encode the fields with `URLSearchParams`) or `multipart/form-data` (a raw `FormData` object, for file uploads). A `fetch` that sends `JSON.stringify(...)` with `Content-Type: application/json` is silently **not** recorded as a submission — always send URL-encoded key/value pairs (or `FormData`), never JSON.
+**⚠️ Astro on-demand routes:** Routes with `export const prerender = false` or `output: "server"` are never scanned at build time, so their forms are never registered. Put the form on a prerendered page, or rely on the static skeleton file.
 
-### Vanilla JavaScript
+**Next.js Runtime v5 (Next.js 13.5+):** extract form definitions to the static skeleton file and submit via AJAX rather than full-page navigation. See https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview#v5-breaking-changes
 
-```javascript
-const form = document.querySelector("form");
-form.addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const formData = new FormData(form);
-  await fetch("/", {
+## AJAX submission
+
+```js
+const handleSubmit = event => {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  fetch("/__forms.html", {   // static sites may POST to "/"; SSR must target the skeleton file
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(formData).toString(),
-  });
+    body: new URLSearchParams(formData).toString()
+  })
+    .then(() => alert("Thank you for your submission"))  // or navigate("/thank-you")
+    .catch(error => alert(error));
+};
+document.querySelector("form").addEventListener("submit", handleSubmit);
+```
+
+- **Body MUST be URL-encoded. JSON is NOT supported.**
+- If the rendered form has no hidden `form-name` input, you MUST include a `form-name` field in the POST body.
+- The honeypot field name and `g-recaptcha-response` (if used) must be in the body — automatic with `FormData()`.
+
+## File uploads
+
+Add `type="file"`; optionally `enctype="multipart/form-data"` on the `<form>`. For AJAX file uploads, **do NOT set a `Content-Type` header** — let the browser set it (with the multipart boundary).
+
+```js
+document.forms.fileForm.addEventListener("submit", event => {
+  event.preventDefault();
+  fetch("/", { body: new FormData(event.target), method: "POST" })  // no headers
+    .then(() => { /* success */ });
 });
 ```
 
-> **SSR frameworks (TanStack Start, Next.js, SvelteKit, Remix, Nuxt):** The `fetch` URL must target the static skeleton
-> file path (e.g. `"/__forms.html"`), **not** `"/"`. In SSR apps, `fetch("/")` is intercepted by the SSR catch-all
-> function and never reaches Netlify's form processing middleware. See the React example and troubleshooting section below.
+Limits: one file per field (use multiple fields for multiple files) · 8 MB max request size · 30 s upload timeout · after form deletion, uploaded files stay at their direct URL for 24 h. PII uploads need extra security (Very Good Security integration).
 
-### React Example
+## Custom success page
 
-```tsx
-function ContactForm() {
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    // For SSR apps, use the skeleton file path instead of "/" (e.g. "/__forms.html")
-    const response = await fetch("/__forms.html", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(formData as any).toString(),
-    });
-    if (response.ok) {
-      // Show success feedback
-    }
-  };
+Add an `action` path relative to site root, starting with `/`. **Use extensionless paths** — Netlify serves `thank-you.html` at `/thank-you`; the `.html` path returns 404.
 
-  return (
-    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" placeholder="Name" />
-      <input type="email" name="email" placeholder="Email" />
-      <textarea name="message" placeholder="Message" />
-      <button type="submit">Send</button>
-    </form>
-  );
-}
+```html
+<form name="contact" action="/thank-you" method="POST" data-netlify="true"></form>
 ```
 
-> **SSR troubleshooting:** If form submissions appear to succeed (200 response) but nothing shows in the Netlify Forms
-> UI, the POST is likely being intercepted by the SSR function. Ensure `fetch` targets the skeleton file path (e.g.
-> `"/__forms.html"`), not `"/"`. The skeleton file path routes through the CDN origin where Netlify's form handler runs.
+Custom success *alert* is only possible via AJAX (substitute the redirect with your own logic).
 
-## Spam Filtering
+## Spam prevention
 
-Netlify uses Akismet automatically. Add a honeypot field for extra protection:
+All submissions are filtered by Akismet. Passed → **Verified submissions**; flagged → **Spam submissions**. Honeypot/reCAPTCHA failures are rejected and appear in neither list.
+
+**Honeypot:** add `netlify-honeypot="bot-field"` to the `<form>` and include a CSS-hidden field of that name. Any value entered → submission quietly rejected.
 
 ```html
 <form name="contact" method="POST" netlify-honeypot="bot-field" data-netlify="true">
-  <p style="display:none">
-    <label>Don't fill this out: <input name="bot-field" /></label>
-  </p>
-  <!-- visible fields -->
+  <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
+  <!-- real fields -->
 </form>
 ```
 
-For reCAPTCHA, add `data-netlify-recaptcha="true"` to the form and include `<div data-netlify-recaptcha="true"></div>` where the widget should appear.
+**Netlify reCAPTCHA 2:** add `data-netlify-recaptcha="true"` to the `<form>` AND an empty `<div data-netlify-recaptcha="true"></div>` where it renders. Only ONE Netlify-provided challenge per page — for multiple, use custom reCAPTCHA. For JS-rendered forms, also add the `div` to the static skeleton file.
 
-By default Netlify provisions and verifies the reCAPTCHA for you — do **not** add a site key/secret or load Google's reCAPTCHA script yourself. To use **your own** reCAPTCHA v2 keys, keep the same `data-netlify-recaptcha="true"` markup and set the credentials as Netlify environment variables: `SITE_RECAPTCHA_KEY` (the site key, scoped to Builds and Runtime) and `SITE_RECAPTCHA_SECRET` (the secret, scoped to Runtime). Netlify picks these up automatically — the secret stays server-side as an env var (never hardcoded in client code), and you still don't render the widget with Google's own script or build a custom Function to verify the token.
+**Custom reCAPTCHA 2:** your own reCAPTCHA snippet + `data-netlify-recaptcha="true"` on the `<form>`, plus env vars:
+- `SITE_RECAPTCHA_KEY` — site key (scopes: Builds + Runtime)
+- `SITE_RECAPTCHA_SECRET` — secret (scope: Runtime)
 
-> **Spam submissions are silent.** Akismet-flagged submissions are moved to a separate **Spam** list in the Forms UI — they do **not** appear in the verified submissions list and do **not** trigger email/Slack notifications. Submissions caught by a honeypot field or a failed reCAPTCHA challenge are discarded entirely and never appear in either list. So a "missing" legitimate submission is usually a false-positive spam classification, not a delivery bug: check the Spam list (or the Submissions API with `?state=spam`) and mark it verified — do not build a custom Function to "recover" it or disable spam filtering as a first resort.
+## Email notifications & subject line
 
-## File Uploads
+Default sender: `formresponses@netlify.com`. Set subject via a hidden `subject` input **or** the Netlify UI (Configuration > Notifications) — **not both; the HTML value always overrides the UI.**
 
 ```html
-<form name="upload" enctype="multipart/form-data" data-netlify="true">
-  <input type="text" name="name" />
-  <input type="file" name="attachment" />
-  <button type="submit">Upload</button>
-</form>
+<input type="hidden" name="subject" value="New lead from %{formName} (%{submissionId})" />
 ```
 
-For AJAX file uploads, use `FormData` directly — do **not** set `Content-Type` (the browser sets it with the correct boundary):
+Variables: `%{formName}`, `%{siteName}`, `%{submissionId}`. Forms created before **May 5, 2023** carry a `[Netlify]` subject prefix — remove it by adding the `data-remove-prefix` attribute to the `subject` input.
 
-```javascript
-await fetch("/", { method: "POST", body: new FormData(form) });
-```
+Set up notifications (email/webhook/Slack) in the UI: Configuration > Notifications > Form submission notifications > **Add notification**.
 
-**Limits:** 8 MB max request size, 30-second timeout, one file per input field.
+## Reading submissions via the API
 
-## Notifications
+Use only documented surfaces. Do NOT invent `api.netlify.com` endpoints or read tokens from local CLI config files. Reference: https://open-api.netlify.com/#tag/submission/operation/listFormSubmissions
 
-Configure in the Netlify UI under **Project configuration > Notifications**:
+- **Page through results using the `Link` header** — code that reads only the first response silently drops the rest.
+- `listFormSubmissions` returns data from old/removed fields no longer shown in the UI.
+- Query spam with `?state=spam`.
 
-- **Email**: Auto-sends on submission. Add `<input type="hidden" name="subject" value="Contact form" />` for custom subject lines.
-- **Slack**: Via Netlify App for Slack.
-- **Webhooks**: Trigger external services on submission.
+## Submission summary (field order matters)
 
-## Submissions API
+The UI summary is derived from field **type**, not name:
+- **Title**: first non-hidden text `<input>` that isn't email-like (`type="email"`, or name matching `email`/`mail`/`from`/`twitter`/`sender`); falls back to a field named `title` or `subject`.
+- **Body**: first `<textarea>`.
 
-Access submissions programmatically:
+Field order in the HTML affects what appears in the summary.
 
-```
-GET /api/v1/forms/{form_id}/submissions
-Authorization: Bearer <PERSONAL_ACCESS_TOKEN>
-```
+## Debugging missing submissions
 
-Key endpoints:
+- **First suspect: Akismet false positive.** A missing legitimate submission is usually spam-flagged — check the **Spam** list (or API `?state=spam`) and mark it verified. Do NOT build a custom recovery function or disable spam filtering as a first resort.
+- Test submissions get flagged as spam: use a real email (not `test@test.com`), write full sentences, don't hammer from one IP.
+- No submissions at all: confirm form detection is enabled and redeploy.
+- SSR/JS forms silently failing: verify the static skeleton file exists with exactly-matching field names and that AJAX targets the skeleton file, not `/`.
+- Missing old-field data: the UI shows only fields from the last deployed form version. Mark old fields `hidden` instead of removing them to keep them visible; old data remains available via `listFormSubmissions`.
 
-| Action | Method | Path |
-|---|---|---|
-| List forms | GET | `/api/v1/sites/{site_id}/forms` |
-| Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
-| Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
-| Delete submission | DELETE | `/api/v1/submissions/{id}` |
+## Constraints
 
-### Pagination
+- Deleting a form is permanent: future submissions return `404`, past submissions become unavailable. Export CSV first.
+- Submitted code is sanitized (`<script>` → escaped entities).
+- For PII, export and delete data regularly.
+- Data is stored in Netlify's database, not accessible except via UI/API/CSV.
 
-The Netlify API paginates any response over 100 items (100 per page by default). Pass `?page=` (1-based) and optionally `?per_page=` (max 100), and follow the `Link` response header — it carries the `rel="next"` and `rel="last"` page URLs. To sync **every** submission, page through until there is no `rel="next"` link (or a page returns fewer than `per_page` items). A single request does **not** return all submissions once a form has more than 100 — code that reads only the first response silently drops the rest.
+<!-- system: agent-context/forms/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (forms)
 
-## Use only documented surfaces
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-forms skill; owned by the
+skills maintainer.
 
-To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
-
-- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
-- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
-
-If a documented path fails, report the exact error and context to the user and stop.
+1. In SSR apps (Next.js, Nuxt, SvelteKit, etc.), `fetch("/")` is intercepted
+   by the SSR catch-all function and never reaches Netlify's form processing.
+   POST the AJAX submission to the static skeleton file itself (e.g.
+   `/__forms.html`), not to an arbitrary path.
+2. Use only documented surfaces: do not curl `https://api.netlify.com/...`
+   with an invented endpoint shape, and do not read tokens out of local CLI
+   config files (`~/Library/Preferences/netlify/config.json`).
+3. When reading submissions via the API, page through results (`Link`
+   header); code that reads only the first response silently drops the rest.
+4. For JS-rendered and SSR forms, always create the static skeleton file
+   `public/__forms.html`: a hidden copy of each form with
+   `data-netlify="true"`, a hidden `form-name` input, and every field the
+   component submits — names matching exactly (Netlify validates field names
+   against the registered form). Without this file, submissions silently fail.
+5. Astro routes rendered on demand (`export const prerender = false`, or
+   `output: "server"` routes) are never scanned at build time, so their forms
+   are never registered. Put the form on a prerendered page or rely on the
+   static skeleton file.
+6. A "missing" legitimate submission is usually an Akismet false positive:
+   check the Spam list (or the API with `?state=spam`) and mark it verified.
+   Do not build a custom recovery function or disable spam filtering as a
+   first resort.
+7. For custom success pages, use extensionless `action` paths (`/thank-you`,
+   not `/thank-you.html`) — Netlify serves `thank-you.html` at `/thank-you`
+   and the `.html` path returns 404.

--- a/cursor/rules/netlify-frameworks.mdc
+++ b/cursor/rules/netlify-frameworks.mdc
@@ -1,116 +1,241 @@
 ---
-description: Guide for deploying web frameworks on Netlify. Use when setting up a framework project (Vite/React, Astro, TanStack Start, Next.js, Nuxt, SvelteKit, Remix) for Netlify deployment, configuring adapters or plugins, running a framework project locally with Netlify's platform features, or troubleshooting framework-specific Netlify integration. Covers what Netlify needs from each framework, how adapters handle server-side rendering, and the general local development options (`netlify dev` versus the Netlify Vite plugin family).
+description: Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and env vars. Use when setting up or fixing a framework deploy (Next.js / Astro / Nuxt / SvelteKit / Remix / React Router / TanStack Start / SolidStart / Gatsby / Angular / Vite / Express / Hydrogen / Hugo / Eleventy / Vue / React), adding SSR or edge functions or middleware wired to Netlify context, fixing SPA redirect and catch-all rules, setting a build command or publish directory, or debugging "why isn't my env var updating" and framework build failures.
 alwaysApply: false
 ---
 
-# Frameworks on Netlify
+Route framework-specific deep work to the guides in this skill: `references/astro.md`, `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`, `references/tanstack.md`, `references/vite.md`.
 
-Netlify supports any framework that produces static output. For frameworks with server-side capabilities (SSR, API routes, middleware), an adapter or plugin translates the framework's server-side code into Netlify Functions and Edge Functions automatically.
+## Env vars: modern rules (read first)
 
-## How It Works
+Env values are injected **at build time**. Any change (client- or server-side) requires a **redeploy** — editing a var in the UI/CLI does NOT reach the live site or already-deployed functions until a new build runs.
 
-During build, the framework adapter writes files to `.netlify/v1/` — functions, edge functions, redirects, and configuration. Netlify reads these to deploy the site. You do not need to write Netlify Functions manually when using a framework adapter for server-side features.
+**Never use a client prefix for secrets.** Client-prefixed vars are inlined into the browser bundle:
+`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`.
 
-## Detecting Your Framework
+Client-embed prefixes by framework: CRA `REACT_APP_`, Gatsby `GATSBY_`, Next `NEXT_PUBLIC_`, Nuxt `NUXT_ENV_`, Vue CLI `VUE_APP_`.
 
-Check these files to determine the framework:
+**Scopes:** build-time access needs **Builds** scope; SSR/DSG runtime access needs **both Functions and Builds**. `netlify.toml` is read only during build — functions cannot read it at runtime; set runtime vars in UI/CLI/API.
 
-| File | Framework |
-|---|---|
-| `astro.config.*` | Astro |
-| `next.config.*` | Next.js |
-| `nuxt.config.*` | Nuxt |
-| `vite.config.*` + `react-router` | Vite + React (SPA or Remix) |
-| `vite.config.*` + `@tanstack/react-start` | TanStack Start |
-| `svelte.config.*` | SvelteKit |
-
-## Framework Reference Guides
-
-Each framework has specific adapter/plugin requirements and local dev patterns:
-
-- **Vite + React (SPA or with server routes)**: See [references/vite.md](references/vite.md)
-- **Astro**: See [references/astro.md](references/astro.md)
-- **TanStack Start**: See [references/tanstack.md](references/tanstack.md)
-- **Next.js**: See [references/nextjs.md](references/nextjs.md)
-- **Nuxt**: See [references/nuxt.md](references/nuxt.md)
-- **SvelteKit**: See [references/sveltekit.md](references/sveltekit.md)
-
-## Local Development
-
-Running a framework project locally with Netlify's platform features (environment variables, Functions, Edge Functions) generally comes from one of two places:
-
-### `netlify dev`
-
-```bash
-netlify dev
-```
-
-Wraps the framework's own dev server and adds:
-- Environment variable injection
-- Functions and Edge Functions
-- Redirects and headers processing
-
-Works with any framework — run `netlify dev` in place of the framework's native dev command (e.g. instead of `npm run dev`).
-
-Custom dev-server wiring — a non-standard `command`, a `port`/`targetPort`, or the `framework` key — goes in `netlify.toml`'s `[dev]` block; see the **netlify-config** skill for the full syntax. One easy-to-miss rule: if you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`, otherwise Netlify Dev runs its own detector and silently ignores your command.
-
-### Netlify Vite plugin family (Vite-based frameworks)
-
-For frameworks built on Vite, a Netlify Vite plugin exposes platform primitives (Functions, Blobs, DB, environment variables) directly inside the framework's own dev server, so no `netlify dev` wrapper is needed — run the framework's normal dev command (e.g. `npm run dev`) once the plugin is registered in `vite.config.ts`.
-
-- Vite-based projects (React SPA, SvelteKit, Remix): `@netlify/vite-plugin` — see [references/vite.md](references/vite.md)
-- TanStack Start: `@netlify/vite-plugin-tanstack-start` — see [references/tanstack.md](references/tanstack.md)
-
-The per-framework reference guides may also document other local dev options (e.g. `netlify dev`) — check the guide for your framework for setup specifics.
-
-### Running a single command with the Netlify environment loaded
-
-```bash
-netlify dev:exec <cmd>
-```
-
-Loads the Netlify environment (env vars, etc.) for a single command without starting a dev server — useful for scripts, tests, or one-off tasks that need Netlify-managed environment variables.
-
-## General Patterns
-
-### Client-Side Routing (SPA)
-
-For single-page apps with client-side routing, add a catch-all redirect:
-
+Netlify build variables can't be used as values in the UI or `netlify.toml` env sections. Set them inline before the build command:
 ```toml
-# netlify.toml
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+[build]
+  command = "REACT_APP_CONTEXT=$CONTEXT npm run build"
 ```
 
-> **Remove this catch-all when you adopt an SSR adapter.** A `/* → /index.html` rule left over from an SPA setup will shadow your server routes: user-defined redirects in `netlify.toml`/`_redirects` take precedence over the routes a framework adapter generates, so every request — including SSR pages and API/function routes — is served the static `index.html` with a 200. When you migrate a client-rendered app to SSR, delete the SPA catch-all.
+## SPA redirects and the SSR catch-all footgun
 
-### Custom 404 Pages
+SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.html` for `pushState`:
+```
+/* /index.html 200
+```
 
-- **Static sites**: Create a `404.html` in your publish directory. Netlify serves it automatically for unmatched routes.
-- **SSR frameworks**: Handle 404s in the framework's routing (the adapter maps this to Netlify's function routing).
+**Remove any SPA catch-all when adopting an SSR adapter.** A leftover `/* → /index.html 200` silently serves static `index.html` for SSR pages and API routes — user redirects beat adapter-generated routes.
 
-### Environment Variables in Frameworks
+## Local dev with platform emulation (no Netlify CLI)
 
-Each framework exposes environment variables to client-side code differently:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
 
-| Framework | Client prefix | Access pattern |
-|---|---|---|
-| Vite / React | `VITE_` | `import.meta.env.VITE_VAR` |
-| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_VAR` |
-| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_VAR` |
-| Nuxt | `NUXT_PUBLIC_` | `useRuntimeConfig().public.var` |
+| Framework | Plugin/module | Run |
+|-----------|---------------|-----|
+| Astro (5.12+) | built-in (Netlify Vite plugin auto-loaded) | `astro dev` |
+| Nuxt | `@netlify/nuxt` | `nuxt dev` |
+| React Router | `@netlify/vite-plugin` | `react-router dev` |
+| SolidStart 2 | `@netlify/vite-plugin` | `vite dev` |
+| TanStack Start | `@netlify/vite-plugin-tanstack-start` | (vite) |
+| Vite | `@netlify/vite-plugin` | `npx vite` |
 
-In server-side code, prefer `Netlify.env.get("VAR")` to read environment variables. `process.env.VAR` also works inside Netlify Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps server code working in both.
+Still need `netlify dev` (Netlify CLI) for: Gatsby generated functions (run `netlify build` first), Angular SSR local test (`netlify serve`), and frameworks without a Vite plugin.
 
-**Never use a client prefix (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) for secrets.** Client-prefixed variables are inlined into the client bundle and exposed to the browser.
+**`netlify dev` gotcha:** with both a custom `command` and a `targetPort` in `[dev]`, you must set `framework = "#custom"` — otherwise the detector runs and your custom command is silently ignored.
 
-### Environment Variable Changes Require a Redeploy
+## Build settings by framework
 
-Client-prefixed vars (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`) are **inlined into the client bundle at build time** — their values are compiled into the JavaScript shipped to the browser. Editing one in the Netlify UI or CLI has no effect on the live site until a new build runs. The same applies server-side: Netlify injects environment variables at build time, so changing a value in the dashboard does **not** propagate to already-deployed functions on the next request. Any env var change — client- or server-side — requires a redeploy to take effect. If a value looks stale after you changed it, trigger a new deploy.
+| Framework | Build command | Publish |
+|-----------|---------------|---------|
+| Angular (standard) | `ng build --prod` | `dist/YOUR_PROJECT_NAME` |
+| Astro | `astro build` | `dist` |
+| Create React App | `react-scripts build` | `build` |
+| Eleventy | `eleventy` | `_site` |
+| Gatsby | `gatsby build` | `public` |
+| Hugo | `hugo` | `public` |
+| Hydrogen | `remix vite:build` | `dist/client` |
+| Next.js (SSR/hybrid) | `next build` | `.next` |
+| Next.js (static export) | `next build && next export` | `out` (`NETLIFY_NEXT_PLUGIN_SKIP=true`) |
+| Nuxt 3 | `nuxt build` | `dist` |
+| Nuxt 2 | `nuxt generate` | `dist` |
+| React Router | `react-router build` | `build/client` |
+| Remix (Vite) | `remix vite:build` | `build/client` |
+| SolidStart 2 (Vite plugin) | `vite build` | `dist/client` |
+| SolidStart 2 (Nitro) | `vite build` | `dist` |
+| SolidStart 1.x | `vinxi build` | `dist` |
+| SvelteKit | `vite build` | `build` |
+| TanStack Start (1.132.0+) | `vite build` | `dist/client` |
+| Vite | `vite build` | `dist` |
+| Vue CLI | `vue-cli-service build` | `dist` |
 
-### Runtime File Reads in Adapter-Generated Functions
+Detection suggests these; override in `netlify.toml` or UI (project configuration > Build & deploy > Continuous deployment > Build settings).
 
-When an adapter turns your server code into a Netlify Function, only traced module dependencies are bundled. Arbitrary files you read from disk at runtime — a local JSON/Markdown data file, an email template, an `fs.readFile()` target — are **not** uploaded with the function unless you declare them. Such a read succeeds under `npm run dev` (the whole project is on disk) but throws `ENOENT` in production. Declare the files so they ship with the function: in Next.js set `outputFileTracingIncludes` in `next.config`; for a hand-written Netlify Function use `included_files` in its `config`. Never assume the project filesystem is present at function runtime.
+## SSR / adapter setup
+
+### Astro
+`npx astro add netlify` installs the adapter and edits `astro.config.mjs`. Adapter needed for SSR and out-of-the-box Image CDN for `<Image />`. SSR → Netlify Functions; middleware → Edge Functions. Adapter-less deploy only if no server features and no Image CDN need. Skew protection from 5.15.0.
+
+### Next.js (13.5+ only)
+Zero-config via the OpenNext adapter (`@netlify/plugin-nextjs`). Do NOT pin the version — Netlify auto-updates each build. Treat the legacy adapter as read-only history, never a recommendation.
+Adapter provisions: serverless function for SSR/ISR/PPR/route handlers/Server Actions; Edge Function for Middleware; Full Route + Data Cache; Image CDN with `next/image`.
+Skew protection is opt-in: set `NETLIFY_NEXT_SKEW_PROTECTION=true`, redeploy. No automatic support for client `fetch` — direct calls with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`. Details in `references/nextjs.md`.
+
+### SvelteKit
+```bash
+npm install -D @sveltejs/adapter-netlify
+```
+```js
+import adapter from '@sveltejs/adapter-netlify';
+export default { kit: { adapter: adapter() } };
+```
+Replace `@sveltejs/adapter-auto` with the specific import. SSR routes → a `render` function.
+- `split: true` → one function per route. **Incompatible with Edge Functions** (`edge: false` or omit).
+- `edge: true` → SSR in a Deno edge function; can't combine with `split`.
+- **Redirects NOT supported in `netlify.toml`** — use `_redirects`.
+- Edge functions don't work locally with `netlify dev` for SvelteKit.
+
+### React Router (7+)
+New: `npx create-react-router@latest --template netlify/react-router-template`. Existing:
+```bash
+npm install @netlify/vite-plugin-react-router
+```
+Add `netlifyReactRouter()` to Vite plugins. Default target = Serverless Functions.
+**Edge (Deno):** needs plugin v2.1.1+, set `edge: true`, and you **must** create `app/entry.server.tsx`:
+```typescript
+export { default } from 'virtual:netlify-server-entry'
+```
+Exclude your own function paths: `netlifyReactRouter({ edge: true, excludedPaths: ['/api/*'] })`.
+**Moving back to Serverless:** remove `edge: true` AND delete `app/entry.server.tsx`.
+Middleware (React Router v7.9.0+, plugin v2.0.0+): opt in via `future.v8_middleware`; import `netlifyRouterContext` from `@netlify/vite-plugin-react-router/serverless` (or `/edge` when `edge: true`); access `context.get(netlifyRouterContext)`.
+
+### Remix
+New: `npx create-remix@latest --template netlify/remix-template` (CLI prompts functions vs Edge Functions). Manual (Remix Vite required):
+```bash
+npm install --save-dev @netlify/remix-adapter
+```
+Add `netlifyPlugin()` from `@netlify/remix-adapter/plugin` to Vite plugins.
+
+### Nuxt
+SSR via Nitro, automatic on Nuxt 3. Local parity via `@netlify/nuxt` (`npx nuxi module add @netlify/nuxt`).
+- SSR on Edge Functions requires a different Nitro deployment preset (not auto-detected).
+- pnpm + Nuxt 3: set `PNPM_FLAGS=--shamefully-hoist`.
+- `nuxt/image` auto-uses Netlify Image CDN; set remote domains in `nuxt.config.ts`.
+
+### SolidStart
+SolidStart 2 builds on Vite — **no SolidStart-specific adapter**. Install `@netlify/vite-plugin`:
+```ts
+import netlify from "@netlify/vite-plugin";
+import { solidStart } from "@solidjs/start/config";
+import { defineConfig } from "vite";
+export default defineConfig({
+  plugins: [solidStart(), netlify({ build: { enabled: true } })],
+});
+```
+Publish `dist/client`. SSR routes, server functions, middleware → Netlify Functions, zero extra config.
+**Nitro alternative:** add `nitro()`, use plain `netlify()` (no `build.enabled`), publish `dist`.
+SolidStart 1: Nitro auto-configures; optionally set `preset: "netlify"` in `app.config.ts`; `vinxi build` / `dist`.
+
+### TanStack Start
+React (and Solid.js) full-stack; SSR/Server Routes/Server Functions/middleware → serverless functions.
+```bash
+npm install -D @netlify/vite-plugin-tanstack-start
+```
+Add `netlify()` to Vite plugins alongside `tanstackStart()`; `vite build` / `dist/client` (1.132.0+). Netlify CLI deploys require netlify-cli 17.31+. Older versions: see `references/tanstack.md`.
+
+### Gatsby
+- **5.12.0+ (adapter):** auto-detects and installs `gatsby-adapter-netlify` (zero-config). Generates functions `SSR`, `DSG`. No Essential Gatsby plugin needed.
+- **5.11.0 or earlier (Essential Gatsby plugin):** auto-installs `@netlify/plugin-gatsby`; also manually install `gatsby-plugin-netlify` (required for SSR, Gatsby redirects, asset caching). Generates `__api`, `__ssr`, `__dsg`, `__ipx`. Skip via `NETLIFY_SKIP_GATSBY_FUNCTIONS` (all) / `NETLIFY_SKIP_API_FUNCTION` / `NETLIFY_SKIP_SSR_FUNCTION` / `NETLIFY_SKIP_DSG_FUNCTION`.
+- Gatsby 5 requires Node 18.
+- Large sites: set `GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE` to load datastore from CDN (avoids max function deploy size; slower first SSR/DSG load).
+- Image CDN: set `NETLIFY_IMAGE_CDN=true` (Contentful/Drupal/WordPress source plugins). **Not supported on 5.12.x with adapter — upgrade to 5.13.0+.**
+- `StaticImage` and `gatsby-transformer-sharp` don't work for SSR/DSG — host images on a CDN.
+
+### Angular
+SSR auto-configured via an Edge Function. Suggested dev: `ng serve` / `4200`.
+- **SSR pages are NOT subject to `_redirects` or `netlify.toml` redirects** — SSR uses Edge Functions that run before redirects. Use Angular's built-in redirects.
+- Access `Request`/`Context` in SSR via `netlify.request` / `netlify.context` providers (from `@netlify/edge-functions`); unavailable client-side or during prerendering. Test locally with `netlify serve`.
+- `NgOptimizedImage` auto-uses Image CDN; set `remote_images` (array of regex) under `[images]` in `netlify.toml`.
+
+### Express
+Node 18.14.0+. Deploy as a Netlify Function via `serverless-http`:
+```bash
+npm i express serverless-http @netlify/functions @types/express
+```
+```ts
+// netlify/functions/api.ts
+import express, { Router } from "express";
+import serverless from "serverless-http";
+const api = express();
+const router = Router();
+router.get("/hello", (req, res) => res.send("Hello World!"));
+api.use("/api/", router);
+export const handler = serverless(api);
+```
+```toml
+[functions]
+  external_node_modules = ["express"]
+  node_bundler = "esbuild"
+[[redirects]]
+  force = true
+  from = "/api/*"
+  status = 200
+  to = "/.netlify/functions/api/:splat"
+```
+No frontend: set a placeholder build command (e.g. `echo Building Functions`). All Function limits apply; not recommended as background/scheduled functions.
+
+### Hydrogen
+Shopify stack on React Router 7. **SSR only on Netlify Edge Functions — Netlify Functions NOT officially supported.** Node 24+. Use the starter:
+```bash
+npm create @shopify/hydrogen@latest -- --template https://github.com/netlify/hydrogen-template
+cp .env.example .env && npm run dev
+```
+
+## Static-site gotchas
+
+### Hugo
+Set `HUGO_VERSION` (any release after 0.19) in `[build.environment]` — a missing/mismatched version causes `exit code: 255`. Install themes as **git submodules** (`git submodule add ...`), not `git clone`.
+
+### Eleventy
+`eleventy` / `_site`. **Build plugins require editing `.gitignore`: change `node_modules` to `**/node_modules/**`** — otherwise Netlify plugins and Eleventy collide on `.netlify/plugins/node_modules/` and the build errors.
+
+## Vite meta-framework support matrix
+Astro (auto on 5.12+), Nuxt (via `@netlify/nuxt`), TanStack Start (via `@netlify/vite-plugin-tanstack-start`), React Router, SolidStart — all **full**. SvelteKit — **experimental**.
+
+## Deploy via CLI (Express, Nuxt, React, Vite)
+```sh
+npm install netlify-cli -g
+netlify init
+```
+Follow prompts to create/link the site and set build settings.
+
+<!-- Node version floors (18.14.0+) are stated per-framework where documented; no cross-framework build-image default is given in sources. -->
+
+<!-- system: agent-context/frameworks/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (frameworks)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Per-framework deep guides live in this skill: `references/astro.md`,
+   `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`,
+   `references/tanstack.md`, `references/vite.md` — route framework-specific
+   work there before improvising.
+2. Next.js: modern runtime (v5, Next ≥13.5) only — treat the legacy adapter
+   as read-only history, never a recommendation.
+3. Remove any SPA catch-all (`/* → /index.html 200`) when adopting an SSR
+   adapter — user redirects beat adapter-generated routes, so a leftover
+   catch-all silently serves static `index.html` for SSR pages and API routes.
+4. Any env var change — client- or server-side — requires a redeploy. Values
+   are injected at build time; editing one in the UI/CLI does not reach the
+   live site or already-deployed functions until a new build runs.
+5. `netlify dev` with both a custom `command` and a `targetPort` requires
+   `framework = "#custom"` in the `[dev]` block — otherwise the detector runs
+   and the custom command is silently ignored.
+6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
+   `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
+   client-prefixed vars are inlined into the browser bundle.

--- a/cursor/rules/netlify-functions.mdc
+++ b/cursor/rules/netlify-functions.mdc
@@ -1,286 +1,348 @@
 ---
-description: Guide for writing Netlify serverless functions. Use when creating API endpoints, background processing, scheduled tasks, or any server-side logic using Netlify Functions. Covers modern syntax (default export + Config), TypeScript, path routing, background functions, scheduled functions, streaming, and method routing.
+description: Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API endpoint or backend route, adding a contact form handler, wiring auth or Identity signup/login hooks, building streaming or AI-proxy responses, scheduling cron jobs, running long background jobs (batch processing/scraping), reacting to deploy or form events, setting up rate limiting or region/memory config, or reading environment variables and secrets inside a function. Covers file locations, the Request/Context/Response handler shape, path routing, config options, and local testing with netlify dev.
 alwaysApply: false
 ---
 
 # Netlify Functions
 
-## Modern Syntax
+Reach for the modern default-handler API (`.mts` TypeScript). Export a default async handler taking a web `Request` and a Netlify `Context`, returning a web `Response`. Avoid the legacy AWS Lambda handler shape unless writing Go or migrating old code (see Legacy at the end).
 
-Always use the modern default export + Config pattern. Never use the legacy `exports.handler` or named `handler` export.
+## File locations
 
-```typescript
-import type { Context, Config } from "@netlify/functions";
+- Default directory: `netlify/functions/` (relative to base directory). Keep it **outside** your publish directory or source files ship as static assets.
+- A function is one file or a subdirectory whose entry file is named `index` or matches the subdirectory name. All of these create a function `hello`:
+  - `netlify/functions/hello.mts`
+  - `netlify/functions/hello/hello.mts`
+  - `netlify/functions/hello/index.mts`
+- Use `.mts` (TS) / `.mjs` (JS) for ES modules. `.cts`/`.cjs` force CommonJS; `.ts`/`.js` follow the nearest `package.json` `"type"`.
+
+## Minimal function
+
+No `config` export. Serves at `/.netlify/functions/hello`.
+
+```ts title="netlify/functions/hello.mts"
+import type { Context } from "@netlify/functions"
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello, world!");
-};
-
-export const config: Config = {
-  path: "/api/hello",
-};
+  return new Response("Hello, world!")
+}
 ```
 
-The handler receives a standard Web API `Request` and returns a `Response`. The second argument is a Netlify `Context` object.
+Install types: `npm install @netlify/functions` (required for TS types; optional for JS).
 
-The bare default export shown above is the recommended form. The default export can also be an object with a `fetch` method — prefer this form only if (1) other functions in the project already use it, or (2) the function also subscribes to platform events (see [Event Handlers](#event-handlers) below), since events are exposed as named handlers on the same object:
+Read env vars and secrets with `Netlify.env.get()`:
 
-```typescript
+```ts
+const apiKey = Netlify.env.get("STRIPE_SECRET_KEY")
+```
+
+Never hardcode secrets. For the variable to exist at runtime its scope must include **Functions**. Variables set in `netlify.toml` are NOT available to functions. Values are frozen per deploy — change them and redeploy to apply.
+
+**Response headers are set in code** on the returned `Response`. `[[headers]]` in `netlify.toml`, `_headers`, and redirect header rules apply ONLY to static CDN responses, not function responses. Do not add CORS headers unless explicitly requested.
+
+## Custom path routing
+
+Set `config.path` to route to custom URLs. When set, the function serves ONLY at that path — not at `/.netlify/functions/<name>`.
+
+```ts title="netlify/functions/travel.mts"
+import type { Config, Context } from "@netlify/functions"
+
+export default async (req: Request, context: Context) => {
+  const { city, country } = context.params
+  return new Response(`You're visiting ${city} in ${country}!`)
+}
+
+export const config: Config = {
+  path: "/travel-guide/:city/:country",
+}
+```
+
+- Multiple paths: `path: ["/cats", "/dogs"]`.
+- Patterns: `path` supports [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) syntax — `path: ["/sale/*", "/item/:sku"]`. Named groups land on `context.params`. For the query string use `req.url`.
+- `excludedPath`: carve exceptions, e.g. `excludedPath: ["/product/*.css"]` with `path: "/product/*"`.
+- `preferStatic: true`: let a real static file at the URL win.
+- `method`: restrict methods, e.g. `method: ["GET", "POST"]`.
+
+## Fetchable module shape (alternative)
+
+Equivalent to the bare handler; carries `config` inline and lets you add event handlers.
+
+```ts
+import type { NetlifyFunction } from "@netlify/functions"
+
 export default {
-  fetch(req: Request, context: Context) {
-    return new Response("Hello, world!");
-  },
-};
+  fetch: (req, context) => new Response("Hello, world!"),
+  config: { path: "/hello" },
+} satisfies NetlifyFunction
 ```
 
-## File Structure
+## Context object
 
-Place functions in `netlify/functions/`:
+Second handler argument (or `getContext()` from `@netlify/functions` when out of handler scope — throws outside a request; wrap in try/catch).
 
-```
-netlify/functions/
-  _shared/           # Non-function shared code (underscore prefix)
-    auth.ts
-    db.ts
-  items.ts           # -> /.netlify/functions/items (or custom path via config)
-  users/index.ts     # -> /.netlify/functions/users
-```
+- `context.params` — named path params.
+- `context.geo` — `city`, `country.code/name`, `latitude`, `longitude`, `subdivision`, `timezone`, `postalCode`.
+- `context.ip` — client IP string.
+- `context.cookies` — `get(name)` / `set(options)` / `delete(name|options)`. Cross-subdomain cookies need a custom domain (`netlify.app` is on the Public Suffix List).
+- `context.site` — `id`, `name`, `url`. `context.deploy` — `context`, `id`, `published`, `skewProtectionToken`. `context.account.id`. `context.server.region`. `context.requestId`.
+- `context.waitUntil(promise)` — run work after the response is sent (analytics, logs) without blocking. Billing/log duration counts until the promise settles. Available for functions deployed on/after 2025-03-20.
 
-Use `.ts` or `.mts` extensions. If both `.ts` and `.js` exist with the same name, the `.js` file takes precedence.
+⚠️ Under `netlify dev`, `context.geo` and `context.ip` are **mocked** — placeholder values that never change. Don't conclude geo code is broken locally. Exercise branches with `netlify dev --geo=mock --country=DE` and verify on a real deploy.
 
-## Path Routing
+## Config object
 
-Define custom paths via the `config` export:
+Export `const config` (or the `config` property of a Fetchable module):
 
-```typescript
-export const config: Config = {
-  path: "/api/items",                    // Static path
-  // path: "/api/items/:id",            // Path parameter
-  // path: ["/api/items", "/api/items/:id"], // Multiple paths
-  // excludedPath: "/api/items/special", // Excluded paths
-  // preferStatic: true,                // Don't override static files
-};
-```
+- `path` / `excludedPath` — `string | string[]`, must start with `/`.
+- `method` — one method or array.
+- `preferStatic` — `boolean`.
+- `background` — `boolean` (see Background).
+- `schedule` — cron string (see Scheduled). Mutually exclusive with `path`/`excludedPath`.
+- `rateLimit` — `{ action: 'rate_limit'|'rewrite', aggregateBy: 'domain'|'ip'|[...], to?, windowSize, windowLimit }`.
+- `memory` / `vcpu` — see below; mutually exclusive.
+- `region` — airport code; see below.
 
-Without a `path` config, functions are available at `/.netlify/functions/{name}`. Setting a `path` makes the function available **only** at that path.
+## Integrations
 
-Access path parameters via `context.params`:
+```ts title="netlify/functions/users.mts"
+import type { Config } from "@netlify/functions"
+import { getDatabase } from "@netlify/database"
 
-```typescript
-// config: { path: "/api/items/:id" }
-export default async (req: Request, context: Context) => {
-  const { id } = context.params;
-  // ...
-};
-```
+const db = getDatabase()
 
-## Method Routing
-
-```typescript
-export default async (req: Request, context: Context) => {
-  switch (req.method) {
-    case "GET":    return handleGet(context.params.id);
-    case "POST":   return handlePost(await req.json());
-    case "DELETE": return handleDelete(context.params.id);
-    default:       return new Response("Method not allowed", { status: 405 });
-  }
-};
-
-export const config: Config = {
-  path: "/api/items/:id",
-  method: ["GET", "POST", "DELETE"],
-};
-```
-
-## Background Functions
-
-For long-running tasks (up to 15 minutes). The client receives an immediate `202` response; return values are ignored.
-
-Enable background mode by setting `background: true` in config:
-
-```typescript
 export default async (req: Request) => {
-  await someLongRunningTask();
-};
+  const users = await db.sql`SELECT id, email FROM users LIMIT 10`
+  return Response.json({ users })
+}
+
+export const config: Config = { path: "/users" }
+```
+
+Blobs: `import { getStore } from "@netlify/blobs"`; `getStore("uploads").set(key, await req.blob())`.
+
+`purgeCache()` from `@netlify/functions` invalidates the edge cache from inside a function:
+
+```ts
+import { purgeCache } from "@netlify/functions"
+
+export default async () => {
+  await purgeCache({ tags: ["products"] }) // omit tags to purge all
+  return new Response("Purged!", { status: 202 })
+}
+```
+
+## Streaming responses
+
+Return a `ReadableStream` as the `Response` body. Limits: **60s execution, 20 MB response**.
+
+```ts
+export default async (req: Request) => {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${Netlify.env.get("OPENAI_API_KEY")}`,
+    },
+    body: JSON.stringify({ model: "gpt-4o-mini", stream: true, messages: [/* ... */] }),
+  })
+  return new Response(res.body, { headers: { "content-type": "text/event-stream" } })
+}
+```
+
+To build a stream manually, `new ReadableStream({ start(controller) { controller.enqueue(...); controller.close() } })`.
+
+## Background functions (long-running)
+
+`config.background: true`. Client gets an immediate `202`; the return value is discarded; runs up to **15 minutes**. No streaming. Retries: on invocation error, retry after 1 min, then again 2 min later. Send results somewhere other than the client.
+
+```ts title="netlify/functions/process.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  // Long-running work. Client already has its 202.
+}
+
+export const config: Config = { background: true, path: "/process" }
+```
+
+Limits: background payload **256 KB**. Legacy `-background` filename suffix still works but prefer `config.background`.
+
+## Scheduled functions (cron)
+
+`config.schedule` with a cron expression, executed in **UTC**. The request body is JSON with `next_run` (ISO-8601). Inline config is TS/JS only — Go must use `netlify.toml`.
+
+Always compute the UTC time for the target local hour. E.g. 9 AM ET → `"0 13 * * *"` UTC (note this shifts by an hour across DST; pick the UTC offset you need). Prefer explicit cron over `@daily`/`@hourly` shortcuts, which can't target a specific local hour.
+
+```ts title="netlify/functions/daily-digest.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  const { next_run } = await req.json()
+  console.log("Next invocation at:", next_run)
+}
 
 export const config: Config = {
-  path: "/process",
-  background: true,
-};
+  schedule: "0 13 * * *", // 9 AM ET (EST); UTC
+}
 ```
 
-Store results externally (Netlify Blobs, database) for later retrieval.
+Via `netlify.toml` (all languages):
 
-The legacy filename convention (`process-background.ts`) is still supported, but new functions should use `config.background`.
-
-## Region
-
-Functions deploy to `cmh` (Ohio) by default for new sites. This is a deliberate choice: US East is centrally located for an international audience, has a broad provider ecosystem, and gives most projects the lowest overall latency without any configuration. Sites created before October 4, 2023 may have a different default region — check Project configuration > Build & deploy > Continuous deployment > Functions region to confirm.
-
-Do NOT override `config.region` unless the user has stated a specific reason — for example, a database or backend service in another region with measurable roundtrip savings, a data-residency requirement, or an audience concentrated in one region whose compute dependencies (database, backend services) also live in that region.
-
-Two constraints to be aware of before adding `config.region`:
-
-- A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
-- For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
-
-Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
-
-## Memory or vCPU
-
-Functions run with 1024 MB of memory and a proportional amount of compute by default. The default fits most workloads, and raising it has a direct cost impact: function billing scales linearly with the configured size.
-
-Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them when:
-
-- The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
-- The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
-
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
-
-## Scheduled Functions
-
-Run on a cron schedule (UTC timezone):
-
-```typescript
-export default async (req: Request) => {
-  const { next_run } = await req.json();
-  console.log("Next invocation at:", next_run);
-};
-
-export const config: Config = {
-  schedule: "@hourly", // or cron: "0 * * * *"
-};
+```toml
+[functions."daily-digest"]
+  schedule = "0 13 * * *"
 ```
 
-Shortcuts: `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`. Scheduled functions have a **30-second timeout** and only run on published deploys.
+Constraints: **30s limit** (use background for longer); only fire on **published deploys** (not Deploy Previews/branch deploys — invoke manually with **Run now**); no URL invocation; no streaming; no request payloads/POST data; incompatible with Split Testing. All extensions supported **except** `@reboot` and `@annually`.
 
-**Testing and triggering.** A scheduled function does **not** fire on its cron schedule under `netlify dev` — the local dev server never runs the schedule, so waiting for the clock will appear to do nothing. Test it by invoking it directly: `netlify functions:invoke <name>` calls the function once, on demand. In production a scheduled function also has **no public HTTP URL** — it is not reachable at `/.netlify/functions/{name}` and cannot be triggered by an external HTTP request; it runs only on its schedule. If you also need to trigger the same work over HTTP (a manual "run now" or a webhook), expose that logic through a separate ordinary HTTP function and share the implementation rather than trying to POST to the scheduled function.
+## Platform-event functions
 
-## Streaming Responses
+Export a default object with handlers named after events. They always run in the background — no response to a client. Combine with `fetch` in the same function. Every handler is fully typed; import event types from `@netlify/functions`.
 
-Return a `ReadableStream` body for streamed responses (up to 20 MB):
-
-```typescript
-export default async (req: Request) => {
-  const stream = new ReadableStream({ /* ... */ });
-  return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream" },
-  });
-};
-```
-
-## Event Handlers
-
-A function can subscribe to platform events by exporting an object instead of a function as its default. Each event has a named handler property:
-
-```typescript
-import type { DeploySucceededEvent, UserSignupEvent } from "@netlify/functions";
+```ts title="netlify/functions/on-deploy.mts"
+import type { DeploySucceededEvent, DeployFailedEvent } from "@netlify/functions"
 
 export default {
   deploySucceeded(event: DeploySucceededEvent) {
-    console.log(`Deploy ${event.deploy.id} succeeded`);
+    console.log(`Deploy ${event.deploy.id} succeeded for ${event.site.name}`)
   },
-
-  userSignup(event: UserSignupEvent) {
-    return {
-      user: {
-        ...event.user,
-        appMetadata: { ...event.user.appMetadata, roles: ["member"] },
-      },
-    };
+  deployFailed(event: DeployFailedEvent) {
+    console.log(`Deploy ${event.deploy.id} failed: ${event.deploy.errorMessage}`)
   },
-};
+}
 ```
 
-A single function can declare multiple handlers; multiple functions can also subscribe to the same event.
+**Deploy events** (`event.deploy`, `event.site`; return `void`): `deployBuilding`, `deploySucceeded`, `deployFailed`, `deployDeleted`, `deployLocked`, `deployUnlocked`.
 
-**Available handlers:**
+**Identity events** (`event.user`, only `id` guaranteed):
 
-| Handler | Trigger |
-|---|---|
-| `fetch` | HTTP request (equivalent to a bare function default export) |
-| `deployBuilding` / `deploySucceeded` / `deployFailed` / `deployDeleted` / `deployLocked` / `deployUnlocked` | Deploy lifecycle |
-| `userSignup` / `userLogin` / `userValidate` / `userModified` / `userDeleted` | Identity lifecycle |
-| `formSubmitted` | Form submission verified |
+| Handler | Can deny? | Can mutate? |
+|---|---|---|
+| `userValidate` | Yes | Yes |
+| `userSignup` | Yes | Yes |
+| `userLogin` | Yes | Yes |
+| `userModified` | Yes | Yes |
+| `userDeleted` | No | No |
 
-### Identity handlers: deny an action
+- Deny: call `event.deny()` inside the handler → end user gets `401`. First function to deny aborts the chain.
+- Mutate: return `{ user: {...} }` to persist changes; return `undefined` to pass through.
 
-`userSignup`, `userLogin`, `userValidate`, and `userModified` can reject the action by calling `event.deny()`. The end user receives a 401; no observability error is produced (unlike throwing).
+**Form events**: `formSubmitted` → `event.data` (object keyed by field name). Return `void`.
 
-```typescript
-export default {
-  userLogin(event: UserLoginEvent) {
-    if (!event.user.email?.endsWith("@example.com")) {
-      return event.deny();
-    }
-  },
-};
+Multiple functions can handle the same event (all run). Netlify signs each event (JWS) and verifies before invoking, blocking external requests. Legacy filename convention (file named after the event, payload via `await req.json()` → `payload`) still works but prefer typed handlers.
+
+## Region
+
+⚠️ Do NOT override `config.region` unless the user states a specific reason (co-located DB/backend, data residency, regional audience). The default `cmh` (US East, Ohio) is deliberate.
+
+When justified — e.g. an EU-resident database:
+
+```ts
+export const config: Config = { path: "/eu-data", region: "dub" }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain.
+Airport codes (self-serve): `cmh`, `dub`, `fra`, `gru`, `iad`, `lhr`, `nrt`, `pdx`, `sfo`, `sin`, `syd`, `yul`. Support-assisted: `cdg`, `mxp`. Each function runs in exactly one region (no multi-region geo-routing). Region selection needs Pro/Enterprise. Framework-adapter-generated functions can't take `export const config` — set region at project level in the UI. After changing region, **redeploy**. Function-level region beats the site-level UI setting.
 
-## Context Object
+## Memory / vCPU
 
-| Property | Description |
-|---|---|
-| `context.params` | Path parameters from config |
-| `context.geo` | `{ city, country: {code, name}, latitude, longitude, subdivision, timezone, postalCode }` |
-| `context.ip` | Client IP address |
-| `context.cookies` | `.get()`, `.set()`, `.delete()` |
-| `context.deploy` | `{ context, id, published }` |
-| `context.site` | `{ id, name, url }` |
-| `context.account.id` | Team account ID |
-| `context.requestId` | Unique request ID |
-| `context.waitUntil(promise)` | Extend execution after response is sent |
+⚠️ Do NOT set `config.memory` or `config.vcpu` speculatively — billing scales linearly with size. Raise them only for known memory/compute-intensive work (AI inference, image/PDF, large JSON/CSV) or observed OOM/timeouts caused by the function's own work.
 
-**`context.geo` and `context.ip` are mocked under `netlify dev`.** Locally these return placeholder values, not your real location or client IP, so a value that looks "stuck" on a default country does not mean your geo code is broken — real geolocation is populated only for deployed functions. To exercise geo branching locally, start dev with the geo flags: `netlify dev --geo=mock --country=DE` forces mock data (`--geo=mock`) and sets the mock country (`--country`). Don't conclude `context.geo` is broken because local values never change.
+When justified (e.g. observed OOM processing large PDFs):
 
-## Environment Variables
-
-Prefer `Netlify.env.get` inside functions:
-
-```typescript
-const apiKey = Netlify.env.get("API_KEY");
+```ts
+export const config: Config = { path: "/heavy", memory: "2gb" } // or memory: 2048
 ```
 
-`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
+- `memory`: 1024–4096 MB. `vcpu`: 0.5–2.0 (0.5 → 1024 MB, 2.0 → 4096 MB). Mutually exclusive; Netlify sizes the other automatically. Needs Credit-based Pro/Enterprise. Via `netlify.toml`: `[functions.heavy]\n  memory = "2gb"`.
 
-**Environment variables have a small total size budget.** Functions run on AWS Lambda, which caps the *combined* size of all environment variables at roughly 4 KB. A single large value — a service-account JSON credential, a PEM private key, a big config blob — can blow past that on its own and break the deploy or the function at runtime. Do not store large payloads in environment variables; keep only small secrets and config (API keys, connection strings) there and move anything large into a bundled file, Netlify Blobs, or a fetch at runtime. There is no Netlify setting that raises this cap.
+## Bundling & files on disk
 
-## Reading Files at Runtime
-
-Only a function's own code and the modules it `import`s are bundled and deployed. A file the function opens from disk at runtime — `fs.readFile`/`readFileSync` on a template, a JSON data file, a WASM binary, a fixture — is **not** part of the bundle unless you declare it. This is a classic "works locally, ENOENT in production" trap: under `netlify dev` the function reads the file straight from your working tree, but the deployed function only contains what was bundled.
-
-Declare runtime-read files with `included_files` in `netlify.toml` so they ship with the function:
+⚠️ Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM) are **not bundled**: works under `netlify dev`, ENOENT in production. Prefer importing static data as a module. Otherwise declare it in `netlify.toml`:
 
 ```toml
 [functions]
-  included_files = ["netlify/functions/templates/**"]
-
-# or scope it to one function:
-[functions."render-email"]
-  included_files = ["netlify/functions/templates/welcome.html"]
+  included_files = ["files/*.md"]
+  external_node_modules = ["package-1"]
 ```
 
-When the data is static, prefer importing it as a module (`import data from "./data.json"`) so bundling is automatic; reach for `included_files` for files you must read from the filesystem at runtime.
+⚠️ The combined env-var limit is **~4 KB** for ALL functions (they run on AWS Lambda) — no Netlify setting raises it. Keep large payloads (service-account JSON, PEM keys) out of env vars; use a bundled file, Blobs, or a runtime fetch.
 
-## Resource Limits
+JS-only esbuild: `[functions]\n  node_bundler = "esbuild"`.
 
-| Resource | Limit |
-|---|---|
-| Synchronous timeout | 60 seconds |
-| Background timeout | 15 minutes |
-| Scheduled timeout | 30 seconds |
-| Memory | 1024 MB default; configurable 1024–4096 MB (see [Memory or vCPU](#memory-or-vcpu)) |
-| Buffered payload | 6 MB |
-| Streamed payload | 20 MB |
+## Limits (not configurable)
 
-## Framework Considerations
+- Synchronous execution: **60s**. Scheduled: **30s**. Background: **15 min**.
+- Buffered request/response payload: **6 MB** (binary is Base64-encoded, ~30% overhead → effective **4.5 MB** binary limit).
+- Streamed response: **20 MB**. Background payload: **256 KB**.
 
-Frameworks with server-side capabilities (Astro, Next.js, Nuxt, SvelteKit, TanStack Start) typically generate their own serverless functions via adapters. You usually do not write raw Netlify Functions in these projects — the framework adapter handles server-side rendering and API routes. Write Netlify Functions directly when:
+## Local testing & deploy
 
-- Using a client-side-only framework (Vite + React SPA, vanilla JS)
-- Adding background or scheduled tasks to any project
-- Building standalone API endpoints outside the framework's routing
+- Most frameworks emulate functions in their dev server. Vite frameworks (Astro, Nuxt, TanStack Start, React Router): install `@netlify/vite-plugin` and run the dev server. Next.js and anything else: use the [Netlify CLI](https://docs.netlify.com/api-and-cli-guides/cli-guides/local-development/) (`netlify dev`).
+- Scheduled functions don't fire on a schedule locally — invoke once with `netlify functions:invoke <name>`.
+- Deploy: push to Git for continuous deployment, or use the Netlify CLI/API.
+- Logs & metrics live in the Netlify UI; stream with the CLI.
 
-See the **netlify-frameworks** skill for adapter setup.
+## Node runtime version
+
+Runtime follows the build's Node.js version (fallback: Node.js 24). Override by setting env var `AWS_LAMBDA_JS_RUNTIME` (e.g. `nodejs24.x`) via UI/CLI/API — **not** `netlify.toml` — then redeploy. ES modules: `__dirname`/`__filename` unavailable, use `import.meta.url`; named imports of CommonJS packages fail, use a default import.
+
+## Legacy / Go (avoid unless needed)
+
+Go must use the [Lambda-compatible API](https://docs.netlify.com/build/functions/lambda-compatibility/?fn-language=go); Go routing/region/memory are set in `netlify.toml`. For migrating Lambda-style JS/TS, `@netlify/aws-lambda-compat` wraps an AWS handler:
+
+```ts
+import { withLambda } from "@netlify/aws-lambda-compat"
+import type { HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/aws-lambda-compat"
+
+export default withLambda(async (event: HandlerEvent, context: HandlerContext): Promise<HandlerResponse> => {
+  const name = event.queryStringParameters?.name ?? "World"
+  return { statusCode: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ name }) }
+})
+```
+
+Lambda-compat mode enforces the 4 KB env-var limit; [upgrade to modern functions](https://developers.netlify.com/guides/migrating-to-the-modern-netlify-functions/) to remove it.
+
+<!-- system: agent-context/functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (functions)
+
+These are org conventions, not docs facts — they are merged into the rendered
+skill by ctx-gen and are never generated. Extracted from the previous
+hand-written netlify-functions skill; owned by the skills maintainer.
+
+1. Use TypeScript (`.mts`) when possible.
+2. Access environment variables via `Netlify.env.get()` (prefer it over
+   `process.env` for consistency).
+3. Never add CORS headers unless explicitly requested.
+4. Store secrets in environment variables, never in code.
+5. `context.geo` and `context.ip` are mocked under `netlify dev` — placeholder
+   values, not the real location or client IP. Don't conclude geo code is
+   broken because local values never change; exercise branches with
+   `netlify dev --geo=mock --country=DE` and verify on a deploy.
+6. Do NOT set `config.memory` or `config.vcpu` speculatively. Raise them only
+   for known memory/compute-intensive work or observed OOM/timeouts caused by
+   the function's own work — billing scales linearly with size.
+7. Do NOT override `config.region` unless the user has stated a specific
+   reason (co-located database/backend, data residency, regional audience).
+   The `cmh` default is a deliberate choice.
+8. Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM)
+   are not bundled: works under `netlify dev`, ENOENT in production. Prefer
+   importing static data as a module; otherwise declare the file with a
+   scoped `included_files` entry in `netlify.toml`.
+9. The ~4 KB combined environment-variable limit applies to ALL functions
+   (they run on AWS Lambda), not just Lambda-compat mode. Keep large payloads
+   (service-account JSON, PEM keys) out of env vars — use a bundled file,
+   Blobs, or a runtime fetch. No Netlify setting raises this cap.
+10. The body's FIRST function example must be the minimal default: no
+    `config` export at all, stating the function serves at
+    `/.netlify/functions/<name>`. Custom `path` routing appears only in a
+    later example — agents imitate the first example they see.
+11. Never demonstrate `memory`, `vcpu`, or `region` in a generic example —
+    show them only attached to an explicit stated reason (observed OOM,
+    co-located backend, data residency).
+12. Scheduled-function examples use a real cron expression with the UTC
+    conversion spelled out (e.g. 9 AM ET → `"0 13 * * *"` UTC, noting DST) —
+    never only `@hourly`/`@daily` shortcuts, which can't target a specific
+    local hour.
+13. The body must state that `[[headers]]` in netlify.toml, `_headers`, and
+    redirect header rules apply ONLY to static CDN responses — response
+    headers for a function are set in code on the returned `Response`.

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -1,464 +1,293 @@
 ---
-description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity` for new projects; `netlify-identity-widget` and `gotrue-js` still work but are no longer recommended.
+description: Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social login (Google/GitHub/GitLab/Bitbucket), server-side user verification in Functions, role-based access control (RBAC), admin user management, and Identity event hooks. Use when adding a login/signup flow, "add social login", gating content by user role, protecting a function or page behind auth, assigning roles at signup, customizing auth emails, or handling OAuth/confirmation/recovery callbacks. Not for locking an entire site to a company/team — that is netlify-access-control.
 alwaysApply: false
 ---
 
 # Netlify Identity
 
-Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+Auth and user management for a Netlify site without requiring visitors to be Netlify users. Package: `@netlify/identity`.
 
-**Always use `@netlify/identity` for new projects.** `netlify-identity-widget` and `gotrue-js` still work and are maintained, but are no longer the recommended choice. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+**Reach for `@netlify/identity`.** Do NOT use the legacy `netlify-identity-widget` or `gotrue-js` for new work — same capabilities, simpler API, built-in server-side support.
 
-## Identity is app-level — don't confuse it with site access control
+## Footguns — read first
 
-Netlify Identity manages **your app's end users** (signups, logins, roles) and issues the `nf_jwt` cookie. It is a different layer from **Secure Access / Password Protection**, which gates *who can load the site at all* (Basic shared-password is Pro+; team-login/SAML gating is Enterprise), and from **Team/Org SAML SSO**, which controls *who can log in to the Netlify dashboard*. The same provider can appear in more than one (Google, say): Google as an Identity OAuth provider signs in *app users*; Google as a SAML IdP signs in *Netlify team members*. They are unrelated systems with separate sessions, which is where the confusion comes from.
-
-If the task involves "lock this site to my company," "only employees can access it," password protection, or SSO at the site/team level, **read the `netlify-access-control` skill first** to pick the right layer. This skill covers the app-level user-management layer only.
-
-## Dashboard configuration (user handoff required)
-
-**All Identity instance configuration is dashboard-only — there is no public API.** The agent owns the code, deploys, and the handoff checklist; the user owns flipping dashboard settings. Outside of a Netlify Agent Runner deploy, the Identity instance must be enabled in the dashboard before any auth flow will work. If you write Identity code first and only discover this when `/.netlify/identity/signup` 404s after a production deploy, that's wasted work — surface the dashboard handoff up front instead.
-
-**Dashboard URL pattern:** `https://app.netlify.com/projects/<project-slug>/configuration/identity` (it's under project configuration — not under Integrations, and not a top-level sidebar item).
-
-### Dashboard-only operations
-
-- **Enable Identity** — turns the Identity instance on for the site. **Required** before any auth flow works.
-- **Registration mode** — Open (anyone can sign up, the default) or Invite only.
-- **Autoconfirm** — ON skips the email-confirmation step on signup; OFF requires the new user to click a confirmation email before they can log in.
-- **External providers** — Add Google / GitHub / GitLab / Bitbucket. The "Use Netlify's app" option means no `client_id`/`secret` needed — good for prototypes. Adding an OAuth provider does NOT disable email/password — email/password is always available unless the front-end omits it.
-- **Custom email templates / SMTP** — advanced; out of scope for typical prototypes.
-
-There is no CLI command and no public API for any of these. **Do not** curl `https://api.netlify.com/...` to flip toggles, **do not** read auth tokens out of `~/Library/Preferences/netlify/config.json`, and **do not** probe for an undocumented endpoint. Give the user the dashboard URL and exact checklist instead.
-
-### Agent/user sequence
-
-1. Agent asks any missing auth-shape questions before scaffolding.
-2. Agent writes the Identity code and runs a draft deploy.
-3. User enables Identity and any OAuth providers in the dashboard using the handoff checklist.
-4. Agent verifies the draft URL and then runs the production deploy.
-
-### Recommended settings per use case
-
-| Use case | Registration | Autoconfirm | External providers |
-|---|---|---|---|
-| Prototype / demo | Open | ON | as requested |
-| Production with email signup | Open or Invite per product | OFF (real email confirmation) | configured with custom email templates / SMTP as needed |
-
-### Handoff checklist
-
-When the dashboard work is needed, give the user a copy-pasteable checklist **between the draft deploy and the production deploy** — not after the prod deploy fails:
-
-```
-Before this works end-to-end, flip these in the Netlify dashboard at
-https://app.netlify.com/projects/<your-slug>/configuration/identity:
-
-- [ ] Identity → Enable
-- [ ] Registration → Open (default) or Invite only
-- [ ] Autoconfirm → ON for prototypes; OFF for prod with email confirmation
-- [ ] External providers → Add Google (etc.) with "Use Netlify's app"
-
-Tell me when these are flipped and I'll run the production deploy.
-```
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any auth code — the answers shape both the dashboard config above and the auth UI you'll write:
-
-- Should the whole site be locked so only your company/team can even load it (a perimeter), should it be public with per-user accounts inside the app, or both? This decides whether Netlify Identity alone is enough or you also need site-level access control — if "company-only" or "both" comes up, check the `netlify-access-control` skill before scaffolding.
-- Which sign-in methods should this app expose: email/password, OAuth, or both?
-- Which parts of the app need authenticated access: the whole app, specific routes, or only specific actions?
-- Who can create accounts: public signup or invite-only?
-- Should new email/password users be able to log in immediately for a prototype (Autoconfirm ON), or confirm by email first for production (Autoconfirm OFF)?
-- Which OAuth providers should be enabled (Google, GitHub, GitLab, Bitbucket)?
-
-**If you don't have preferences here, tell me what you want overall and I'll pick sensible defaults** — typically email/password + Google OAuth, autoconfirm ON, registration Open for a prototype.
-
-Asking these *after* coding causes rework — both the auth UI shape and the dashboard config fall out of these answers.
-
-## When something fails, surface and stop
-
-If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
-
-## Never hardcode secrets
-
-Never hardcode secrets. Identity URLs, GoTrue endpoints, and OAuth `client_id`/`secret` values do not belong in client or server code — configure OAuth credentials in the Netlify dashboard, not the frontend, and store anything sensitive as a Netlify environment variable (mark it secret). The Identity **admin token** is not one of these: you don't set or read it — the Netlify Functions runtime injects it automatically for `admin.*` calls made inside a Function (see [Authorization and sessions](references/authorization-and-sessions.md)). Never hardcode an admin token or expose admin operations to the browser.
+- **Identity does not work under `netlify dev`.** Test auth flows on a deploy — Deploy Previews work. Local `netlify dev` cannot exercise `/.netlify/identity/*`.
+- **Never build a from-scratch third-party OAuth flow beside Identity** — no provider app registration in code, no `client_id`/`secret` in code, no custom callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`. Raw OAuth beside Identity is the single most common source of rework.
+- **Identity config has no public API — dashboard only.** Never curl `api.netlify.com` to flip/inspect Identity settings, never read tokens from `~/Library/Preferences/netlify/config.json`, never probe undocumented endpoints.
+- **RBAC redirects without a fallback = raw 404.** A visitor lacking the role gets a bare 404 with no way to log in. Always add a fallback rule.
+- **Server-side `login()`/`signup()`/`logout()` need CSRF protection.** Call `verifyRequestOrigin(req)` first, or an attacker can log a victim into the attacker's account.
+- **Site-gating** ("lock this site to my company", employees-only) → route to **netlify-access-control** first. Identity is the app-level user layer only.
+- **On failure** (callback 404s, `/.netlify/identity/*` unreachable, OAuth doesn't return): surface the error, the dashboard URL, and the setting to check — then stop. Do not invent recovery commands.
 
 ## Setup
+
+Identity must be enabled in the dashboard first (no API): **Project configuration > Identity** (`https://app.netlify.com/projects/{site_name}/configuration/identity`) → **Enable Identity**.
 
 ```bash
 npm install @netlify/identity
 ```
 
-The Identity instance must be enabled in the dashboard first (see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above). The one exception: a deploy created by a Netlify Agent Runner session that includes Identity code auto-enables the instance.
+HTTPS is required. On a custom domain, get HTTPS/SSL working before integrating Identity.
 
-### Local Development
+## Client / universal auth
 
-Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+```ts
+import { signup, login, logout, getUser, oauthLogin, handleAuthCallback } from '@netlify/identity'
 
-## Quick Start
+// Sign up — sends a confirmation email by default (skippable via autoconfirm setting)
+const user = await signup('jane@example.com', 'securepassword', { full_name: 'Jane Doe' })
 
-Log in from the browser:
+// Log in / log out
+await login('jane@example.com', 'securepassword')
+await logout()
 
-```typescript
-import { login, getUser } from '@netlify/identity'
+// Current user — null if not logged in (works in browser + server)
+const u = await getUser()
+if (u) console.log(u.email)
 
-const user = await login('user@example.com', '<password>')
-console.log(`Hello, ${user.name}`)
-
-// Later, check auth state
-const currentUser = await getUser()
+// OAuth — redirects browser to provider login
+oauthLogin('github') // 'google' | 'github' | 'gitlab' | 'bitbucket'
 ```
 
-Protect a Netlify Function:
+**Callback handling is mandatory.** Call `handleAuthCallback()` on your landing page. It processes ALL token types in the URL hash — OAuth redirect, email confirmation, password recovery, invite. Without it, confirmation links and OAuth redirects never complete.
 
-```typescript
-// netlify/functions/protected.mts
+```ts
+import { handleAuthCallback } from '@netlify/identity'
+
+const result = await handleAuthCallback()
+if (result) console.log(result.type, result.user.email) // may be falsy if nothing to process
+```
+
+Other client functions:
+- `recoverPassword()` — complete a password reset (alternative to letting `handleAuthCallback()` handle the `recovery_token`).
+- `acceptInvite()` — complete invite acceptance (alternative to `handleAuthCallback()` handling `invite_token`).
+- `refreshSession()` — refresh token/session so newly-assigned roles take effect.
+
+**Don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns.
+
+## Server-side (Functions / Edge Functions)
+
+Handlers are modern v2 functions: `export default async (req, context) => {}`. **v1 `export { handler }` is not supported** for `getUser()`/`login()`/`admin.*`.
+
+```ts
 import { getUser } from '@netlify/identity'
-import type { Context } from '@netlify/functions'
+import type { Context } from '@netlify/functions'      // or '@netlify/edge-functions' for Edge
 
 export default async (req: Request, context: Context) => {
   const user = await getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
+  if (!user.roles.includes('admin')) return new Response('Forbidden', { status: 403 })
   return Response.json({ id: user.id, email: user.email })
 }
 ```
 
-`getUser()` reads the request's `nf_jwt` cookie automatically — no argument is needed in a function or edge function. Server-side auth (`getUser`, `login`, `admin.*`) requires a **modern v2 function** (`export default`); v1 Lambda-compatible functions (`export { handler }`) are not supported.
+`getUser()` works in browser, Netlify Functions, and Edge Functions.
 
-## Core API
+**CSRF — always guard exposed `login`/`signup`/`logout` endpoints:**
 
-Import and use headless functions directly:
+```ts title="netlify/functions/login.ts"
+import { login, verifyRequestOrigin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-```typescript
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  signup,
-  oauthLogin,
-  onAuthChange,
-  getSettings,
-} from '@netlify/identity'
-```
-
-### Login
-
-```typescript
-import { login, AuthError } from '@netlify/identity'
-
-async function handleLogin(email: string, password: string) {
-  try {
-    const user = await login(email, password)
-    showSuccess(`Welcome back, ${user.name ?? user.email}`)
-  } catch (error) {
-    if (error instanceof AuthError) {
-      // Bad credentials → GoTrue returns 400 (invalid_grant) server-side; in the
-      // browser the status is undefined, so fall back to the message there.
-      showError(error.status === 400 ? 'Invalid email or password.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  verifyRequestOrigin(req)   // throws 403 on Origin mismatch; supports { allowedOrigins }
+  const { email, password } = await req.json()
+  await login(email, password)
+  return new Response(null, { status: 302, headers: { Location: '/dashboard' } })
 }
 ```
 
-### Signup
+### admin — Netlify Functions ONLY
 
-After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+`admin.*` uses a short-lived admin token and runs **only in Netlify Functions** — NOT browser, NOT Edge Functions.
 
-```typescript
-import { signup, AuthError } from '@netlify/identity'
+```ts
+import { admin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-async function handleSignup(email: string, password: string, name: string) {
-  try {
-    const user = await signup(email, password, { full_name: name })
-    if (user.emailVerified) {
-      // Autoconfirm ON — user is logged in immediately
-      showSuccess('Account created. You are now logged in.')
-    } else {
-      // Autoconfirm OFF — confirmation email sent
-      showSuccess('Check your email to confirm your account.')
-    }
-  } catch (error) {
-    if (error instanceof AuthError) {
-      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  const users = await admin.listUsers()   // array of users
+  return Response.json({ total: users.length })
 }
 ```
 
-### Logout
+- `admin.listUsers()` — array of users.
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
 
-```typescript
-import { logout } from '@netlify/identity'
+### Session cookies
+JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.
 
-await logout()
-```
+### The `User` object
+`id`, `email`, `roles` (array from `app_metadata.roles`, included in the JWT).
 
-### OAuth
+## Identity event functions
 
-**When Netlify Identity is the goal, never build a from-scratch third-party OAuth flow.** Don't tell the user to go register their own Google/GitHub OAuth app, don't ask for a `client_id`/`secret`, and don't write your own `/auth/callback` token-exchange handler. Identity already brokers the OAuth handshake: the provider is enabled in the dashboard with the **"Use Netlify's app"** option (no credentials needed — see the handoff checklist above), and your code just calls `oauthLogin(provider)` + `handleAuthCallback()`. Scaffolding raw OAuth alongside Identity is the single most common source of rework in this flow — it produces two competing auth systems that then have to be untangled by hand. Custom OAuth credentials exist only to *brand* the consent screen, and even then they're pasted into the dashboard, not wired into app code.
+Functions the platform invokes automatically on Identity events (you don't call them).
 
-OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+**Modern typed-handler syntax** — export a default object with a method per event. Typed handlers require `@netlify/functions` ≥ 5.2.0.
 
-```typescript
-import { oauthLogin } from '@netlify/identity'
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
-// Step 1: Redirect to provider (navigates away — never returns)
-function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
-  oauthLogin(provider)
+export default {
+  userSignup(event: UserSignupEvent) {
+    console.log(`New signup: ${event.user.email}`)
+  },
 }
 ```
 
-Providers must be enabled in the dashboard before `oauthLogin()` works — see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above. Registration is Open by default, so OAuth users can create accounts without any extra signup-related configuration; only the provider itself must be enabled.
+Handlers and triggers:
 
-Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, omit the email/password form from your UI; the front-end is the gate.
-
-### Handling Callbacks
-
-Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
-
-```typescript
-import { handleAuthCallback, AuthError } from '@netlify/identity'
-
-async function processCallback() {
-  try {
-    const result = await handleAuthCallback()
-    if (!result) return // No callback hash — normal page load
-
-    switch (result.type) {
-      case 'oauth':
-        showSuccess(`Logged in as ${result.user?.email}`)
-        break
-      case 'confirmation':
-        showSuccess('Email confirmed. You are now logged in.')
-        break
-      case 'recovery':
-        // User is authenticated but must set a new password
-        showPasswordResetForm(result.user)
-        break
-      case 'invite':
-        // User must set a password to accept the invite
-        showInviteAcceptForm(result.token)
-        break
-      case 'email_change':
-        showSuccess('Email address updated.')
-        break
-    }
-  } catch (error) {
-    if (error instanceof AuthError) showError(error.message)
-  }
-}
-```
-
-### Auth State
-
-```typescript
-import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
-
-// Check current user (never throws — returns null if not authenticated)
-const user = await getUser()
-
-// Subscribe to auth state changes (returns unsubscribe function)
-const unsubscribe = onAuthChange((event, user) => {
-  switch (event) {
-    case AUTH_EVENTS.LOGIN:
-      console.log('Logged in:', user?.email)
-      break
-    case AUTH_EVENTS.LOGOUT:
-      console.log('Logged out')
-      break
-    case AUTH_EVENTS.TOKEN_REFRESH:
-      break
-    case AUTH_EVENTS.USER_UPDATED:
-      console.log('Profile updated:', user?.email)
-      break
-    case AUTH_EVENTS.RECOVERY:
-      console.log('Password recovery initiated')
-      break
-  }
-})
-```
-
-### Settings-Driven UI
-
-You cannot see a project's live Identity configuration while you are writing the code — there is no API, MCP tool, or CLI command that reports whether Identity is enabled or which providers are on; that state lives in the dashboard. So **don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns, so the UI matches whatever the user actually enabled — and a provider you assumed was on but isn't won't render a dead button. (`getSettings()` hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev`, which proxies to the live service — but it can't tell you anything pre-run, so ask the user what's configured while you're still scaffolding.)
-
-```typescript
-import { getSettings } from '@netlify/identity'
-
-const settings = await getSettings()
-// settings.autoconfirm — boolean
-// settings.disableSignup — boolean
-// settings.providers — Record<AuthProvider, boolean>
-
-if (!settings.disableSignup) showSignupForm()
-
-for (const [provider, enabled] of Object.entries(settings.providers)) {
-  if (enabled) showOAuthButton(provider)
-}
-```
-
-## Minimal React Example
-
-```tsx
-import { useEffect, useState } from 'react'
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  oauthLogin,
-  onAuthChange,
-} from '@netlify/identity'
-
-function App() {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    ;(async () => {
-      await handleAuthCallback()
-      setUser(await getUser())
-      setLoading(false)
-    })()
-    return onAuthChange((_event, currentUser) => setUser(currentUser))
-  }, [])
-
-  const handleLogin = async (email, password) => {
-    const currentUser = await login(email, password)
-    setUser(currentUser)
-  }
-
-  const handleGoogleLogin = () => oauthLogin('google')
-
-  const handleSignOut = async () => {
-    await logout()
-    setUser(null)
-  }
-
-  if (loading) return <p>Loading...</p>
-  // Render login form or user details based on `user` state
-}
-```
-
-## Error Handling
-
-`@netlify/identity` throws two error classes:
-
-- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
-- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
-
-`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
-
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid login credentials — wrong email/password (GoTrue `invalid_grant`) |
-| 401 | Missing, invalid, or expired bearer token on an authenticated endpoint |
-| 403 | Action not allowed (e.g., signups disabled) |
-| 422 | Validation error (e.g., weak password, malformed email) |
-| 404 | User or resource not found |
-
-Note: in the browser, `login()` surfaces gotrue-js failures as an `AuthError` with `status` **undefined** (the HTTP status isn't propagated), so don't branch on `status` for bad-credentials UX there — fall back to `error.message`. Server-side (`login()` in a Function) passes the real status through, so `400` is reliable.
-
-## Identity Event Functions
-
-Functions can subscribe to Identity lifecycle events by exporting an object whose properties are named event handlers. See the **netlify-functions** skill for the full event-handler pattern.
-
-The typed handler API below (the `userSignup`/`userValidate`/… object export, the typed `*Event` types, and `event.deny()`) requires **`@netlify/functions` ≥ 5.2.0** — it isn't present in 5.1.x. On older installs, use the legacy filename convention described at the end of this section.
-
-**Available identity handlers:**
-
-| Handler | Trigger |
+| Handler | Fires when |
 |---|---|
-| `userValidate` | User attempts to sign up. Can deny. |
-| `userSignup` | User completes signup. Can deny or mutate. |
-| `userLogin` | User logs in. Can deny or mutate. |
-| `userModified` | User profile is updated. Can deny or mutate. |
-| `userDeleted` | User is deleted. Notification only. |
+| `userValidate` | User attempts signup, before account creation — block by email domain, rate-limit, custom validation. |
+| `userSignup` | Signup completes (email or external). Fires *after* email confirmation if confirmation is enabled. Assign roles, sync, notify. |
+| `userLogin` | User logs in — track logins, sync, block a user. |
+| `userModified` | Profile updated. |
+| `userDeleted` | User deleted (notification only). |
 
-Each handler receives a typed event with a parsed `user` object (camelCase fields: `appMetadata`, `userMetadata`, `confirmedAt`, etc.).
+**Deny an action:** call `event.deny()` from `userValidate`/`userSignup`/`userLogin`/`userModified` (NOT `userDeleted`). User gets a `401`; no observability error. With multiple subscribers, the first `event.deny()` aborts the chain.
 
-### Mutate the user
+```typescript title="netlify/functions/identity.mts"
+import type { UserValidateEvent } from "@netlify/functions"
 
-Return `{ user: ... }` to substitute the user record before it's persisted. This is the common pattern for role assignment at signup.
+export default {
+  userValidate(event: UserValidateEvent) {
+    if (!event.user.email?.endsWith("@example.com")) return event.deny()
+  },
+}
+```
 
-```typescript
-// netlify/functions/identity.mts
-import type { UserSignupEvent } from '@netlify/functions'
+**Assign roles at signup** — return `{ user: {...} }` to mutate the persisted record. Payload fields are **camelCase** (`appMetadata`, `userMetadata`, `confirmedAt`).
+
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
 export default {
   userSignup(event: UserSignupEvent) {
     return {
-      user: {
-        ...event.user,
-        appMetadata: {
-          ...event.user.appMetadata,
-          roles: ['member'],
-        },
-      },
+      user: { ...event.user, appMetadata: { ...event.user.appMetadata, roles: ["member"] } },
     }
   },
 }
 ```
 
-### Deny an action
+**Background mode** — action completes immediately, handler runs async:
 
-Call `event.deny()` to reject a signup, login, validation, or modification. The end user receives a 401. Do not throw — `event.deny()` is the canonical denial mechanism and does not produce an error in observability.
+```typescript title="netlify/functions/identity.mts"
+import type { Config, UserLoginEvent } from "@netlify/functions"
 
-```typescript
-import type { UserValidateEvent } from '@netlify/functions'
-
-export default {
-  userValidate(event: UserValidateEvent) {
-    if (!event.user.email?.endsWith('@example.com')) {
-      return event.deny()
-    }
-  },
-}
+export default { userLogin(event: UserLoginEvent) { /* async tracking */ } }
+export const config: Config = { background: true }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain — subsequent functions are not invoked.
+Event types from `@netlify/functions`: `UserValidateEvent`, `UserSignupEvent`, `UserLoginEvent`, `UserModifiedEvent`, `UserDeletedEvent`, `Config`.
 
-### Legacy filename convention
+## Registration & providers (dashboard)
 
-The previous syntax — files named `identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, exporting `handler` and signaling denial via non-2xx response — still works. New functions should prefer the typed handler syntax above.
+- **Registration preferences** — **Open** (default: any visitor signs up via `signup()`) or **Invite only** (all new users, including external-provider logins, must be invited first).
+- **Confirmation:** open registration sends a confirmation email; skip via **Emails > Confirmation template > Configure** (allow signup without verifying email / autoconfirm).
+- **External providers** — enable Google/GitHub/GitLab/Bitbucket under **Registration > External providers**. Set your own client ID/secret for branded OAuth (your app name shows on the provider screen). No email confirmation for external-provider signup, but Invite-only still requires an invite.
+- **Invitations** — **Project configuration > Identity > Users**; Netlify team users with any role can invite. Invite link carries an `invite_token` → process with `handleAuthCallback()` or `acceptInvite()`.
 
-## Roles and Authorization
+## Roles & metadata
 
-### First Admin User
+Stored on the User object; edit in **Identity > Users > Edit settings**:
+- **Name** — user-editable: `user_metadata.full_name`.
+- **Email** — user-editable; triggers email-change confirmation; changes login credentials: `user_metadata.email`.
+- **Roles** — NOT user-editable: `app_metadata.roles`. Read via `getUser()`.
 
-The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
+Set roles: at signup via `userSignup` handler returning `{ user: {...} }`; for existing users via `admin.updateUser()` in a Function. **Role changes take effect on next login or token refresh**, not immediately (they don't invalidate the current JWT — client can `refreshSession()`).
 
-1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
-2. Click **Invite users** and enter the admin user's email address
-3. After the user accepts the invite, click the user in the Identity list to open their detail page
-4. In the **Roles** field, add the `admin` role and save
+## Role-based access control (redirect rules)
 
-Once the first admin exists, subsequent users can be managed programmatically using Identity event functions (e.g., assigning roles in `identity-signup`) or role-based redirects.
+Enforced at the CDN edge (no origin round trip). Add a `Role` parameter to redirect rules.
 
-- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
-- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+```
+# _redirects — ALWAYS include a fallback or non-admins get a raw 404
+/admin/*  /admin/:splat  200!  Role=admin
+/admin/*  /login         401!
 
-### Role-Based Redirects
+# multiple roles, comma-chained
+/private/* /private/:splat  200!  Role=editor,admin
+```
 
 ```toml
 # netlify.toml
 [[redirects]]
   from = "/admin/*"
   to = "/admin/:splat"
+  force = true
   status = 200
-  conditions = { Role = ["admin"] }
-
-[[redirects]]
-  from = "/admin/*"
-  to = "/"
-  status = 302
+  conditions = {Role = ["editor", "admin"]}
 ```
 
-Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+Netlify Identity roles resolve at `app_metadata.roles`.
 
-## References
+### External JWT provider (Enterprise; alternative to Identity)
+You may use Identity **OR** an external JWT provider, **not both** — you cannot authenticate third-party JWT tokens while Identity is enabled. Set the secret at **Project configuration > Access & security > Visitor access > JWT secret** (project-level overrides team-level default).
 
-- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration
-- [Authorization and sessions](references/authorization-and-sessions.md) — where role gating is actually enforced (server-side vs client-side / SPA navigation), admin operations being Functions-runtime-only, and why a role change doesn't apply until the JWT refreshes
+- Tokens must be **HS256**; header requires `"alg": "HS256"`, `"typ": "JWT"`.
+- Payload requires `exp` (future Unix Epoch); other fields optional.
+- External-provider roles resolve at `app_metadata.authorization.roles`. Different path → contact support for a custom role path (support-configured, not self-service).
+
+## Emails (Pro+ for customization)
+
+Default sender `no-reply@netlify.com`. Custom sender (Pro+): set SMTP hostname/port/username/password under **Emails > Outgoing email address** (use SendGrid/Mailjet/etc. for volume).
+
+Custom templates (Pro+): publish HTML to a path on your deployed project, set the path (relative to domain, starting `/`) under **Emails**. Rules: inline CSS only, absolute image links, NO `<html>`/`<head>`/`<body>` tags. Keep template variables intact — don't let your build rewrite them.
+
+Go template variables: `{{ .Email }}`, `{{ .NewEmail }}` (email-change only), `{{ .SiteURL }}`, `{{ .ConfirmationURL }}`, `{{ .Token }}`. Custom link form: `{{ .SiteURL }}/path/#confirmation_token={{ .Token }}` (also `invite_token`, `recovery_token`, `email_change_token`).
+
+## Audit log (Pro+)
+
+**Project configuration > Identity > Identity audit log**. Search with a required scope prefix: `author:[string]` or `action:[string]`. Action names: `login`, `logout`, `user_signedup`, `user_deleted`, `user_modified`, `token_revoked`, `token_refreshed`, `user_recovery_requested`, `user_invited`.
+
+## Plan gating
+
+- Identity itself: all credit-based plans, no extra cost. Unlimited active + invite-only users, custom OAuth credentials, Functions integration — all plans.
+- **Pro+ only:** custom outgoing email, custom email templates, Identity audit log.
+- **Enterprise only:** external JWT providers.
+
+## Deep guides
+
+- `references/advanced-patterns.md` — SSR / session hydration.
+- `references/authorization-and-sessions.md`.
+
+## Legacy (avoid for new work)
+
+- `netlify-identity-widget` / `gotrue-js` — superseded by `@netlify/identity`.
+- Legacy event-function filenames (`identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, `-background` suffix) still work but prefer typed handlers. Legacy denial = return non-2xx status; new code uses `event.deny()`.
+
+<!-- getSettings() referenced in house rules but not documented in sources; its return shape/signature is not specified in the intermediate. -->
+
+<!-- system: agent-context/identity/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (identity)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Deep guides live in this skill: `references/advanced-patterns.md`
+   (SSR/session hydration) and `references/authorization-and-sessions.md`.
+2. Identity does not work under `netlify dev` — test auth flows on deploys
+   (Deploy Previews work).
+3. Identity configuration has no public API — it is dashboard-only. Never curl
+   `api.netlify.com` to flip or inspect Identity settings, never read auth
+   tokens from `~/Library/Preferences/netlify/config.json`, never probe for
+   undocumented endpoints.
+4. On failure (callback 404s, `/.netlify/identity/*` unreachable, OAuth flow
+   doesn't return), surface the error, the dashboard URL, and the setting to
+   check — then stop. Do not invent recovery commands.
+5. Never build a from-scratch third-party OAuth flow when Identity is in play —
+   no provider app registration, no `client_id`/`secret` in code, no custom
+   callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`;
+   raw OAuth beside Identity is the single most common source of rework.
+6. Server-side `getUser()`/`login()`/`admin.*` require modern v2 functions
+   (`export default`) — v1 `export { handler }` is not supported. Typed
+   Identity event handlers (`UserSignupEvent`, `event.deny()`) require
+   `@netlify/functions` ≥ 5.2.0; older installs use the legacy filenames.
+7. Don't hard-code which auth providers exist — call `getSettings()` at
+   startup and render the signup form and OAuth buttons from what it returns.
+8. Site-gating requests ("lock this site to my company", employees-only)
+   route to the netlify-access-control skill first — Identity is the
+   app-level user layer only.

--- a/cursor/rules/netlify-image-cdn.mdc
+++ b/cursor/rules/netlify-image-cdn.mdc
@@ -1,99 +1,157 @@
 ---
-description: Guide for using Netlify Image CDN for image optimization and transformation. Use when serving optimized images, creating responsive image markup, setting up user-uploaded image pipelines, or configuring image transformations. Covers the /.netlify/images endpoint, query parameters, remote image allowlisting, clean URL rewrites, and composing uploads with Functions + Blobs.
+description: Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use when adding responsive images, generating thumbnails, converting formats (avif/webp/png), cropping to aspect ratios, tuning image quality, creating blurred placeholders, allowlisting remote image domains, serving user-uploaded images, or wiring framework image components (Next.js, Astro, Nuxt, Angular, Gatsby) to Netlify. Triggers on tasks like "optimize images", "add image thumbnails", "resize images on the fly", "serve images from an external domain", or "add blur placeholders".
 alwaysApply: false
 ---
 
 # Netlify Image CDN
 
-Every Netlify site has a built-in `/.netlify/images` endpoint for on-the-fly image transformation. No configuration required for local images.
+Transform images by requesting `/.netlify/images` with query parameters. No function or file authoring required — it's a built-in edge endpoint.
 
-## Basic Usage
-
-```html
-<img src="/.netlify/images?url=/photo.jpg&w=800&h=600&fit=cover&q=80" />
+```bash
+# resize + crop to a 50px square, retain left side, convert to webp at q=80
+curl -vs 'https://mysitename.netlify.app/.netlify/images?url=/owl.jpeg&fit=cover&w=50&h=50&position=left&fm=webp&q=80'
 ```
 
-## Query Parameters
+There is no legacy/deprecated form — the endpoint above is the only programmatic surface. Use framework image components where available (below) rather than hand-building URLs.
 
-| Param | Description | Values |
+## Endpoint & query parameters
+
+`GET /.netlify/images?url=<source>&...`
+
+| Param | Values | Notes |
 |---|---|---|
-| `url` | Source image path (required) | Relative path or absolute URL |
-| `w` | Width in pixels | Any positive integer |
-| `h` | Height in pixels | Any positive integer |
-| `fit` | Resize behavior | `contain` (default), `cover`, `fill` |
-| `position` | Crop alignment (with `cover`) | `center` (default), `top`, `bottom`, `left`, `right` |
-| `fm` | Output format | `avif`, `webp`, `jpg`, `png`, `gif`, `blurhash` |
-| `q` | Quality (lossy formats) | 1-100 (default: 75) |
+| `url` | relative path or full remote URL | **REQUIRED**. Only required param. |
+| `w` | integer px | width |
+| `h` | integer px | height |
+| `fit` | `contain` (default), `cover`, `fill` | resize behavior |
+| `position` | `center` (default), `top`, `bottom`, `left`, `right` | only applies when `fit=cover` |
+| `fm` | `avif`, `jpg`, `png`, `webp`, `gif`, `blurhash` | output format; `webp`/`gif` can be animated |
+| `q` | integer `1`–`100` (default `75`) | only for `avif`, `jpg`, `gif`, `webp` |
 
-When `fm` is omitted, Netlify auto-negotiates the best format based on browser support (preferring `webp`, then `avif`).
+### `fit` behavior
 
-### `fm=blurhash` returns a string, not an image
+| `fit=` | aspect ratio kept | crops excess | returns exact dimensions |
+|---|---|---|---|
+| `contain` | yes | no | no — one dimension may be smaller |
+| `cover` | no | yes | yes — scaled proportionally, then cropped |
+| `fill` | no | no | yes — stretched/squished if needed |
 
-`fm=blurhash` is special: the response body is a short BlurHash **text string**, not image bytes. Pointing an `<img src>` (or CSS `background-image`) straight at a `/.netlify/images?...&fm=blurhash` URL does not work — the browser receives text and has nothing to render. Use it as a placeholder workflow instead: obtain the blurhash string ahead of time (server-side, in a data loader, via a `fetch`, or at build time), decode it with a BlurHash decoder library into a rendered placeholder (a canvas or a data-URI), and show that while the real image loads. The real, displayable image is a **separate** `/.netlify/images` request **without** `fm=blurhash`.
+- **`fit=cover` requires BOTH `w` and `h`.** Supplying only one silently misbehaves.
+- `contain` with one dimension calculates the other to preserve aspect ratio.
 
-## Remote Image Allowlisting
+### Format & content negotiation
 
-External images must be explicitly allowed in `netlify.toml`:
+- Source-only request (just `url`, no size/format): image is unchanged in size/shape but **still reformatted** to `avif`/`webp` based on the browser's `Accept` header.
+- No `fm` specified → `webp` if accepted, else `avif` if accepted, else original.
+- `fm=blurhash` returns a BlurHash **text string, not image bytes.** Pointing `<img src>` or a CSS background at it renders nothing. Fetch the string server-side/ahead of time, decode it client-side with a BlurHash library (https://blurha.sh), then load the real image as a separate request without `fm=blurhash`.
+
+### Response codes
+
+- Invalid transformation param values → `404`.
+- Valid, new transformation → `200` with content + `content-type`.
+- Previously transformed → `304`.
+
+## Remote source images
+
+Remote `url` values require allowlisting the domain in `netlify.toml`:
 
 ```toml
 [images]
-remote_images = ["https://example\\.com/.*", "https://cdn\\.images\\.com/.*"]
+  remote_images = ["https://my-images.com/.*", "https://animals.more-images.com/[bcr]at/.*"]
 ```
 
-Values are regex patterns.
+Then percent-encode the remote URL and request it:
 
-A remote source URL that does **not** match any `remote_images` pattern is rejected with a **404** — Netlify does not fetch or proxy it. This is a strict allowlist, not a fallback: there is no automatic proxying of arbitrary external hosts. Add the host (as an escaped regex) to `remote_images` *before* referencing it through `/.netlify/images`, or every transform request for that source will 404. (Local images on the same site never need allowlisting.)
-
-When referencing an allow-listed remote image, **percent-encode the source URL** before placing it in the `url` parameter:
-
-```html
-<!-- source: https://cdn.example.com/marketing/banner.jpg -->
-<img src="/.netlify/images?url=https%3A%2F%2Fcdn.example.com%2Fmarketing%2Fbanner.jpg&w=800&fm=webp&q=80" />
+```js
+const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/owl.jpeg")}`;
 ```
 
-Percent-encode the source value (e.g. with `encodeURIComponent`) whenever it contains characters that would otherwise be read as Image CDN params — `?`, `&`, `=`, `#`, or whitespace. This applies to remote URLs and relative paths alike (a filename or user-generated key can contain them too, e.g. `url=/uploads/a%26b.jpg`). Basic paths without those characters don't need encoding.
+- **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
+- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
-## Clean URL Rewrites
+## Reusable transformations (redirects)
 
-Create user-friendly image URLs with redirects:
+Reuse the same params across many images via a redirect:
 
+`_redirects`:
+```
+/transform-small/* /.netlify/images?url=/:splat&w=50&h=50 200
+```
+
+`netlify.toml`:
 ```toml
-# Basic optimization
 [[redirects]]
-from = "/img/*"
-to = "/.netlify/images?url=/:splat"
-status = 200
-
-# Preset: thumbnail
-[[redirects]]
-from = "/img/thumb/:key"
-to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
-status = 200
-
-# Preset: hero
-[[redirects]]
-from = "/img/hero/:key"
-to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
-status = 200
+  from = "/transform-small/*"
+  to = "/.netlify/images?url=/:splat&w=50&h=50"
+  status = 200
 ```
 
-## Local Development
+Then `GET /transform-small/owl.jpeg` yields a 50×50 transform. **Avoid cross-site redirects for transformations** — they hurt performance.
 
-`/.netlify/images` is a Netlify platform endpoint — it does **not** exist in a framework's own dev server. Running `vite`, `next dev`, `astro dev`, etc. directly will **404** on `/.netlify/images`, and `[images]` allowlisting and your image redirects won't apply either. Run `netlify dev` for local work: it emulates the Image CDN endpoint, remote-image allowlisting, and redirect rules, so image URLs resolve locally the same way they do in production. A 404 on `/.netlify/images` locally almost always means a framework dev server is being run directly instead of `netlify dev` — the URL itself is fine.
+## Custom headers (caching)
 
-## Caching
-
-- Transformed images are cached at the CDN edge automatically
-- Cache invalidates on new deploys
-- Set cache headers on source images to control caching:
-
-```toml
-[[headers]]
-for = "/uploads/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
+`_headers`:
+```
+/source-images/*
+  Cache-Control: public, max-age=604800, must-revalidate
 ```
 
-## User-Uploaded Images
+- Headers set on a source image are applied to the transformed asset served by Image CDN.
+- Custom headers **cannot** be applied to remote (other-domain) source images; Netlify respects whatever cache headers the external domain sends.
+- `Cache-Control` on source images applies only to browsers/CDNs in front of Netlify, **not** the Netlify Cache itself.
 
-Combine **Netlify Functions** (upload handler) + **Netlify Blobs** (storage) + **Image CDN** (serving/transforming) to build a complete user-uploaded image pipeline. See [references/user-uploads.md](references/user-uploads.md) for the full pattern.
+## Framework integrations
+
+Use the framework's native image component/handling; it wires to Image CDN automatically. Configure the remote allowlist per framework:
+
+| Framework | Prerequisite | Remote allowlist |
+|---|---|---|
+| Angular | none — `NgOptimizedImage` auto-uses it | `[images] remote_images` in `netlify.toml` |
+| Astro | none — `<Image />` auto-uses it | `image.domains` / `image.remotePatterns` in `astro.config.mjs` |
+| Nuxt | none — `nuxt/image` auto-uses it | `image.domains` in `nuxt.config.ts` |
+| Next.js | Next 13.5+ and adapter v5 | `remotePatterns` in `next.config.js` |
+| Gatsby | env `NETLIFY_IMAGE_CDN=true` + Contentful/Drupal/WordPress source plugin | `[images] remote_images` in `netlify.toml` |
+
+## Local development
+
+Run `netlify dev` (Netlify CLI) to test transformations locally — it mimics production including Image CDN.
+
+- **A local `404` on `/.netlify/images` almost always means a framework dev server (`vite`, `next dev`, `astro dev`) is running instead of `netlify dev`.** The endpoint, `[images]` allowlisting, and image redirects only exist under `netlify dev`. The URL itself is usually fine.
+
+## Caching & deploys
+
+Transformed results are uniquely cached on Netlify's edge. Atomic deploys are respected: changing a source image in a new deploy re-runs transformations on new requests so stale assets aren't served.
+
+## User-uploaded image pipelines
+
+For user-uploaded image pipelines (Functions + Blobs + Image CDN composed), see `references/user-uploads.md` in this skill.
+
+## Limitations
+
+- **Split Testing is not supported** — you may get inconsistent image results between split test branches.
+- Not currently supported in Netlify's HIPAA-compliant hosting offering. See the Trust Center for the HIPAA-compliant reference architecture.
+
+<!-- system: agent-context/image-cdn/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (image-cdn)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. For user-uploaded image pipelines (Functions + Blobs + Image CDN
+   composed), see `references/user-uploads.md` in this skill — an authored
+   guide with no single docs source.
+2. Percent-encode remote source URLs before placing them in the `url`
+   parameter (`encodeURIComponent`) — URLs containing `?` or `&` break
+   otherwise.
+3. `fm=blurhash` returns a BlurHash TEXT string, not image bytes. Pointing an
+   `<img src>` (or CSS background) at it renders nothing — fetch the string
+   ahead of time, decode it client-side with a BlurHash library, and load the
+   real image as a separate request without `fm=blurhash`.
+4. A local 404 on `/.netlify/images` almost always means a framework dev
+   server (`vite`, `next dev`, `astro dev`) is running instead of
+   `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
+   only exist under `netlify dev`. The URL itself is usually fine.
+5. In `remote_images` patterns, the meaningful escape is the dot:
+   `"https://example\.com/.*"`. Forward slashes are not regex
+   metacharacters — do not write `https:\/\/`.

--- a/skills/netlify-access-control/SKILL.md
+++ b/skills/netlify-access-control/SKILL.md
@@ -1,65 +1,165 @@
 ---
 name: netlify-access-control
-description: Use when the task involves controlling who can reach a Netlify site, or telling Netlify Identity apart from Secure Access. Trigger whenever the user wants to lock a site or deploy to their company/team, restrict access to employees only, build an internal or employees-only app, set up password protection, SSO, or SAML, asks "who can access my site", or is confused about Netlify Identity vs Secure Access vs team login vs OAuth providers. Routes the request to the right layer — app-level Identity, site-visitor Password Protection, the Auth0 extension, or Team/Org SAML SSO — and explains the two-layer (perimeter + in-app identity) pattern and its double-login tradeoff. For building the app-level auth itself, use the netlify-identity skill.
+description: Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call "auth". Use when a developer wants to password-protect a site or previews, restrict a project to their team, make a project public/private, set team visibility defaults, require SSO to view a site, or debug SSO-session symptoms like being logged out mid-session / getting 401s on an SSO-protected site / token expiry or refresh. Routes app-user login ("who is this user in my app") to the netlify-identity skill and dashboard/team SSO SSO elsewhere; this skill only chooses the perimeter layer for site/preview access.
 ---
 
-# Netlify Access Control
+# Netlify access control (picking the protection layer)
 
-"Auth" on Netlify means three different things that are easy to conflate. Picking the wrong one — or stacking two when one would do — is the main source of friction. This skill disambiguates the layers and routes you to the right one. For actually building app-level user auth, see the **netlify-identity** skill.
+This skill ROUTES. Its job is choosing the correct protection layer for loading a site, not implementing app auth. Before recommending anything, disambiguate — three unrelated layers get called "auth":
 
-## The three layers
+- **Netlify Identity** — "who is this user *inside* my app" (issues `nf_jwt`). App login, OAuth providers for your users, auth code. → Route to the **netlify-identity** skill. Not covered here.
+- **Password Protection / Project visibility** — "can this request load the site at all." Platform perimeter. **This skill.**
+- **Team/Org SAML SSO** — "can you log into the Netlify dashboard." Team member access to Netlify itself.
 
-| Layer | Answers | Who it's for | Plan | How it's configured |
-|---|---|---|---|---|
-| **Netlify Identity** | "Who is this user *inside my app*?" (signups, logins, roles; issues `nf_jwt`) | Your app's end users | All plans, free | Dashboard + `@netlify/identity` code |
-| **Password Protection** (Secure access to *sites*) | "Can this request even *load the site*?" | Basic: anyone with a shared password · Team login: Netlify team members | Basic: Pro+ · Team login: Enterprise | Dashboard-only |
-| **Team / Org SAML SSO** (Secure access to *Netlify*) | "Can you log in to the *Netlify dashboard*?" (and, with strict mode, pass the site gate) | Netlify team members, via a corporate SAML IdP | Enterprise | Dashboard-only |
+Sessions are separate. The same provider (e.g. Google) can be an Identity OAuth provider for app users AND a SAML IdP for team members — unrelated wiring.
 
-These are independent. The `nf_jwt` cookie is issued by app-level JWT auth: Netlify Identity, or a configured external JWT provider such as Auth0/Okta (the two are mutually exclusive); Password Protection and SAML SSO sessions are separate, with their own lifecycles, and do not populate `nf_jwt`.
+## Footgun: no API, CLI, or MCP for these settings
 
-> **Note on terminology:** Netlify's docs file Identity, Password Protection, role-based access, and more under an umbrella called "Secure access to your sites," while SAML SSO lives under "Secure access to Netlify." So "Secure Access" is not one feature — when a user says it, find out whether they mean *gating site visitors* (Password Protection) or *gating dashboard login* (SAML SSO).
+These settings have **no public API, no CLI command, and no MCP tool**. Do NOT curl `api.netlify.com` or read local auth tokens to inspect or change them. Hand the user the dashboard path and checklist. On failure, report what you tried and stop.
 
-## Why Google causes confusion
+## Footgun: the double login is real
 
-The same provider can show up in two unrelated places:
+A Password-Protection / team-login perimeter session and a Netlify Identity app session have **no bridge** — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire them together. For the combined Password-Protection + Identity pattern and its tradeoffs, see `references/two-layer-pattern.md`.
 
-- **Google as a Netlify Identity OAuth provider** — your app's end users click "Log in with Google." Any Google account works, it creates an Identity user, and it issues an `nf_jwt`. This is app-level auth.
-- **Google Workspace as a SAML IdP for Team/Org SSO** — your *Netlify team members* log in to the dashboard (and, with strict mode + team-login, pass the site gate) using their corporate Google account. It does **not** create an Identity user and does **not** issue an `nf_jwt`.
-
-Both are "sign in with Google," but they target different populations and produce different sessions. Don't assume one implies the other.
+For company-wide app-level SSO with a single sign-in (no double login), recommend the **Auth0 extension** (federating to the corporate IdP) BEFORE the two-layer stack.
 
 ## Pick the layer
 
-Start from what the user actually needs and walk down:
+| Goal | Use |
+|---|---|
+| Restrict site to your team, invite by email | Private project (Credit-based) or team login protection |
+| Shared password anyone can use | Basic password protection, or Password visibility (Pro only) |
+| Protect only previews, keep production open | "Non-production deploys only" / "Previews only" |
+| Require SSO to view the site | Org/Team SSO with **Only SSO allowed (strict)** + team login protection |
+| Log in users *inside* your app | → netlify-identity skill |
+| Single company-wide app SSO, no double login | → Auth0 extension |
 
-1. **Does anyone need to be blocked from loading the site at all?**
-   - **No — the site is public, but I need user accounts/roles inside the app** → **Netlify Identity** (open or invite-only registration). Use the **netlify-identity** skill. Done.
-   - **Yes — restrict who can reach it** → keep going.
+## UI naming by plan (same mechanism, different labels)
 
-2. **What kind of restriction?**
-   - **Just keep the public out — a shared secret is fine, no per-user identity needed** (staging, a soft pre-launch gate) → **Basic Password Protection** (Pro+, one shared password). Dashboard-only.
-   - **Only my employees, it's an internal tool / smaller team, and I also want to tell users apart inside the app** → **invite-only Netlify Identity** (all plans, free). Invite only company addresses; Identity itself becomes the gate because no uninvited user can sign in. **One login, full per-user identity, every plan.** This is the best default for "employees-only internal tool." Tradeoff: you manage invites manually and rely on invite links not being shared — it doesn't auto-provision from a corporate directory.
-   - **Big company, app-level company SSO with a single sign-in (no double login), where company-only is enforced inside the IdP** → the **Auth0 extension**. The extension links an Auth0 tenant to your site and exposes `AUTH0_*` env vars so your app authenticates end users through Auth0; Auth0 federates to your corporate IdP (Okta, Entra, Google Workspace) and enforces who counts as company, so users sign in once. This is **app-level**, not a CDN-edge perimeter: the site still loads and your app redirects unauthenticated visitors. Use it when invite-only Identity won't scale to a real org but you don't need a true edge perimeter; that's Option D below. Configured via the Netlify Auth0 extension (dashboard); see the Netlify docs setup guide.
-   - **I genuinely need a CDN-edge perimeter (Enterprise team login / SSO-gated site access) AND a separate app-level Identity** → the **two-layer pattern**. This works, but users sign in **twice** (once at the perimeter, once in the app) — there is no passthrough today. Read [references/two-layer-pattern.md](references/two-layer-pattern.md) before recommending it.
+The UI names differ by plan — the underlying protection is identical:
 
-If the user isn't sure, the most common real answer is **invite-only Netlify Identity** for "just my team" and the **Auth0 extension** for "my whole company with our existing IdP." Lead with those before reaching for the double-login stack.
+- **Credit-based Free / Personal / Pro:** per-project **Project visibility**; team-level **Default project visibility**.
+- **Enterprise / Open Source / legacy (non-Credit-based):** per-site **Password Protection**; team-level **Default Password Protection settings**.
 
-## The double login is real — name it early
+Legacy → Credit-based translation:
 
-When Password Protection (team login) and Netlify Identity are both on, **users authenticate twice** and there is no documented bridge between them — no shared cookie, no header forwarding, no JWT exchange. Don't burn iterations trying to wire the perimeter session into the app session; it isn't supported. If single sign-on matters, that's a reason to choose the Auth0 extension (or invite-only Identity) instead of the two-layer stack. Full detail and the per-option tradeoffs are in [references/two-layer-pattern.md](references/two-layer-pattern.md).
+| Password Protection (old) | Project visibility (new) |
+|---|---|
+| No protection settings | Public |
+| Basic protection | Password |
+| Team protection | Private |
+| All deploys | Production and previews |
+| Non-production deploys only | Previews only |
 
-Also flag the hidden cost of team-login: it admits only **Netlify team members**, so every employee who passes that gate needs a paid Netlify seat. That alone usually rules it out for company-wide apps.
+## Dashboard paths
 
-## Configuration is dashboard-only — hand it off, don't probe
+**Credit-based (Project visibility):**
+- Per-project: `Project configuration > General > Visitor access > Project visibility` — `https://app.netlify.com/projects/{site_name}/configuration/general/#project-visibility`
+- Team default: `Team settings > General > Visitor access > Default project visibility` — `https://app.netlify.com/teams/{team_name}/settings/general#default-project-visibility`
 
-Password Protection, Team/Org SAML SSO, and the Auth0 extension are all configured in the Netlify dashboard or the extensions UI — **there is no public API, CLI command, or MCP tool to set or read them**, and there is no way for an agent to see this state while writing code. So:
+**Enterprise / Open Source / legacy (Password Protection):**
+- Per-site: `Project configuration > Access & security > Visitor access > Password Protection` — `https://app.netlify.com/projects/{site_name}/configuration/access#site-protection`
+- Team default: `Team settings > Access & security > Visitor access > Default Password Protection settings` — `https://app.netlify.com/teams/{team_name}/settings/access#default-site-protection-settings`
 
-- Give the user the dashboard location and an exact checklist; let them flip the setting and confirm.
-- **Do not** `curl https://api.netlify.com/...`, read tokens off disk, or probe for an undocumented endpoint to inspect or change access settings.
-- If a documented path fails, report it to the user with context (what you tried, the URL, the error) and stop — don't work around it.
+## Checklist: set a password (Credit-based, Pro)
 
-For the one piece an agent *can* read at runtime (which Identity providers are live), call `getSettings()` from `@netlify/identity` rather than hard-coding assumptions. It hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev` (which proxies to the live service). See the netlify-identity skill.
+1. Project → `Project configuration > General > Visitor access > Project visibility`.
+2. **Edit visibility**. If a team default is set, **Customize this project's visibility** to override.
+3. Select **Password**, enter the password (share it with visitors).
+4. Choose **Preview access**: **Production and previews** or **Previews only**.
+5. **Save**. Change later via **Change password**; remove by choosing **Public** or **Private**.
 
-## References
+## Checklist: Password Protection (Enterprise / OSS / legacy)
 
-- [Two-layer pattern (perimeter + in-app identity)](references/two-layer-pattern.md) — the four architecture options for "company-only access + per-user identity," the double-login reality, plan/seat costs, and the visibility gap.
+Per-site or team default via the paths above → **Configure Password Protection** → **Customize this site's protection settings** (if a default exists) → choose **Basic password protection** (single shared password) or **Team login protection** (Netlify team login, SSO-capable) → scope **All deploys** or **Non-production deploys only** → **Save**.
+
+## Checklist: require SSO to view a site
+
+1. FIRST set up Organization SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-organization-saml-sso`) or Team SSO (`https://docs.netlify.com/manage/security/secure-netlify-access/configure-team-saml-sso`).
+2. Configure Password Protection → **Team login protection**.
+3. To force SSO, set the SSO config to **Only SSO allowed (strict)**.
+
+## SSO session symptoms (logged out mid-session, 401s)
+
+SSO auth tokens **expire after 1 hour**. An SSO-protected site starts returning HTTP `401` once the token expires — this is the "logged out mid-session" symptom.
+
+The platform returns a `Netlify-Site-Protection-Expires-In` response header (seconds until the token expires) on requests to SSO-protected sites. Read it and re-auth before it hits zero:
+
+```js
+// SSO-protected site: refresh before the 1-hour token expires to avoid a 401.
+const res = await fetch(window.location.href, { credentials: "include" });
+const secondsLeft = Number(res.headers.get("Netlify-Site-Protection-Expires-In"));
+if (!Number.isNaN(secondsLeft) && secondsLeft < 60) {
+  window.location.reload(); // triggers re-auth via the identity provider
+}
+```
+
+The header name and semantics are documented; the JS wrapper is illustrative.
+
+## Project visibility values (Credit-based)
+
+One visibility setting — **Public**, **Password**, or **Private** — plus a separate scope (**Production and previews** or **Previews only**).
+
+- **Public** — anyone with the URL.
+- **Private** — team + invitees only, enforced with Netlify login. Recommended way to restrict to your team; lets you invite by email. No password needed.
+- **Password** — public but requires a shared password. **Pro only** among Credit-based plans.
+
+Previews stay private unless you change preview visibility (includes Deploy Previews, agent-run previews, and branch deploys). There is **no** default shared password — set a password per project.
+
+**Team defaults:** *Private for new projects* (new start behind team login; existing keep visibility), *Private for all projects* (new + all existing locked to team login; none can be made public), *Public for new projects* (new are public; existing keep visibility).
+
+## Constraints & gotchas
+
+- **Previews-only Password scope is Enterprise-only** for Password Protection settings ("Protecting only non-production deploys is only available for Enterprise plans"). Credit-based plans expose a "Previews only" scope via Project visibility separately — the docs do not fully reconcile these; state Enterprise-only for the Password Protection path.
+- **Access order:** Advanced Web Security (Firewall rules → WAF → rate limiting) runs BEFORE any password/login prompt. A blocked IP can hit an error page before ever seeing a login prompt.
+- **Team login excludes Git Contributors** — they cannot access team-login-protected deploys. It applies to Developers, Team Owners, Billing Admins; Reviewers can be invited (unlimited).
+- **Basic password protection prompts everyone**, including managing team members.
+- **Private projects can't receive third-party webhooks** (Slack, Stripe, etc.) — receiving webhooks requires the project to be **public**.
+- **Plan gating:** Basic password (whole site) available on Pro and Enterprise; all options (incl. team login) on Enterprise. Project visibility is Credit-based Free/Personal/Pro only; Free/Personal private projects are visible only to the Team Owner, Pro allows unlimited members. Enterprise/OSS/legacy have no project visibility — use team login protection.
+- **Who can change:** Password Protection — Developer (per-site), Team Owner (default). Project visibility — Org Owners (certain Enterprise plans), Team Owners, Developers with project access. Internal Builders can't publish to production, so can't make a project public.
+- **Team default by creation date:** teams created on/after July 28, 2026 default to **Private for new projects**; teams created before default to **Public**.
+- **Make public** requires at least one successful production deploy. Making public exposes production deploys; previews stay private unless changed.
+- **Invites:** Free/Personal are single-seat (upgrade to Pro to invite); Pro invites unlimited members to a single project or the whole team.
+
+## Compatibility
+
+- "Site-wide password protection" — old name, now part of **Password Protection**.
+- "Selective password protection" — old name for **Basic authentication with custom HTTP headers** (`https://docs.netlify.com/manage/security/secure-access-to-sites/basic-authentication-with-custom-http-headers`), which is code you author — out of scope here.
+
+See also: `references/two-layer-pattern.md` for the combined Password-Protection + Identity pattern.
+
+<!-- system: agent-context/access-control/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (access-control)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. This is a routing/disambiguation skill: keep it narrow — its job is
+   picking the right protection layer, not teaching each one.
+2. The combined Password-Protection + Identity pattern lives in this skill's
+   `references/two-layer-pattern.md`.
+3. "Auth" on Netlify is three unrelated layers users constantly conflate:
+   Netlify Identity ("who is this user inside my app" — issues `nf_jwt`),
+   Password Protection / project visibility ("can this request load the site
+   at all"), and Team/Org SAML SSO ("can you log in to the Netlify
+   dashboard"). Sessions are separate; the same provider (Google) can appear
+   in two unrelated places — Identity OAuth for app users, SAML IdP for team
+   members. Disambiguate before recommending anything.
+4. The double login is real: a Password-Protection/team-login perimeter
+   session and an Identity app session have no bridge — no shared cookie, no
+   header forwarding, no JWT exchange. Don't burn iterations wiring them
+   together; tradeoffs live in `references/two-layer-pattern.md`.
+5. These settings have no public API, CLI command, or MCP tool. Never curl
+   `api.netlify.com` or read local auth tokens to inspect or change them —
+   hand the user the dashboard path and checklist; on failure, report what
+   you tried and stop.
+6. Identity setup, auth code, and OAuth providers for app users belong to the
+   netlify-identity skill — route there; this skill only picks the layer.
+7. For company-wide app-level SSO with a single sign-in (no double login),
+   the Auth0 extension — federating to the corporate IdP — is the
+   recommendation before the two-layer stack.
+8. The description's triggers must include the SSO-session symptoms users
+   actually report — "logged out mid-session", 401s on an SSO-protected
+   site, token expiry/refresh — not only setup phrasing. The
+   `Netlify-Site-Protection-Expires-In` guidance is unreachable if the
+   skill never triggers on the symptom.

--- a/skills/netlify-ai-gateway/SKILL.md
+++ b/skills/netlify-ai-gateway/SKILL.md
@@ -1,240 +1,200 @@
 ---
 name: netlify-ai-gateway
-description: Reference for Netlify AI Gateway — the managed proxy that routes calls to OpenAI, Anthropic, and Google Gemini SDKs without provider API keys. Use this skill any time the user wants to add AI on a Netlify site (chat, completion, reasoning, image generation, image-to-image edit/stylize), choose or change a model, wire up the OpenAI / Anthropic / @google/genai SDK, decide which provider to use for an image-gen feature (it's Gemini-only on the gateway), or debug "model not found" / "API key missing" against the gateway. Required reading before pinning a model — the gateway exposes a curated subset, not every provider model.
+description: Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing provider API keys or accounts — the gateway injects credentials automatically. Reach for this when you add an AI chatbot or completion endpoint, generate images or text with Gemini/GPT/Claude, summarize form submissions with AI, build an LLM-backed API route, stream a long AI generation, or wire up any server-side AI provider call on Netlify. Covers provider SDK setup, injected env vars, model availability, rate limits, credit costs, streaming for long generations, and local dev with netlify dev or the Vite plugin.
 ---
 
 # Netlify AI Gateway
 
-> **IMPORTANT:** Only use models listed in the "Available Models" section below. AI Gateway does not support every model a provider offers. Using an unsupported model returns an HTTP error from the gateway.
+Call AI providers from Netlify server-side compute using each provider's **official SDK** with zero credential config — the gateway injects the API keys and base URLs the SDKs already read. Instantiate the client with no args (except OpenRouter, which needs an explicit base URL).
 
-> **First-deploy requirement:** The AI Gateway only activates after a site has had at least one production deploy. Local dev (`netlify dev`, `@netlify/vite-plugin`) will NOT have gateway access on a brand-new project until you deploy to production once.
+**Never do these** (they silently fail or cost money):
+- **Not browser-callable.** The gateway lives in Functions/Edge Functions only. Never call it from client-side React/browser code.
+- **Runtime-only credentials.** Never call the gateway from build scripts, prerender/SSG, or build plugins — those get no credentials and fail. Do AI work at request time; cache to Netlify Blobs if output must look precomputed.
+- **60s sync timeout.** A slow generation in a synchronous function is killed at 60s. Stream it (SDK streaming + `ReadableStream`), or use a background function that persists output for the client to fetch.
+- **Requires a production deploy.** The gateway does not activate until the project has at least one production deploy — even in local dev.
+- **Don't hardcode model lists.** Model availability changes; check the live providers endpoint rather than baking in IDs.
 
-> **Usage is credit-metered:** Gateway calls draw down your Netlify AI credit/inference allowance and start returning errors once it's exhausted — there's no separate provider bill behind it. Budget for this explicitly in any bulk or fan-out design (generating content for hundreds of rows/pages, retry loops), and don't retry unbounded.
+## Function example
 
-Netlify AI Gateway provides access to AI models from multiple providers without managing API keys directly. It is available on all Netlify sites.
+File: `netlify/functions/joke.js` (`mkdir -p netlify/functions`). Install: `npm install openai`.
 
-## How It Works
-
-The AI Gateway acts as a proxy — you use standard provider SDKs but point them at Netlify's gateway URL. Netlify auto-injects both the base URL and a placeholder API key for each provider, then authenticates upstream on your behalf.
-
-Always make the call through the provider's official SDK, constructed bare (`new OpenAI()`, `new Anthropic()`, `new GoogleGenAI()`) — the SDK reads the auto-injected base URL and key from the environment. **Don't hand-roll the gateway call with a raw `fetch()` and a manually-read `process.env.OPENAI_API_KEY`** (or a hardcoded key/URL): the injected key is only a placeholder, and rolling your own request bypasses the supported path the gateway expects.
-
-## Setup
-
-1. Enable AI on your site in the Netlify UI
-2. Deploy to production at least once — the gateway does not activate until then
-3. Install the provider SDK you want to use
-
-Don't set your own `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` (the `@google/genai` SDK reads either `GEMINI_API_KEY` or `GOOGLE_API_KEY`). Doing so disables Netlify's auto-injection and routes calls directly to the provider, bypassing the gateway.
-
-## Using OpenAI SDK
-
-```bash
-npm install openai
-```
-
-```typescript
+```js
+import process from "process";
 import OpenAI from "openai";
 
-const openai = new OpenAI();
-// `OPENAI_API_KEY` and `OPENAI_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+export default async () => {
+  const client = new OpenAI(); // reads OPENAI_API_KEY + OPENAI_BASE_URL
+  try {
+    const res = await client.responses.create({
+      model: "gpt-5-mini",
+      input: [{ role: "user", content: "Give me a random short dad joke" }],
+      reasoning: { effort: "minimal" },
+    });
+    return Response.json({
+      joke: res.output_text?.trim() || "Out of jokes",
+      model: res.model,
+      tokens: { input: res.usage.input_tokens, output: res.usage.output_tokens },
+    });
+  } catch (e) {
+    return Response.json({ error: `${e}` }, { status: 500 });
+  }
+};
 
-const completion = await openai.chat.completions.create({
-  model: "gpt-4o-mini",
-  messages: [{ role: "user", content: "Hello!" }],
-});
+export const config = { path: "/api/joke" }; // route, local + deployed
 ```
 
-## Using Anthropic SDK
+Client-side fetch just hits the route:
 
-```bash
-npm install @anthropic-ai/sdk
+```jsx
+const res = await fetch("/api/joke");
+const data = await res.json();
 ```
 
-```typescript
-import Anthropic from "@anthropic-ai/sdk";
+## Provider SDKs (modern — instantiate with no args)
 
-const client = new Anthropic();
-// `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` are auto-injected; the SDK
-// reads both from the environment, so no constructor args are needed.
+Each SDK auto-reads the injected env vars. **OpenRouter is the exception:** its base URL must be passed explicitly.
 
-const message = await client.messages.create({
-  model: "claude-sonnet-4-5-20250929",
+```js
+// Anthropic — npm i @anthropic-ai/sdk
+import Anthropic from '@anthropic-ai/sdk';
+const anthropic = new Anthropic(); // ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
+await anthropic.messages.create({
+  model: 'claude-sonnet-4-5-20250929',
   max_tokens: 1024,
-  messages: [{ role: "user", content: "Hello!" }],
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-## Using Google Gemini SDK
-
-Use `@google/genai` (the unified Google GenAI SDK). The older `@google/generative-ai` package does not pick up the gateway env vars.
-
-```bash
-npm install @google/genai
-```
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-// `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` are auto-injected. The SDK also
-// honors `GOOGLE_API_KEY`; leave both Gemini keys unset so the gateway's
-// injection isn't shadowed.
-
-const response = await ai.models.generateContent({
-  model: "gemini-2.5-flash",
-  contents: "Hello!",
-});
-
-const text = response.text;
-```
-
-## In a Netlify Function
-
-```typescript
-import type { Config, Context } from "@netlify/functions";
-import OpenAI from "openai";
-
-export default async (req: Request, context: Context) => {
-  const { prompt } = await req.json();
-  const openai = new OpenAI();
-
-  const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  return Response.json({
-    response: completion.choices[0].message.content,
-  });
-};
-
-export const config: Config = {
-  path: "/api/ai",
-  method: "POST",
-};
-```
-
-Return the reply as JSON with `Response.json({...})`, even when the request only asks for "the reply text" back — a raw `text/plain` body breaks JSON-consuming clients and diverges from the convention used everywhere else in Netlify Functions.
-
-## Image Generation
-
-Image generation on the gateway is supported through **Gemini image models** (e.g., `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`). OpenAI's image models (`gpt-image-1`, `dall-e-*`) are **not** routed through the gateway.
-
-Both text-to-image and image-to-image use the same `generateContent` method as chat — only the model and response shape differ. The image is returned as base64 `inlineData` on a content part, not as a URL.
-
-### Text-to-image
-
-```typescript
-import { GoogleGenAI } from "@google/genai";
-
-const ai = new GoogleGenAI({});
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: "A watercolor portrait of a corgi wearing a beret",
-});
-
-const imagePart = response.candidates[0].content.parts.find(
-  (p) => p.inlineData,
-);
-const base64 = imagePart.inlineData.data;
-const mimeType = imagePart.inlineData.mimeType; // e.g. "image/png"
-const bytes = Buffer.from(base64, "base64");
-```
-
-### Image-to-image (edit / stylize an input image)
-
-Pass the source image as an additional content part with `inlineData`:
-
-```typescript
-const sourceBase64 = sourceBuffer.toString("base64");
-
-const response = await ai.models.generateContent({
-  model: "gemini-3.1-flash-image",
-  contents: [
-    { text: "Restyle this photo as a Picasso-era cubist portrait" },
-    { inlineData: { mimeType: "image/png", data: sourceBase64 } },
-  ],
+```js
+// OpenAI — npm i openai
+import OpenAI from 'openai';
+const openai = new OpenAI(); // OPENAI_API_KEY + OPENAI_BASE_URL
+await openai.chat.completions.create({
+  model: 'gpt-5',
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
-The response shape is the same — pull `base64` and `mimeType` off the first part with `inlineData`. Most callers persist the bytes to Netlify Blobs (see `netlify-blobs/SKILL.md`) and serve a URL back to the client rather than returning multi-MB base64 in the function response.
+```js
+// Google Gemini — npm i @google/genai
+import { GoogleGenAI } from '@google/genai';
+const genAI = new GoogleGenAI({}); // GEMINI_API_KEY + GOOGLE_GEMINI_BASE_URL
+await genAI.models.generateContent({
+  model: 'gemini-2.5-pro',
+  contents: 'Hello!',
+});
+```
 
-## Environment Variables
+```js
+// OpenRouter — npm i @openrouter/sdk — base URL REQUIRED
+import { OpenRouter } from '@openrouter/sdk';
+const openRouter = new OpenRouter({
+  serverURL: process.env.OPENROUTER_BASE_URL, // API key auto-read from OPENROUTER_API_KEY
+});
+await openRouter.chat.send({
+  chatRequest: {
+    model: 'x-ai/grok-4.5',
+    messages: [{ role: 'user', content: 'Hello!' }],
+  },
+});
+```
 
-All of these are injected automatically by Netlify when AI is enabled. Setting your own value for any of the per-provider vars disables gateway routing.
+**OpenRouter models via the OpenAI SDK:** you can reach any OpenRouter-served model (xAI, DeepSeek, Meta, Mistral, Qwen) through the plain OpenAI SDK — just pass the model ID in OpenRouter notation, no extra config:
 
-| Variable | Provider | Purpose |
-|---|---|---|
-| `OPENAI_BASE_URL` | OpenAI | Gateway endpoint |
-| `OPENAI_API_KEY` | OpenAI | Placeholder; satisfies the SDK's "key required" check |
-| `ANTHROPIC_BASE_URL` | Anthropic | Gateway endpoint |
-| `ANTHROPIC_API_KEY` | Anthropic | Placeholder; satisfies the SDK's "key required" check |
-| `GOOGLE_GEMINI_BASE_URL` | Google Gemini | Gateway endpoint |
-| `GEMINI_API_KEY` | Google Gemini | Placeholder; satisfies the SDK's "key required" check |
-| `NETLIFY_AI_GATEWAY_BASE_URL` | (universal) | Provider-agnostic gateway endpoint |
-| `NETLIFY_AI_GATEWAY_KEY` | (universal) | Provider-agnostic gateway key |
+```js
+await openai.chat.completions.create({
+  model: 'deepseek/deepseek-v4-flash-0731',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
 
-The real upstream API keys live on Netlify's side. The per-provider `*_API_KEY` vars are placeholders so the SDKs construct successfully; the gateway authenticates server-side. You don't read these yourself — the SDK picks them up.
+## Injected environment variables
 
-When your own code needs some *other* environment value (a config flag, a model name you've parameterized), prefer `Netlify.env.get("VAR")` — it works in Netlify Functions and Edge Functions, and Edge Functions expose **only** `Netlify.env.get`. (In a framework's own server routes, use whatever that framework documents for env access — often `process.env`.)
+Set in all Netlify compute contexts at function init **only if you have not already set them** at project/team level (Netlify never overrides your keys):
 
-## Local Development
+| Provider | Vars |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
+| Anthropic | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
+| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_GEMINI_BASE_URL` |
+| OpenRouter | `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL` |
 
-With `@netlify/vite-plugin` or `netlify dev`, gateway environment variables are injected automatically into the local process — but only after the site has had at least one production deploy. A brand-new local-only project will see "API key missing" or "model not found" errors until you deploy.
+**Gemini special case:** Netlify will **not** inject `GEMINI_API_KEY` / `GOOGLE_GEMINI_BASE_URL` if either `GOOGLE_API_KEY` or `GOOGLE_VERTEX_BASE_URL` is set (use those to point at Vertex or your own Google credentials).
 
-Local injection also requires the working directory to be **linked** to the Netlify site. `netlify dev` pulls the gateway base URL and placeholder key from the linked site's environment, so an unlinked directory has no site context — nothing is injected and gateway calls fail even when the site has already been deployed to production. Run `netlify link` (or `netlify init`) in the project first, then start `netlify dev`. A bare framework dev server started outside `netlify dev` / `@netlify/vite-plugin` also gets no gateway env vars.
+**Always injected, never collide with your provider vars:**
+- `NETLIFY_AI_GATEWAY_KEY`
+- `NETLIFY_AI_GATEWAY_BASE_URL`
 
-## Usage metering and where the gateway runs
+Use the SDK path with the per-provider injected vars above as your default. Reach for `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` only when a third-party or unsupported library needs the credentials passed explicitly — that's the correct time to configure them by hand.
 
-**Gateway usage is credit-metered.** Calls draw down your Netlify AI credit/inference allowance; when that limit is reached the gateway **pauses** and returns errors until the allowance resets or is raised. There's no separate provider bill to fall back on — an unbounded loop of gateway calls burns the allowance and then starts failing, so budget for it and don't retry indefinitely.
+## Local dev
 
-**Gateway credentials are runtime-only.** Netlify injects the base URL and placeholder key only into runtime compute — deployed functions, edge functions, and server-rendered routes at request time. They are **not** present during the build: AI calls made at build time, in prerender/SSG, or in a build plugin get no gateway credentials and fail. Do AI work at request time (in a function or server route) and cache the result if you need it to look precomputed (e.g. to Netlify Blobs) — don't call the gateway from build scripts or static-generation hooks.
+Two supported paths — both still require an existing production deploy:
+- **Netlify CLI:** `netlify dev` (full support). Needs `npm install -g netlify-cli@latest` and `netlify login`.
+- **Netlify Vite plugin:** install `@netlify/vite-plugin`, add `netlify()` to `vite.config.js` plugins, run your normal `npm run dev` — gateway access without `netlify dev`.
 
-## No browser-callable gateway — proxy through server code
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import netlify from "@netlify/vite-plugin";
 
-Gateway credentials are injected only into server-side runtime compute (functions, edge functions, server-rendered routes). There is **no browser-callable gateway endpoint**: client-side JavaScript has no gateway credentials, and there is no public URL a browser can hit to reach the gateway directly. Client code (React/Vue/vanilla JS running in the browser) that constructs a provider SDK against the gateway will find no key and fail — and "fixing" it by hardcoding a real provider key in the client leaks that key to every visitor AND bypasses the gateway (a user-set key disables Netlify's auto-injection).
+export default defineConfig({
+  plugins: [react(), netlify()],
+})
+```
 
-The correct pattern is to proxy: put the gateway call in a **Netlify Function** (or edge function / server route), and have the browser `fetch()` your own endpoint (e.g. `/api/chat`). The function talks to the gateway server-side with the auto-injected credentials and returns the result to the client. Never import a provider SDK into a browser bundle to call the gateway, and never expose a provider API key to the client.
+## Enable & deploy
 
-## Long generations and the function timeout
+1. Be on a credit-based plan (Free, Personal, Pro; Enterprise via Account Manager). Legacy plans must switch to a current plan.
+2. Link a project: `netlify init`.
+3. **Deploy to production at least once** — required to activate: `netlify deploy --prod --open`.
+4. Don't disable AI Features; don't set your own provider keys unless you intend to override.
 
-A gateway call runs inside your function, so it is bound by the **60-second synchronous function timeout**. Large completions, reasoning models, and image generations can run longer than that, and a synchronous function that exceeds the ceiling is terminated before it can respond. Two mitigations:
+## Constraints & gotchas
 
-- **Stream the response.** Enable streaming on the SDK call and return a `ReadableStream` (e.g. `Content-Type: text/event-stream`), forwarding the provider's tokens/chunks as they arrive — for example `stream: true` on the OpenAI SDK, `client.messages.stream(...)` on Anthropic, or `generateContentStream(...)` on `@google/genai`. Streaming sends bytes to the client incrementally instead of buffering the whole completion inside the sync window, and is the right default for interactive chat and long text.
-- **Use a background function** for long, fire-and-forget jobs (batch generation, large image renders). Background functions run up to 15 minutes, but they return a `202` immediately and their return value is ignored — they cannot hand the result back to the caller. Persist the output (e.g. to Netlify Blobs or a database) and have the client poll or fetch it.
+- **Plan gating:** Credit-based plans only (Free/Personal/Pro; Enterprise via Account Manager).
+- **Context window:** input capped at **200k tokens**.
+- **Rate limits** (per team, across all projects, per minute, in credits): Free 90 / Personal 450 / Pro 1,800 / Enterprise 9,000. Set up [rate limiting rules](https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/) on AI functions to prevent visitor abuse driving up cost.
+- **Credit cost:** tokens → USD (provider published rates) → credits. **$1 USD of usage = 180 credits.** Enable [auto recharge](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/configure-auto-recharge/) or buy [credit packs](https://docs.netlify.com/manage/accounts-and-billing/billing/billing-for-credit-based-plans/buy-credit-packs/) to meet demand.
+- **No request headers passed through** — you can't enable proprietary header-gated experimental features.
+- **Batch inference not supported.**
+- **OpenAI priority processing not supported.**
+- **Prompt caching:** Anthropic — only the default 5-minute ephemeral cache; OpenAI — a per-account `prompt_cache_key` is set; Gemini — explicit context caching not supported.
+- **Zero Data Retention only:** the gateway only routes to ZDR providers. A model listed in the OpenRouter directory is **not** served if no ZDR host offers it. Browse the ZDR-filtered catalog at https://openrouter.ai/models?zdr=true.
+- **Model list is dynamic** — served-directly models (Anthropic, OpenAI, Gemini) are enumerated from a live endpoint; OpenRouter-served models (xAI, DeepSeek, Meta, Mistral, Qwen) use OpenRouter notation. Don't hardcode; check availability at runtime.
+- **Privacy:** the gateway does not store prompts or outputs.
 
-Don't leave a slow synchronous generation unstreamed and assume it will finish — bound the model and `max_tokens`, and choose streaming or a background function based on how long the job runs.
+## Reference
 
-## Errors & Troubleshooting
+- Full docs, quickstart, and example projects (AI SEO Image Generator, form-submission summaries, TanStack Start chat app) at [AI Gateway overview](https://docs.netlify.com/build/ai-gateway/overview.md) and [quickstart](https://docs.netlify.com/build/ai-gateway/quickstart-for-ai-gateway.md).
 
-- **Unsupported model:** the gateway returns an HTTP error. Check the "Available Models" list below — the gateway exposes a curated subset, not every model the provider offers.
-- **`OPENAI_API_KEY missing` (or equivalent) at runtime:** AI Features are disabled on the site, or the project has not had a production deploy yet.
-- **Calls succeed but skip the gateway / aren't tracked:** check you haven't set your own `*_API_KEY`. Any user-set provider key shadows Netlify's auto-injection and routes directly to the provider.
-- **Limits:** 200k-token context window. Batch inference, custom request headers, and OpenAI priority processing are not supported. Anthropic prompt caching is limited to the 5-minute ephemeral cache; Gemini explicit caching is not supported.
+<!-- GAP: source does not enumerate concrete model IDs (dynamic live endpoint); model names in examples are illustrative only. -->
+<!-- GAP: SDK streaming + background-function patterns are mandated by house rules but no streaming code example exists in the source. -->
 
-## Available Models
+<!-- system: agent-context/ai-gateway/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (ai-gateway)
 
-_Verified 2026-04-30 against the live AI Gateway providers list. The user-facing reference is https://docs.netlify.com/build/ai-gateway/overview/ — re-check before pinning a new model._
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
 
-### Anthropic (chat)
-- `claude-haiku-4-5`, `claude-haiku-4-5-20251001`
-- `claude-sonnet-4-0`, `claude-sonnet-4-20250514`, `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-6`
-- `claude-opus-4-1-20250805`, `claude-opus-4-20250514`, `claude-opus-4-5`, `claude-opus-4-5-20251101`, `claude-opus-4-6`, `claude-opus-4-7`
-
-### OpenAI (chat / reasoning / Codex)
-- gpt-4 family: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
-- gpt-5: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-5-codex`; dated: `gpt-5-2025-08-07`, `gpt-5-mini-2025-08-07`
-- gpt-5.1: `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`; dated: `gpt-5.1-2025-11-13`
-- gpt-5.2: `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.2-pro`; dated: `gpt-5.2-2025-12-11`, `gpt-5.2-pro-2025-12-11`
-- gpt-5.3: `gpt-5.3-chat-latest`, `gpt-5.3-codex` (no unversioned `gpt-5.3`)
-- gpt-5.4: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`; dated: `gpt-5.4-2026-03-05`, `gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano-2026-03-17`, `gpt-5.4-pro-2026-03-05`
-- gpt-5.5: `gpt-5.5`, `gpt-5.5-pro`; dated: `gpt-5.5-2026-04-23`, `gpt-5.5-pro-2026-04-23`
-- Reasoning (o-series): `o3`, `o3-mini`, `o4-mini`
-
-### Google Gemini (chat + image)
-- Chat: `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`, `gemini-flash-latest`, `gemini-flash-lite-latest`
-- Image: `gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`
-
+1. Use the provider SDK with the injected env credentials — don't hand-roll
+   a raw `fetch()` against the gateway, even though raw REST is a supported
+   surface. The body must not present raw REST or the
+   `NETLIFY_AI_GATEWAY_KEY` / `NETLIFY_AI_GATEWAY_BASE_URL` pair as a
+   recommended path — but it MUST still document the pair as facts: always
+   injected, never collide with user-set provider vars, and the right choice
+   when a third-party or unsupported library needs explicit configuration.
+   Demote the recommendation; keep the knowledge.
+2. The gateway is not browser-callable: calls belong in functions or edge
+   functions, never client-side code.
+3. Model availability changes: don't hardcode model lists; check the live
+   providers endpoint.
+4. Gateway credentials are runtime-only: never call the gateway from build
+   scripts, prerender/SSG, or build plugins — those calls get no credentials
+   and fail. Do AI work at request time and cache the result (e.g. to
+   Netlify Blobs) if it must look precomputed.
+5. Gateway calls in a synchronous function are bound by the 60-second
+   timeout: stream long generations (SDK streaming + `ReadableStream`), or
+   use a background function that persists output for the client to fetch —
+   never leave a slow generation unstreamed and assume it finishes.

--- a/skills/netlify-blobs/SKILL.md
+++ b/skills/netlify-blobs/SKILL.md
@@ -1,171 +1,264 @@
 ---
 name: netlify-blobs
-description: Guide for using Netlify Blobs for file and asset storage — images, documents, uploads, exports, cached binary artifacts. Covers getStore(), CRUD operations, metadata, listing, deploy-scoped vs site-scoped stores, and local development. Do NOT use Blobs as a dynamic data store — use Netlify Database for that.
+description: Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/value API from Functions, Edge Functions, and Build Plugins. Use when a task involves saving user file or image uploads, persisting form or contact-form submissions, storing generated output from Background Functions (sitemaps/processed media/bulk-email results), building read-only asset stores, adding client-side blob expiration, or wiring file-based blob uploads at deploy time. Not for per-user, transactional, or relational data (counters/balances/sessions) — reach for Netlify DB there instead.
 ---
 
 # Netlify Blobs
 
-Netlify Blobs is zero-config object storage for **files and assets**: images, documents, uploads, exports, cached binary artifacts. Available from any Netlify compute (functions, edge functions, framework server routes). No provisioning required.
+Modern import — reach for this:
 
-**Not for dynamic data.** If the project needs to store records, user data, application state, or anything queryable, use Netlify Database instead — see `netlify-database/SKILL.md`. Reach for Blobs when the thing you're storing is a file or an asset blob, not a record.
-
-```bash
-npm install @netlify/blobs
+```ts
+import { getStore, getDeployStore, listStores } from "@netlify/blobs";
 ```
 
-## Before you build
+Install: `npm install @netlify/blobs`. Fetch API is required (built into Node 18+); otherwise pass a custom `fetch`.
 
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any blob storage — answers shape access patterns, scoping, and how the assets are served back to clients:
+Two ways to open a store — use the **options-object form** when you need `consistency` or a custom `fetch` (the string form cannot pass them):
 
-- **What kind of asset?** (User uploads, exported documents, cached binaries, generated images — drives the storage and serving pattern.)
-- **Who should be able to read it?** Public (anyone with a URL, or an unauthenticated endpoint that streams the blob) or private (only authenticated users, gated by your server code)? Blobs have **no built-in access control** — the serving layer is the gate. When in doubt, default to private; making something public later is easy, while pulling back data that was inadvertently exposed is not.
-- **Site-scoped or deploy-scoped?** Site-scoped (`getStore()`) persists across deploys — the right default for user data. Deploy-scoped (`getDeployStore()`) is tied to a single deploy and disappears when that deploy is replaced — use only when the lifecycle should match a deploy (e.g., per-deploy build artifacts).
-- **Roughly how big and how many?** Helps choose between a single large blob vs many small keyed blobs, and informs whether you'll need `list({ prefix: ... })` patterns.
+```ts
+const store = getStore("file-uploads");                          // string form
+const store = getStore({ name: "animals", consistency: "strong" }); // options form
+```
 
-**If you don't have preferences here, tell me what the assets are and I'll pick sensible defaults** — typically site-scoped with private access, served through an authenticated function.
+`siteID`, `token`, `deployID`, and `region` are set automatically inside Functions, Edge Functions, and Build Plugins — do not pass them manually there.
 
-## Getting a Store
+## Choosing the store type — READ THIS FIRST
 
-```typescript
+- **`getStore(name)`** — site-scoped. Persists across deploys and is **shared across ALL deploy contexts**. Code on a Deploy Preview reads, overwrites, and deletes production data. **Never seed throwaway data or run destructive tests from a preview.**
+- **`getDeployStore(name)`** — scoped to one deploy; isolated from production. Use this for throwaway/per-deploy data, or use a context-specific store name for isolation.
+
+Blobs have **no built-in access control** — the serving function is the gate. Default to private: gate reads behind an authenticated function rather than exposing blobs publicly. Never accept an arbitrary caller-supplied key against a store holding sensitive data.
+
+## Common tasks
+
+### Persist a user upload with metadata (`set`)
+
+```ts
 import { getStore } from "@netlify/blobs";
+import type { Context } from "@netlify/functions";
+import { v4 as uuid } from "uuid";
 
-const store = getStore({ name: "my-store" });
+export default async (req: Request, context: Context) => {
+  const form = await req.formData();
+  const file = form.get("file") as File;
+  const key = uuid();
 
-// Use "strong" consistency when you need immediate reads after writes
-const store = getStore({ name: "my-store", consistency: "strong" });
+  const uploads = getStore("file-uploads");
+  await uploads.set(key, file, {
+    metadata: { country: context.geo.country.name }
+  });
+
+  return new Response("Submission saved");
+};
 ```
 
-## CRUD Operations
+Edge Function form is identical but imports `Context` from `@netlify/edge-functions`.
 
-These are the **only** store methods. Do not invent others.
+### Persist JSON (`setJSON`)
 
-### Create / Update
-
-```typescript
-// String or binary data
-await store.set("key", "value");
-await store.set("key", fileBuffer);
-
-// With metadata
-await store.set("key", data, {
-  metadata: { contentType: "image/png", uploadedAt: new Date().toISOString() },
-});
-
-// JSON data
-await store.setJSON("key", { name: "Example", count: 42 });
+```ts
+const uploads = getStore("json-uploads");
+await uploads.setJSON(key, data, { metadata: { country: context.geo.country.name } });
 ```
 
-### Read
+### Read a blob (`get`) — always null-check
 
-```typescript
-// Text (default)
-const text = await store.get("key");                    // string | null
+```ts
+const uploads = getStore("file-uploads");
+const entry = await uploads.get(key);          // string by default
+if (entry === null) {
+  return new Response(`Could not find ${key}`, { status: 404 });
+}
+return new Response(entry);
+```
 
-// Typed retrieval
-const json = await store.get("key", { type: "json" });  // object | null
-const stream = await store.get("key", { type: "stream" });
-const blob = await store.get("key", { type: "blob" });
-const buffer = await store.get("key", { type: "arrayBuffer" });
+Pass `type` for other formats: `get(key, { type: "json" | "arrayBuffer" | "blob" | "stream" | "text" })`.
 
-// With metadata
-const result = await store.getWithMetadata("key");
-// { data: any, etag: string, metadata: object } | null
+### Atomic conditional write
 
-// Metadata only (no data download)
-const meta = await store.getMetadata("key");
-// { etag: string, metadata: object } | null
+Write only if the key is new:
+
+```ts
+const { modified } = await store.set("jane@netlify.com", "Jane Doe", { onlyIfNew: true });
+if (!modified) return new Response("Email already exists", { status: 400 });
+```
+
+Write only if the entry matches a known ETag (compare-and-swap):
+
+```ts
+const { modified } = await store.set(key, "New Jane", { onlyIfMatch: etag });
+if (!modified) return new Response("Cached data is stale", { status: 400 });
+```
+
+**Do not build counters, balances, or read-modify-write logic on a blob key** — even with `onlyIfMatch` retries. That is transactional data; use Netlify DB.
+
+### List blobs
+
+```ts
+const { blobs } = await store.list();          // auto-paginates all pages
+// blobs: [ { etag: "\"etag1\"", key: "..." }, ... ]
+```
+
+Manual pagination (returns an `AsyncIterator`):
+
+```ts
+for await (const entry of store.list({ paginate: true })) {
+  console.log(entry.blobs);
+}
+```
+
+Hierarchical listing — group keys with `/`, set `directories: true` to list one level, and use a **trailing slash** on `prefix` to drill in (without it, `cats` would also match `catsuit`):
+
+```ts
+const { blobs, directories } = await store.list({ directories: true });      // top level
+const catList = await store.list({ directories: true, prefix: "cats/" });    // inside cats/
+```
+
+### List stores
+
+```ts
+const { stores } = await listStores();   // does NOT include deploy-specific stores
 ```
 
 ### Delete
 
-```typescript
-await store.delete("key");
+```ts
+await store.delete(key);                       // resolves undefined
+const { deletedBlobs } = await store.deleteAll(); // deletes the whole store; 0 if it didn't exist
 ```
 
-### List
+### Build plugin — write to a deploy-specific store
 
-```typescript
-const { blobs } = await store.list();
-// blobs: [{ etag: string, key: string }, ...]
+Build plugins can **READ from any of the site's stores, but can WRITE only to deploy-specific stores** (`getDeployStore`).
 
-// Filter by prefix
-const { blobs } = await store.list({ prefix: "uploads/" });
+```js
+import { readFile } from "node:fs/promises";
+import { getDeployStore } from "@netlify/blobs";
+import { v4 as uuid } from "uuid";
+
+export const onPostBuild = async () => {
+  const file = await readFile("some-file.txt", "utf8");
+  const uploads = getDeployStore("file-uploads");
+  await uploads.set(uuid(), file);
+};
 ```
 
-`store.list()` **auto-paginates**: a plain `await store.list()` transparently fetches every page and returns the complete `blobs` array — you do NOT hand-roll page cursors or offsets. For a very large store, pass `{ paginate: true }` to get an async iterator and stream results a page at a time instead of buffering every key in memory:
+### Client-side expiration (no server-side TTL)
 
-```typescript
-for await (const page of store.list({ paginate: true })) {
-  for (const { key } of page.blobs) {
-    // handle each key
-  }
+Blobs have no TTL. Store a timestamp in metadata, check it on read, and `delete` when expired:
+
+```ts
+await uploads.set(key, await req.text(), {
+  metadata: { expiration: new Date("2024-01-01").getTime() }
+});
+const entry = await uploads.getWithMetadata(key);
+const { expiration } = entry.metadata;
+if (expiration && expiration < Date.now()) {
+  await uploads.delete(key);
 }
 ```
 
-Pass `{ directories: true }` to group keys by the `/` delimiter (folder-style): the result's `blobs` holds keys at the current level and `directories` holds the common prefixes, which you drill into with `prefix`. Keys are a flat namespace — `/` is only a naming convention that `prefix` and `directories` let you navigate.
+### Conditional read with ETag (`getWithMetadata`)
 
-## Store Types
-
-- **Site-scoped** (`getStore()`): Persist across all deploys. Use for most cases.
-- **Deploy-scoped** (`getDeployStore()`): Tied to a specific deploy lifecycle.
-
-**A site-scoped store is shared across ALL deploy contexts.** Production, deploy previews, and branch deploys all read and write the *same* `getStore()` store — unlike Netlify Database, which forks a separate branch per preview, Blobs does not isolate previews. Code running on a deploy preview reads, overwrites, and deletes the same production data. Don't run destructive tests or seed throwaway data against a `getStore()` store from a preview — it hits production. When you need per-context isolation, use `getDeployStore()`, or partition by deploy context with a context-specific store `name` or key prefix.
-
-## Consistency and concurrency
-
-Blobs are **eventually consistent by default**: an immediate read right after a write may return the previous value or `null`. Opt into **strong** consistency when you need read-your-writes. You can set it once on the store, or request it per read:
-
-```typescript
-import { getStore } from "@netlify/blobs";
-
-const store = getStore({ name: "my-store", consistency: "strong" });
-
-// or just for a single read that must see the latest write:
-const fresh = await store.get("key", { consistency: "strong" });
+```ts
+const { data, etag } = await uploads.getWithMetadata("my-key", { etag: cachedETag });
+if (etag === cachedETag) {
+  // data is null — cached copy still fresh
+}
 ```
 
-Strong reads are **slower** than eventual reads, so don't make everything strong "to be safe" — reserve it for the reads that genuinely need the latest write (typically a read right after a write in the same request). For read-heavy access to data that rarely changes, the default eventual consistency is faster and is the right choice.
+`getWithMetadata` returns `{ data, etag, metadata }`, or `null` if the key is absent. `getMetadata(key)` returns `{ metadata, etag }` (no blob body) — use it to check existence cheaply.
 
-Blobs has **no concurrency control**: there is no locking and there are no transactions, and concurrent writes to the same key are **last-write-wins** — one silently overwrites the other. Do NOT build counters, balances, or any read-modify-write logic over a single blob key and expect it to be correct under concurrent traffic (two requests can both read the old value and both write back, losing an update). When you need atomic or transactional updates, use Netlify Database (see `netlify-database/SKILL.md`), which provides real transactions — not Blobs.
+## API surface
 
-## Limits
+Store instance methods:
+- `set(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`. `value` is `ArrayBuffer | Blob | string`.
+- `setJSON(key, value, { metadata, onlyIfMatch, onlyIfNew })` → `{ modified, etag }`.
+- `get(key, { consistency, type })` → blob in requested format, or `null`.
+- `getWithMetadata(key, { consistency, etag, type })` → `{ data, etag, metadata }` or `null`.
+- `getMetadata(key, { consistency, etag })` → `{ metadata, etag }` or `null`.
+- `list({ directories, paginate, prefix })` → `{ blobs, directories }` (auto-paginates unless `paginate: true`).
+- `delete(key)` → `undefined`.
+- `deleteAll()` → `{ deletedBlobs }`.
 
-| Limit | Value |
-|---|---|
-| Max object size | 5 GB |
-| Metadata per object | 2 KB |
-| Store name max length | 64 bytes |
-| Key max length | 600 bytes |
+Module functions:
+- `listStores({ paginate })` → `{ stores }`. Excludes deploy-specific stores.
 
-Object metadata is capped at **2 KB per object** — it's for small descriptors (content type, size, timestamps, a status flag), not a place to stash large JSON. Anything bigger belongs in the blob value itself, not in `metadata`.
+## Configuration
 
-## Local Development
+### Consistency
+Default is **eventual**: writes are globally readable immediately; updates and deletes propagate within **60 seconds**. Opt into **strong** consistency per store or per read:
 
-Local dev uses a sandboxed store (separate from production). For Vite-based projects, install `@netlify/vite-plugin` to enable local Blobs access. Otherwise, use `netlify dev`.
-
-**Common error**: "The environment has not been configured to use Netlify Blobs" — install `@netlify/vite-plugin` or run via `netlify dev`.
-
-## Inspecting blobs from the CLI
-
-The Netlify CLI can read and write blobs directly — useful for debugging, seeding, or a one-off fix without writing and deploying a function:
-
-```bash
-netlify blobs:list <store-name>
-netlify blobs:get <store-name> <key>
-netlify blobs:set <store-name> <key> <value>
-netlify blobs:delete <store-name> <key>
+```ts
+const store = getStore({ name: "animals", consistency: "strong" }); // whole store
+await store.get("dog", { consistency: "strong" });                  // single read
 ```
 
-These act on the linked site's store, so link the project first (`netlify link`). Reach for these documented subcommands for manual inspection or repair rather than the raw API.
+The CLI always uses strong consistency.
 
-## Uploading blobs at build time
+### Regions (deploy-specific stores)
+Deploy-specific stores default to the function's region. Override with `region`:
 
-You don't have to write blobs from runtime code — you can seed a store during the build by writing files into a special directory. Files placed in `.netlify/blobs/deploy/` during the build are uploaded to a **deploy-scoped** store and are then readable at runtime via `getDeployStore()`. The path under that directory becomes the blob key (so `.netlify/blobs/deploy/products/1.json` is stored under the key `products/1.json`). This avoids a runtime function looping over `store.set` on a cold start.
+```ts
+const uploads = getDeployStore({ name: "file-uploads", region: "ap-southeast-2" });
+```
 
-To attach metadata to a build-time blob, add a JSON sidecar whose name is the blob's filename prefixed with `$` and suffixed with `.json` — metadata for `logo.png` goes in `$logo.png.json`. Read these blobs back with `getDeployStore()`, not `getStore()`: they live in the deploy-scoped store and are replaced when the deploy is replaced.
+Available regions: https://docs.netlify.com/build/functions/configuration#region
 
-## When a store operation fails
+### File-based uploads (no build plugin)
+Place blob files under `.netlify/blobs/deploy/` in the site's base directory; Netlify uploads them to deploy-specific stores (preserving directory structure) after build, before deploy.
 
-If a `get`/`set` call throws in a deployed function, don't guess at a fix or route around it — the exact error is in the **function logs**, and it almost always names the cause. Read it first. Common causes: the store isn't reachable from the calling context, a missing or mismatched store `name`, or a read-after-write timing gap (an immediate read of a just-written key — use `consistency: "strong"` when you need read-your-writes).
+- Attach metadata with a sibling JSON file prefixed with `$`: `$mouse.jpg.json` for `mouse.jpg`, `dogs/$good-boy.jpg.json` for `dogs/good-boy.jpg`.
+- Metadata files must be valid JSON or **the deploy fails**.
+- `.netlify/blobs/deploy` is **wiped before each build** — files must be created DURING the build (build command or plugin). Files committed to the repo beforehand are NOT uploaded.
+- Requires continuous deployment or CLI deploys.
 
-The store exposes only the documented methods above; there is no lower-level REST endpoint to fall back on. If the logs don't resolve it, report the exact error plus the affected site/deploy to the user and stop. Reaching around a failing store — direct `https://api.netlify.com/...` calls, reading auth tokens off disk, or inventing endpoints — can't work (those aren't supported surfaces) and risks corrupting or losing the very data you're trying to save.
+## Constraints & gotchas
+
+- **Store names:** no `/`, no `:`, max 64 bytes.
+- **Keys:** non-empty, cannot start with `/`, max 600 bytes, any Unicode. (UTF-8: most chars 1 byte, some more, e.g. `à` = 2 bytes.)
+- **Sizes:** object ≤ 5 GB; metadata ≤ 2 KB.
+- **Pagination pages:** `list` and `listStores` cap pages at 1,000 entries/stores.
+- **Last write wins** — no concurrency control beyond `onlyIfMatch` / `onlyIfNew`.
+- **Go Functions cannot access Blobs.**
+- **Local dev (Netlify Dev)** uses a sandboxed local store: no file-based uploads, and you cannot read production data.
+- **Not supported** under Netlify's HIPAA-compliant hosting.
+- Deploy deletion cleans up deploy-specific stores only; other stores need manual deletion or your own expiration logic.
+- Downloading a deploy does NOT include deploy-specific blobs; locking a published deploy does NOT prevent writes to its deploy-specific stores.
+- Encrypted at rest and in transit; blobs are reachable only through your own site.
+
+## When something fails
+Surface the error and read the function logs. Do not invent REST endpoints or side-channel APIs to retry a failed store operation.
+
+## CLI & migration
+Inspect blobs with `netlify blobs:list` / `:get` / `:set` / `:delete` — reference: https://cli.netlify.com/commands/blobs/
+
+If you wrote to site-wide stores with `@netlify/blobs` ≤ 6.5.0, data becomes inaccessible after upgrading (namespacing change). Migrate with the latest CLI, which makes the store accessible on 7.0.0+:
+
+```sh
+netlify recipes blobs-migrate YOUR_STORE_NAME
+```
+
+<!-- system: agent-context/blobs/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (blobs)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Blobs is not a database. For dynamic, per-user, or transactional data,
+   use Netlify DB — Blobs is for objects, files, and cache-like state.
+2. When a store operation fails, surface the error and read the function
+   logs — do not invent REST endpoints or side-channel APIs to retry.
+3. `netlify blobs:list/get/set/delete` exist for inspection; the CLI
+   reference is their source of truth — link, don't restate.
+4. Blobs have no built-in access control — the serving function is the gate.
+   When in doubt, default to private: gate reads behind an authenticated
+   function rather than exposing blobs publicly.
+5. Site-scoped stores are shared across ALL deploy contexts — code on a
+   deploy preview reads, overwrites, and deletes production data. Never run
+   destructive tests or seed throwaway data from previews; use
+   `getDeployStore()` or a context-specific store name for isolation.
+6. Don't build counters, balances, or read-modify-write logic on a blob key —
+   even with `onlyIfMatch` retries. That's transactional data; use Netlify DB.
+7. Build plugins: state BOTH halves — they can read from any of the site's
+   stores, but write only to deploy-specific stores (`getDeployStore`).

--- a/skills/netlify-caching/SKILL.md
+++ b/skills/netlify-caching/SKILL.md
@@ -1,186 +1,311 @@
 ---
 name: netlify-caching
-description: Guide for controlling caching on Netlify's CDN. Use when configuring cache headers, setting up stale-while-revalidate, implementing on-demand cache purge, or understanding Netlify's CDN caching behavior. Covers Cache-Control, Netlify-CDN-Cache-Control, cache tags, durable cache, and framework-specific caching patterns.
+description: Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add caching or cache-control headers to a function response, tune cache TTL or stale-while-revalidate, set up the durable cache, vary a cache key by query/header/cookie/country/language, purge or invalidate the cache by site or cache tag, use the programmatic Cache API (caches.open/match/put) or @netlify/cache helpers (fetchWithCache/cacheHeaders/getCacheStatus), speed up an expensive API call, add ISR or on-demand revalidation, or debug why a response is or isn't cached via the Cache-Status header.
 ---
 
-# Caching on Netlify
+# Netlify caching
 
-## Default Behavior
+## Cache-control header to reach for
 
-**Static assets** are cached automatically:
-- CDN: cached for 1 year, invalidated on every deploy
-- Browser: always revalidates (`max-age=0, must-revalidate`)
-- No configuration needed
+Dynamic responses (Functions, Edge Functions, proxies) are **NOT cached by default** — you must opt in. Set `Netlify-CDN-Cache-Control` on the response:
 
-**Dynamic responses** (functions, edge functions, proxied) are **not cached by default**. Add cache headers explicitly.
+```ts
+import type { Context } from "@netlify/functions";
 
-**Only `GET` requests are cached.** Netlify's CDN caches responses to `GET` requests only. Responses to `POST`, `PUT`, `PATCH`, `DELETE`, and other non-`GET` methods are never cached, no matter what cache headers you set on them. If a response needs to be CDN-cacheable, expose it on a `GET` route (put the inputs in the URL/query string) — you cannot make the CDN cache a mutating `POST` endpoint by adding cache headers.
-
-## Cache-Control Headers
-
-Three headers control caching, from most to least specific:
-
-| Header | Who sees it | Use case |
-|---|---|---|
-| `Netlify-CDN-Cache-Control` | Netlify CDN only (stripped before browser) | CDN-only caching |
-| `CDN-Cache-Control` | All CDN caches (stripped before browser) | Multi-CDN setups |
-| `Cache-Control` | Browser and all caches | General caching |
-
-### Common Patterns
-
-```typescript
-// Cache at CDN for 1 hour, browser always revalidates
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, s-maxage=3600, must-revalidate",
-    "Cache-Control": "public, max-age=0, must-revalidate",
-  },
-});
-
-// Stale-while-revalidate (serve stale for 2 min while refreshing)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=120",
-  },
-});
-
-// Durable cache (shared across edge nodes, serverless functions only)
-return new Response(body, {
-  headers: {
-    "Netlify-CDN-Cache-Control": "public, durable, max-age=60, stale-while-revalidate=120",
-  },
-});
-```
-
-### Immutable Assets
-
-For fingerprinted files (hash in filename):
-
-```toml
-# netlify.toml
-[[headers]]
-for = "/assets/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
-```
-
-## Cache Tags and On-Demand Purge
-
-Tag responses for selective cache invalidation:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-Tag": "product,listing",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
-```
-
-Purge by tag:
-
-```typescript
-import { purgeCache } from "@netlify/functions";
-
-export default async () => {
-  await purgeCache({ tags: ["product"] });
-  return new Response("Purged", { status: 202 });
+export default async (req: Request, context: Context) => {
+  return new Response("Hello world", {
+    headers: {
+      'Netlify-CDN-Cache-Control': 'public, durable, max-age=60, stale-while-revalidate=120'
+    }
+  });
 };
 ```
 
-Purge entire site:
+Header choice (most specific wins; `CDN-Cache-Control`/`Cache-Control` always pass downstream):
+- `Netlify-CDN-Cache-Control` — Netlify CDN only. **Reach for this.**
+- `CDN-Cache-Control` — all CDNs that support it.
+- `Cache-Control` — any CDN or the browser.
 
-```typescript
-await purgeCache();
+**Legacy path to avoid:** On-demand Builders do **not** support these headers or `Netlify-Vary` — they use a TTL pattern and key on URL path only. Don't reach for ODBs in new code.
+
+## Footguns (read first)
+
+- **Only `GET` is cached.** POST/PUT/etc. are never cached regardless of headers — expose cacheable data on a GET route (inputs in the URL or query string).
+- **`netlify dev` does not emulate the CDN cache.** A local cache miss every time is expected. Verify caching on a deployed URL (Deploy Preview or production) via its `Cache-Status` header.
+- **Without `Netlify-Vary: query=...`, the full query string is the cache key** — every distinct query string (`utm_*`, `fbclid`, …) is a separate cache entry. Enumerate only the params that change the response.
+- **Static assets are fresh for up to a year** — a shorter `max-age` is ignored. They change only on a new deploy or manual purge.
+- **basic-auth on ANY page disables caching for the ENTIRE site.**
+- **`durable` is serverless-only** — it has no effect on Edge Function responses.
+- Never opt sensitive content out of automatic invalidation — it can stay publicly cached after deploys/firewall changes.
+
+## Directives
+
+- `public` cache it / `private` browser-only, not Netlify's shared cache / `no-store` don't cache.
+- `s-maxage=N` seconds in Netlify's shared cache (overrides `max-age` there).
+- `max-age=N` seconds in any cache.
+- `stale-while-revalidate=N` serve stale for N seconds after expiry while revalidating in background.
+- `durable` (serverless only) store in Netlify's durable cache so other edge nodes reuse it instead of re-invoking the function.
+
+Defaults when no header is set — static: `Netlify-CDN-Cache-Control: public, s-maxage=31536000, must-revalidate`; dynamic: `Cache-Control: public, max-age=0, must-revalidate`.
+
+## Cache key variation — `Netlify-Vary`
+
+Comma-delimited instructions on the response; pipe-delimited value lists:
+
+```
+Netlify-Vary: query=item_id|page, country=es+de|us, cookie=ab_test|is_logged_in
 ```
 
-`purgeCache()` picks up the site ID and credentials automatically **only when it runs inside a deployed Netlify Function**. Called from anywhere else — a local script, a CI job, a build step, or any code outside the Netlify Functions runtime — it has no ambient credentials, and you must pass a Netlify personal access token (and the site ID). Read the token from an environment variable; never hardcode it:
+- `query=a|b` subset, or bare `query` for all params. Keys case-sensitive; param order irrelevant.
+- `header=Device-Type|App-Version` — custom + most standard headers.
+- `language=en|es+pt` — `+` groups; checked against `Accept-Language` with quality weighting.
+- `country=us|es+pt` — GeoIP, ISO 3166-1 two-letter codes; `+` groups.
+- `cookie=ab_test|is_logged_in` — target specific keys, not the whole `Cookie` header.
 
-```typescript
-await purgeCache({
-  token: process.env.NETLIFY_PURGE_TOKEN, // a Netlify personal access token, from env
-  siteID: process.env.NETLIFY_SITE_ID,
-  tags: ["product"],
-});
+**Cannot vary by header on:** `Accept*`, `Cache-Control`, `Connection`, `Content-Length`, `Cookie`, `Host`, `If-*`, `Range`, `Referer`, `Upgrade`, `User-Agent`. For language/cookie/format use `Vary: Accept-Language`/`Vary: Cookie` or the specific `Netlify-Vary` instruction.
+
+**Consistency rule:** a URL must return the same `Netlify-Vary` on every response — the first cached response's instructions win and later ones are ignored. `Netlify-Vary` + standard `Vary` are both respected (use `Vary` for format/encoding, and to pass instructions to an upstream CDN like Cloudflare).
+
+## Cache tags & opt-out
+
+Tag responses for taggable purging:
+
+```
+Netlify-Cache-Tag: tag1,tag2,tag3
 ```
 
-`Netlify-Cache-Tag` is **purge-only**: tagged responses are still cleared by automatic deploy-based invalidation like everything else. The tag only lets you purge them on demand between deploys.
+- `Netlify-Cache-Tag` (Netlify CDN) wins over `Cache-Tag` (passed downstream). Some providers strip `Cache-Tag` — set both when proxying through them.
+- Constraints: case-insensitive, UTF-8 only, ≤1024 chars/tag, ≤500 tags/response.
 
-### Surviving deploys with `Netlify-Cache-ID`
+Opt a response out of automatic atomic-deploy invalidation with `Netlify-Cache-ID` (comma-separated; auto-registered as cache tags for purging; separate 500-ID limit):
 
-To keep a cached response *across* deploys, set a `Netlify-Cache-ID` header. A response carrying it is **excluded from automatic deploy-based invalidation** — it persists across deploys and clears only on explicit purge. The `Netlify-Cache-ID` value also auto-registers as a purge tag, so you purge it by that same id:
-
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Cache-ID": "catalog",
-    "Netlify-CDN-Cache-Control": "public, s-maxage=86400",
-  },
-});
+```
+Netlify-Cache-ID: cms-proxy,product,image
 ```
 
-```typescript
+After opting out, purge on-demand after relevant changes (e.g. redirect/proxy or function changes behind a `Netlify-Cache-ID`).
+
+## On-demand invalidation (purge)
+
+Purge from a **deployed function** with `purgeCache` (site ID is passed automatically):
+
+```ts
 import { purgeCache } from "@netlify/functions";
 
-// Purge by the same id — it doubles as a purge tag.
-await purgeCache({ tags: ["catalog"] });
+export default async () => {
+  await purgeCache(); // no args = purge everything for the site
+  return new Response("Purged!", { status: 202 });
+};
 ```
 
-## Cache Key Variation
+Purge by tag, optionally targeting a deploy/subdomain:
 
-`Netlify-Vary` controls what creates separate cache entries. Each directive names a dimension — `query`, `header`, `cookie`, `country`, or `language` — followed by an enumerated, pipe-separated list of the values to key on:
+```ts
+import { purgeCache } from "@netlify/functions";
 
-```typescript
-return new Response(body, {
-  headers: {
-    "Netlify-Vary": "cookie=ab_test|is_logged_in",
-  },
+export default async (req: Request) => {
+  const cacheTag = new URL(req.url).searchParams.get("tag");
+  if (!cacheTag) return;
+  await purgeCache({
+    tags: [cacheTag],
+    deployAlias: "deploy-preview-11",
+    domain: "early-access.company.com",
+  });
+  return new Response("Purged!", { status: 202 });
+};
+```
+
+**Ambient credentials only work inside a deployed function.** From CI, local scripts, or the build, pass `token` (a personal access token read from an env var — never hardcoded) and `siteID`.
+
+**Lambda-compatible functions** use the legacy `module.exports.handler = async (event, context) => {…}` signature and must pass `context.clientContext.custom.purge_api_token`:
+
+```ts
+import { purgeCache } from "@netlify/functions";
+
+module.exports.handler = async (event, context) => {
+  const token = context.clientContext.custom.purge_api_token;
+  await purgeCache({ tags: ["tag1", "tag2"], token });
+  return { body: "Purged!", statusCode: 202 };
+};
+```
+
+Direct API (from outside a function) — `POST https://api.netlify.com/api/v1/purge` with `Authorization: Bearer <personal_access_token>` and `Content-Type: application/json`:
+
+```sh
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <personal_access_token>" \
+  --data '{"site_slug": "mysitename", "cache_tags": ["news"], "deploy_alias": "deploy-preview-11", "domain": "early-access.company.com"}' \
+  'https://api.netlify.com/api/v1/purge'
+```
+
+- Purge by site: `site_id` or `site_slug`. By tag: `cache_tags` + site. Omitting `cache_tags` purges the whole site; an **empty** `cache_tags` list purges NOTHING.
+- Identifier mapping: in the UI (Project configuration > General > Project details), **Project ID** = `site_id`, **Project name** = `site_slug`. See https://docs.netlify.com/api-and-cli-guides/api-guides/get-started-with-api#get-site.
+- **Rate limit:** each tag or site can be purged only twice per 5s — exceeding returns `429`.
+
+## Cache API (`caches` global)
+
+Programmatic read/write of HTTP responses from Functions/Edge Functions. Use for caching individual components of a route or arbitrary fetches, alongside header-based route caching.
+
+**Scope rule:** `caches.open()` anywhere, but `match`/`put`/`delete` **only inside the request handler** — doing them at module/global scope throws.
+
+```ts
+import type { Config, Context } from "@netlify/functions";
+
+const cache = await caches.open("my-cache"); // ok in global scope
+
+export default async (req: Request, context: Context) => {
+  const request = new Request("https://example.com/expensive-api");
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const fresh = await fetch(request);
+  if (fresh.ok) {
+    cache.put(request, fresh.clone()).catch((error) => {
+      console.error("Failed to add to the cache:", error);
+    });
+  }
+  return fresh;
+};
+
+export const config: Config = { path: "/cache-api-example" };
+```
+
+`CacheStorage` subset:
+- `caches.match(request)` → `Response` from any cache, or `undefined`.
+- `caches.open(name)` → `Cache`. Distinct names fragment the cache and lower hit ratio — use few, meaningful names.
+
+`Cache` methods (all require `caches.open()`):
+- `cache.match(request)` → `Response` | `undefined`.
+- `cache.put(request, response)` → adds a response.
+- `cache.add(request)` / `cache.addAll(requests)` → fetch + store.
+- `cache.delete(request)` → `true`.
+- `keys()` is **not implemented** — no way to list contents.
+
+Consistency: reads/writes strongly consistent; **deletes eventually consistent** (a deleted entry may still return briefly).
+
+**Cannot cache:** partial responses (206), `Vary: *`, or non-`GET` methods. Responses need a cache-control header with `max-age`/`s-maxage` ≥ 1s, `public` (not `private`/`no-cache`/`no-store`), and a 2xx status — otherwise storage errors. For responses you don't control, rewrite headers with `fetchWithCache`.
+
+**Limits per invocation:** 100 lookups, 20 insertions/deletions. Exceeding: further lookups return nothing; writes/deletes no-op. Limits are shared across edge functions in a request but separate between serverless and edge functions. Cache data is per-region (not replicated), auto-invalidated on redeploy and on `max-age`/`s-maxage` expiry.
+
+## `@netlify/cache` module
+
+Install to get helpers, time constants (`MINUTE`/`HOUR`/`DAY`), and a `caches` export for local dev:
+
+```
+npm install @netlify/cache
+```
+
+**Local-dev workaround:** the `caches` global isn't part of Node.js. Netlify provides it in its Functions/Edge runtimes (live and under `netlify dev`), but if you run your framework's own dev server the global is undefined and throws — import it instead:
+
+```ts
+import { caches } from "@netlify/cache";
+const cache = await caches.open("my-cache");
+```
+
+Requires Netlify CLI 20.0.3+; nothing persists locally (lookups return nothing, writes/deletes don't mutate). No functional change from the global.
+
+### `cacheHeaders(settings)` → header object
+
+```ts
+import { cacheHeaders, DAY } from "@netlify/cache";
+
+const headers = {
+  "x-custom-header": "some value",
+  ...cacheHeaders({
+    ttl: 2 * DAY,          // s-maxage
+    swr: HOUR,             // stale-while-revalidate
+    durable: true,
+    tags: ["product", "sale"],
+    overrideDeployRevalidation: ["tag"], // opt out of atomic-deploy invalidation
+    vary: {
+      cookie: ["ab_test_name", "ab_test_bucket"],
+      query: ["item_id", "page"], // or true for all
+      country: ["us", ["es", "pt"]], // nested = OR
+      language: ["en"],
+      header: ["Device-Type"],
+    },
+  }),
+};
+```
+
+For only generic (non-Netlify) headers, use the `cdn-cache-control` npm module instead.
+
+### `fetchWithCache(resource, options?, cacheSettings?)`
+
+Drop-in `fetch` that returns a cached response or fetches, stores, and returns. `cacheSettings` override conflicting response headers; with `swr`, background revalidation is handled automatically.
+
+```ts
+import { fetchWithCache, DAY } from "@netlify/cache";
+
+const response = await fetchWithCache("https://example.com/expensive-api", {
+  ttl: 2 * DAY,
+  tags: ["product", "sale"],
+  vary: { cookie: ["ab_test_name"], query: ["item_id", "page"] },
 });
 ```
 
-- `query=param1|param2` — key on the named query parameters
-- `header=X-Custom` — key on the named request header
-- `cookie=ab_test|is_logged_in` — key on the named cookies
-- `country=us|de` — serve a distinct cached entry to visitors from the listed countries (two-letter, lowercase ISO country codes)
-- `language=en|fr` — key on the listed `Accept-Language` values
+### `getCacheStatus(response | headers | headerString)`
 
-Combine dimensions by separating directives with commas — e.g. `Netlify-Vary: query=theme, cookie=plan` keys the cache on both the `theme` query parameter and the `plan` cookie. Always enumerate the specific values; keying on an entire dimension (for example a bare `Vary: Cookie`) fragments the cache into a separate entry per unique visitor.
+Returns `{ hit, caches: { durable: { hit, stale, stored, ttl }, edge: { hit, stale } } }`.
 
-## Framework-Specific Caching
-
-### Next.js
-ISR uses Netlify's durable cache automatically (runtime 5.5.0+). `revalidatePath` and `revalidateTag` trigger cache purge.
-
-### Astro / Remix
-Full control over cache headers in server routes. Set `Netlify-CDN-Cache-Control` in responses for CDN caching.
-
-### Nuxt
-Default Nitro preset handles caching. ISR-style patterns use `routeRules` with `swr` or `isr` options.
-
-### Vite SPA
-Static assets are cached by default. API responses from Netlify Functions need explicit cache headers.
-
-**The full query string is part of the cache key by default.** With no `Netlify-Vary: query=` directive, every distinct query string is cached as a separate entry — so appending tracking or marketing params (`?utm_source=…`, `fbclid`, and the like) silently fragments the cache into many near-duplicate entries and lowers the hit rate, even when those params don't change the response. Add `Netlify-Vary: query=<names>` listing only the parameters that actually affect the output; the CDN then keys on just those and ignores all other query params, collapsing the variants onto one cache entry.
-
-## Local Development
-
-`netlify dev` does not emulate the CDN cache. Header-based CDN caching is only observable on a deployed site: locally, cache headers pass through untouched, nothing is stored in or served from the CDN cache, Cache-API reads return no persisted entries, and the `Cache-Status` response header is absent. A "cache miss every time" on `localhost` is expected, not a bug — you cannot validate `Netlify-Vary` keying, cache tags, durable cache, or purge behavior locally. Verify caching on a deployed URL instead (a Deploy Preview or production) and read its `Cache-Status` header.
-
-## Debugging
-
-Check the `Cache-Status` response header. Netlify emits it in the RFC 9211 format — one entry per named cache layer the request passed through, not a bare `HIT`/`MISS`:
-
-```
-Cache-Status: "Netlify Edge"; fwd=miss, "Netlify Durable"; hit; ttl=3600
+```ts
+const { hit, edge, durable } = getCacheStatus(response);
 ```
 
-- A named layer (`"Netlify Edge"`, `"Netlify Durable"`) with `hit` — served from that cache
-- `fwd=miss` — the entry was not in that layer, so the request was forwarded onward
-- `ttl=…` — remaining freshness (seconds) for a hit
+### `needsRevalidation(response)` → boolean
 
-## Constraints
+Only needed when calling `cache.match`/`cache.put` directly (not with `fetchWithCache`+`swr`). True when a Cache-API response is stale within its SWR window — return it, then revalidate in `context.waitUntil` and `cache.put` the fresh copy:
 
-- Basic auth disables caching for the entire site
-- Durable cache is serverless functions only (not edge functions)
-- Same URL must return identical `Netlify-Vary` headers across responses
-- Deploy invalidation is scoped to deploy context (production vs preview)
+```ts
+if (cached) {
+  if (needsRevalidation(cached)) {
+    context.waitUntil(
+      fetch(request).then((fresh) => {
+        const response = new Response(fresh.body, {
+          headers: { ...Object.fromEntries(fresh.headers), ...cacheHeaders({ ttl: MINUTE, swr: HOUR }) },
+        });
+        return cache.put(request, response);
+      })
+    );
+  }
+  return cached;
+}
+```
+
+## Durable cache
+
+Add `durable` (serverless only) so edge nodes lacking a local copy check the shared durable cache before invoking the function — fewer invocations, better cache-miss latency. Eventually consistent, so multiple regions may still invoke the function a few times per version. Co-located with the site's functions region. Works with `Netlify-Vary`, SWR, and on-demand invalidation. **Next.js:** Next Runtime 5.5.0+ uses the durable cache automatically.
+
+## Debugging with `Cache-Status`
+
+Netlify sets `Cache-Status` (RFC 9211) on all responses. Check it on a **deployed** URL. Look for values starting `"Netlify Edge"` or `"Netlify Durable"`:
+
+- `"Netlify Edge"; fwd=miss` — nothing cached.
+- `"Netlify Edge"; hit` — served from cache.
+- `"Netlify Edge"; hit; fwd=stale` — stale served while revalidating (SWR).
+- Durable stored on miss: `"Netlify Durable"; fwd=uri-miss; stored=true; ttl=3600`.
+- Durable hit: `"Netlify Durable"; hit; ttl=1234`.
+
+`ttl` negative = seconds since expiry. Each request may hit a different cache instance — without production traffic or `durable`, expect several empty caches before a hit; repeat requests to warm one.
+
+<!-- Gaps: package/method inconsistency in @netlify/cache local-dev docs (caches import shown with cache.set, not the documented cache.put) resolved to cache.put per Cache API surface. -->
+
+<!-- system: agent-context/caching/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (caching)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Only `GET` responses are cached by the CDN. `POST`/`PUT`/etc. are never
+   cached regardless of headers — expose cacheable data on a `GET` route
+   (put the inputs in the URL or query string).
+2. Without `Netlify-Vary: query=...`, the full query string is the cache key —
+   every distinct query string (`utm_*`, `fbclid`, ...) is a separate cache
+   entry. Enumerate only the params that actually change the response.
+3. `netlify dev` does not emulate the CDN cache — a cache miss every time
+   locally is expected, not a bug. Verify caching behavior on a deployed URL
+   (Deploy Preview or production) via its `Cache-Status` header.
+4. `purgeCache()` has ambient credentials only inside a deployed function.
+   From CI, local scripts, or the build, pass `token` (a personal access
+   token read from an env var, never hardcoded) and `siteID`.

--- a/skills/netlify-config/SKILL.md
+++ b/skills/netlify-config/SKILL.md
@@ -1,228 +1,302 @@
 ---
 name: netlify-config
-description: Reference for netlify.toml configuration and site environment variables. Use when configuring build settings, redirects, rewrites, headers, deploy contexts, the `[dev]` block that controls `netlify dev` (command, port, targetPort, framework), or any site-level configuration — and when managing environment variables or secrets with the Netlify CLI, including scoping values to specific deploy contexts. Covers the complete netlify.toml syntax including redirects with splats/conditions, headers, deploy contexts, functions config, edge functions config, and the `[dev]` block (including when `framework` must be `"#custom"` — required when both a custom `command` and `targetPort` are set).
+description: Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy contexts alongside environment variables/scopes and the Secrets Controller plus redirect/rewrite/proxy and custom-header rules. Use when setting a build command or publish directory, adding redirect or rewrite or proxy rules, configuring custom headers or basic auth, setting or scoping environment variables and secrets, wiring up a monorepo or SPA fallback, or skipping unnecessary builds. Reach for this whenever you touch netlify.toml or ask "why is my env var undefined in a function" or "how do I redirect this path".
 ---
 
-# Netlify Configuration (netlify.toml)
+# Netlify configuration
 
-Place `netlify.toml` at the repository root. In a monorepo, Netlify searches for the config and uses the **first** one it finds: the package directory (the subdirectory containing the site), then the base directory, then the repository root — so put a site-specific `netlify.toml` in the package directory to take precedence over root-level config (see the **netlify-deploy** skill's monorepo notes).
+`netlify.toml` lives at the repo root (or set `base`/package directory for monorepos). Settings in `netlify.toml` **override** the Netlify UI on conflict. `_headers` and `_redirects` are extensionless plain-text files in the **publish directory**, processed **before** `netlify.toml` rules.
 
-**`netlify.toml` takes precedence over the Netlify UI.** When the same property (build command, publish directory, an environment variable, a redirect, a header) is configured in both places, the value in `netlify.toml` wins and silently overrides the corresponding Netlify UI setting — the dashboard field still shows its old value but is inert. Once a `netlify.toml` is present, treat it as the source of truth and change settings there, not in the UI.
+## Footguns (read first)
 
-## Build Settings
+- **Env vars in `netlify.toml` are NOT available to functions or edge functions at runtime** — reading them there returns `undefined`. Vars declared in `netlify.toml` only get the **Builds** and **Post processing** scopes. Set runtime vars in the UI or with `netlify env:set`.
+- **Never put secrets in client-prefixed vars** (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, …) — they are inlined into the client bundle. `--secret` does not protect them.
+- **`.env` is not read by the Netlify build system** — import variables into Netlify first (`netlify env:import`). The CLI reads `.env` only for local builds.
+- **Direct env injection into `netlify.toml` (`key = "$VAR"`) is unsupported** — except signed proxy redirects. Use a build plugin or `sed` in the build command.
+- **`[[redirects]]` and `[[headers]]` are global** — NOT context-aware, cannot be scoped to branches/contexts. Workaround: per-context build command copies a custom file into the publish directory.
+- **Proxy rewrites time out at 26 seconds.** HTTP `307` is unsupported — use `302`.
+
+## `netlify.toml` — core structure
 
 ```toml
 [build]
-  base = "project/"          # Base directory (default: root)
-  command = "npm run build"  # Build command
-  publish = "dist/"          # Output directory
+  base = "project/"          # base directory
+  publish = "build-output/"  # relative to base, default /
+  command = "npm run build"  # runs in Bash shell
+  [build.environment]
+    NODE_VERSION = "18"
+
+[context.production]         # production branch deploy
+  command = "make publish"
+  environment = { NODE_VERSION = "14.15.3" }
+[context.deploy-preview]     # PR/MR previews
+  publish = "dist/"
+[context.branch-deploy]      # non-production branches
+  command = "echo branch"
+[context.dev.environment]    # local dev env vars ONLY
+  NODE_ENV = "development"
+[context.staging]            # a specific branch name
+  command = "echo staging"
+[context."feat/branch"]      # quote branches with special chars
+  command = "echo special"
 ```
 
-## Redirects
+Context precedence (least → most specific): UI settings < base context-aware key < `[context.production|deploy-preview|branch-deploy|dev]` < `[context.branchname]`. Only `[build]` and `[[plugins]]` are context-aware. All paths are absolute relative to the base directory (root `/` default).
 
-```toml
-# Basic redirect
-[[redirects]]
-from = "/old"
-to = "/new"
-status = 301              # 301 (default), 302, 200 (rewrite), 404
+Config file search order: package directory → base directory → root.
 
-# SPA catch-all
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
-
-# Splat (wildcard)
-[[redirects]]
-from = "/blog/*"
-to = "/news/:splat"
-
-# Path parameters
-[[redirects]]
-from = "/users/:id"
-to = "/api/users/:id"
-status = 200
-
-# Force (override existing files)
-[[redirects]]
-from = "/app/*"
-to = "/index.html"
-status = 200
-force = true
-
-# Proxy to external service
-[[redirects]]
-from = "/api/*"
-to = "https://api.example.com/:splat"
-status = 200
-[redirects.headers]
-  X-Custom = "value"
-
-# Country/language conditions
-[[redirects]]
-from = "/*"
-to = "/fr/:splat"
-status = 200
-conditions = { Country = ["FR"], Language = ["fr"] }
-```
-
-**Rule order matters** — Netlify processes the first matching rule. Place specific rules before general ones.
-
-Redirect rules can also live in a plain-text `_redirects` file in the publish directory. If both a `_redirects` file and `[[redirects]]` in `netlify.toml` exist, the `_redirects` file rules are processed **first**, then the `netlify.toml` rules, reading top to bottom — and the first matching rule wins. The same ordering applies to a `_headers` file versus `[[headers]]`. Because a `_redirects` rule can silently shadow a `netlify.toml` rule for the same path, keep overlapping rules in a single source.
-
-## Headers
-
-```toml
-[[headers]]
-for = "/*"
-[headers.values]
-  X-Frame-Options = "DENY"
-  X-Content-Type-Options = "nosniff"
-
-[[headers]]
-for = "/assets/*"
-[headers.values]
-  Cache-Control = "public, max-age=31536000, immutable"
-```
-
-Headers apply only to files served from Netlify's CDN (not to function or edge function responses — set those in code).
-
-## Deploy Contexts
-
-Override settings per deploy context:
-
-```toml
-[context.production]
-command = "npm run build"
-environment = { NODE_ENV = "production" }
-
-[context.deploy-preview]
-command = "npm run build:preview"
-
-[context.branch-deploy]
-command = "npm run build:staging"
-
-[context.dev]
-environment = { NODE_ENV = "development" }
-
-# Specific branch
-[context."staging"]
-command = "npm run build:staging"
-```
-
-**`[[redirects]]` and `[[headers]]` are global — they cannot be scoped to a deploy context.** Context tables like `[context.production]` work for keys such as `[build]`, `[build.environment]`, and `[[plugins]]`, but redirect and header rules apply to every context no matter where you place them in the file; there is no `[context.production.redirects]` or context-nested `[[redirects]]`. For context-specific redirects or headers, use the per-deploy escape hatch: generate a `_redirects` or `_headers` file during that context's build (those files ship per deploy), or gate the behavior on a runtime signal in an edge function.
-
-## Environment Variables
-
-```toml
-[build.environment]
-NODE_VERSION = "20"
-
-[context.production.environment]
-API_URL = "https://api.prod.com"
-
-[context.deploy-preview.environment]
-API_URL = "https://api.staging.com"
-```
-
-**Do not put secrets in netlify.toml** (it's committed to source control). Use the Netlify UI or CLI for sensitive values — see CLI Management below.
-
-**Variables declared in `netlify.toml` are build-scoped only.** Values under `[build.environment]` or `[context.*.environment]` are available to the build (and snippet injection) but are **not** injected into the Functions or Edge Functions runtime — reading them with `Netlify.env.get("VAR")` or `process.env.VAR` inside a function returns `undefined`. To make a variable available at function runtime, set it in the Netlify UI or with `netlify env:set` (those are available to both builds and runtime), not in `netlify.toml`.
-
-### CLI Management
-
-```bash
-# Set
-netlify env:set API_KEY "value"
-netlify env:set API_KEY "value" --secret              # Hidden from logs
-netlify env:set API_KEY "value" --context production   # Context-specific
-
-# Get
-netlify env:get API_KEY
-
-# List
-netlify env:list
-netlify env:list --plain > .env   # Local snapshot only — keep .env gitignored, never commit it
-
-# Import from file
-netlify env:import .env
-
-# Delete
-netlify env:unset API_KEY
-```
-
-**Never put secrets in client-prefixed variables** (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) — these are inlined into the client bundle and exposed to the browser. `--secret` only hides a value from logs and the UI; it does not protect a client-prefixed variable.
-
-### Context Scoping
-
-Variables set via the CLI can also be scoped to deploy contexts:
-
-```bash
-netlify env:set API_URL "https://api.prod.com" --context production
-netlify env:set API_URL "https://api.staging.com" --context deploy-preview
-netlify env:set DEBUG "true" --context branch:feature-x
-```
-
-This is the CLI equivalent of the `[context.*.environment]` tables above, but the resulting variables are available at both build and runtime (unlike `netlify.toml`-declared ones).
-
-When reading these variables in server code, prefer `Netlify.env.get("VAR")`. `process.env.VAR` also works inside Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps the same code working in both runtimes.
-
-For the client-side rules (`VITE_`/`PUBLIC_` prefixes and framework specifics), see the **netlify-frameworks** skill; for function-side details, see **netlify-functions**.
-
-## Functions Configuration
+## Functions config
 
 ```toml
 [functions]
-directory = "netlify/functions"   # Default
-node_bundler = "esbuild"
+  directory = "functions/"           # default: YOUR_BASE_DIR/netlify/functions
+  node_bundler = "esbuild"           # prefer esbuild; zisi is the JS default
+  external_node_modules = ["package-1"]
+  included_files = ["files/*.md", "!files/skip.md"]
 
-# Scheduled function
-[functions."cleanup"]
-schedule = "@daily"
+[functions."api_*"]                  # glob filter; values CONCATENATE across matches
+  external_node_modules = ["package-2"]
 ```
 
-Use the single-table `[functions]` form for global settings and `[functions."name-or-glob"]` for per-function overrides. There is **no** `[[functions]]` array-of-tables and no path-based function routing table in `netlify.toml` — functions are routed by file (served at `/.netlify/functions/{name}`) or by an in-code `path`/`config` export, not by config.
+- `esbuild` = smaller/faster artifacts; TypeScript functions **always** use `esbuild`.
+- `external_node_modules` applies only with `esbuild`. `included_files`: `*` wildcard, `!` excludes; paths absolute to base.
 
-## Edge Functions Configuration
+## Environment variables
+
+Set runtime/scoped vars via CLI/UI/API (not `netlify.toml`):
+
+```sh
+netlify env:set MY_KEY value --secret     # --secret marks an env var secret
+netlify env:import .env                    # site-level, all scopes, all contexts
+netlify env:list --plain --context production > .env
+netlify env:unset MY_KEY
+```
+
+**Keep any `.env` snapshot gitignored — never commit it.**
+
+**Types:** site vars (one site) vs shared vars (whole team; Pro/Enterprise; Team Owners only).
+
+**Scopes** (Pro/Enterprise; default = all): **Builds**, **Functions** (also Edge Functions + On-demand Builders), **Runtime** (forms, signed proxy redirects), **Post processing** (snippet injection). Vars from `netlify.toml` are locked to **Builds** + **Post processing**.
+
+**Scope precedence is independent per scope:** a site variable scoped only to Builds does NOT shadow a shared variable for the Functions scope — the shared value still applies there. Site beats shared only within the scopes the site variable actually carries.
+
+**Deploy-context values:** `Production`, `Deploy Previews`, `Branch deploys` (override per-branch with a `Branch` value, wildcard suffix `release/*`), `Preview server`, `Local development`.
+
+**Overrides:** `netlify.toml` vars override same-key UI/CLI/API vars. Site var beats shared var per its scopes/contexts.
+
+**Limits:** keys ≤ 255 chars, alphanumeric + underscore, first char a letter (`KEY1` ok; `1KEY`/`_KEY1` invalid). Values ≤ 5,000 chars (functions within AWS limits). Reserved read-only names can't be overridden.
+
+### Build variables
+
+Settable in `netlify.toml` `[build.environment]`: `NODE_VERSION`, `NODE_ENV`, `NPM_VERSION`, `NPM_FLAGS`, `NPM_TOKEN`, `YARN_VERSION`, `PNPM_FLAGS`, `BUN_VERSION`, `RUBY_VERSION`, `PHP_VERSION`, `PYTHON_VERSION`, `GO_VERSION`, `HUGO_VERSION`, `NETLIFY_USE_YARN`, `CI`, etc.
+
+**Set in UI/CLI only (NOT `netlify.toml`, which is read after clone):** `AWS_LAMBDA_JS_RUNTIME`, `GIT_LFS_ENABLED`, `GIT_LFS_FETCH_INCLUDE`, `NETLIFY_BUILD_DEBUG`.
+
+Read-only build metadata (examples): `NETLIFY`, `BUILD_ID`, `CONTEXT` (`production`/`deploy-preview`/`branch-deploy`/`dev`), `BRANCH`, `HEAD`, `COMMIT_REF`, `CACHED_COMMIT_REF`, `PULL_REQUEST`, `REVIEW_ID`, `URL`, `DEPLOY_URL`, `DEPLOY_PRIME_URL`, `DEPLOY_ID`, `SITE_NAME`, `SITE_ID`, `ACCOUNT_ID`.
+
+Access: Bash `$VAR_NAME` in build/ignore commands; `process.env.VAR_NAME` in Node scripts and plugins. Scope must include **Builds**.
+
+### Inject env values into headers/redirects
 
 ```toml
-[[edge_functions]]
-path = "/admin/*"
-function = "auth"
-excludedPath = "/admin/public/*"   # Carve exceptions out of `path` (string or array of globs)
-
-# Import map for Deno URL imports
-[functions]
-deno_import_map = "./import_map.json"
+[build]
+  command = "sed -i \"s|HEADER_PLACEHOLDER|${PROD_API_LOCATION}|g\" netlify.toml && yarn build"
 ```
 
-## Dev Server
+Substitution only reaches `[[headers]]`/`[[redirects]]` (read after build); NOT available to build plugins. Alternatively mutate `netlifyConfig` in a local build plugin.
+
+## Redirects & rewrites
+
+`_redirects` (one rule per line) or `[[redirects]]`. Rules process top-down; first match wins. `_redirects`/file rules run before `netlify.toml`.
+
+```
+/home            /                301
+/my-redirect     /                302
+/store id=:id    /blog/:id        301
+/news/*          /blog/:splat
+/*               /index.html      200          # SPA fallback
+```
 
 ```toml
-[dev]
-command = "npm start"       # Dev server command
-port = 8888                 # Netlify Dev port
-targetPort = 3000           # Your app's dev server port
-framework = "#auto"         # "#auto", "#static", "#custom"
+[[redirects]]
+  from = "/old-path"
+  to = "/new-path"
+  status = 302              # default 301
+  force = true             # default false; shadow an existing URL
+  query = { id = ":id" }
+  conditions = { Language = ["en"], Country = ["US"], Role = ["admin"] }
+  [redirects.headers]
+    X-From = "Netlify"
 ```
 
-**If you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`.** With `framework = "#auto"` (the default) Netlify Dev runs its own detector and ignores your custom `command`; `"#custom"` tells it to run your `command` as the app server and connect to `targetPort`. Setting `command` + `targetPort` while leaving `framework` at `#auto` (or omitting it) is a silent misconfiguration.
+- **Force/shadow:** you can't shadow an existing URL by default — append `!` in `_redirects` or `force = true` in toml.
+- **Splats** (`*`) only at the end of a path segment (`/jobs/*.html` won't work). Can't exclude a path from a splat — order a more specific rule first.
+- **Query:** `id=:id` matches URLs with *only* `id` and no other params. List optional-param variants most-general-last.
+- **Trailing slash:** URLs are normalized before rules run; you cannot add/remove a trailing slash via a redirect (infinite loop). Pretty URLs (on by default) handle standardization.
+- **Country/Language conditions:** no spaces (`Country=au,nz`). `Country` = ISO 3166-1 alpha-2; `Language` = browser/locale codes, matches the FIRST `Accept-Language` entry. `nf_country`/`nf_lang` cookies override.
+- **Domain redirects:** HTTP and HTTPS need separate rules unless forcing SSL; the domain must be assigned to the site.
+- Role-based redirects with external auth: Enterprise only. HTTP `307` unsupported → use `302`.
+- **10,000+ redirects:** favor wildcards/placeholders; serialization across `_redirects` + `netlify.toml` can fail the deploy if too large — consider Edge Functions.
 
-## Plugins
+### Rewrites & proxies (status 200)
+
+```
+/api/*            https://api.example.com/:splat        200
+/netlify-site/*   https://my-other-site.netlify.app/:splat  200
+```
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  headers = { X-From = "Netlify" }
+```
+
+- No cross-team rewrites between Netlify sites. Infinite-loop rules (from == to) are ignored.
+- Internal rewrites limited to one hop. Proxy timeout **26s** — use async for longer. Rewrites break relative-path assets — use absolute paths or `<base>`.
+- Proxy to another Netlify site: use its `.netlify.app` subdomain. Rewrites into a separate password-protected site are not allowed.
+
+### Signed proxy redirects (`netlify.toml` only)
+
+```toml
+[[redirects]]
+  from = "/search"
+  to = "https://api.mysearch.com"
+  status = 200
+  force = true
+  signed = "API_SIGNATURE_TOKEN_PLACEHOLDER"
+```
+
+Must be in `netlify.toml`; env var scope must include **Runtime**; not supported proxying Netlify→Netlify. Netlify sends the JWS as HMAC HS256 in the `x-nf-sign` header. (This is the one place `$VAR`-style env injection is allowed.)
+
+## Custom headers
+
+```
+/*
+  X-Frame-Options: DENY
+  cache-control: max-age=0
+  cache-control: no-cache          # multi-value collapses comma-joined
+```
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Basic-Auth = "someuser:somepassword anotheruser:anotherpassword"
+    cache-control = '''
+    max-age=0,
+    no-cache,
+    no-store'''
+```
+
+- **Headers apply only to files Netlify serves from its own store** — proxied content, functions, and edge/SSR pages must return their own headers.
+- Reserved header names Netlify controls (ignored if you set them): `Content-Length`, `Content-Encoding`, `Location` (use redirects), `Set-Cookie` (may be overridden), `Server`, `Date`, `Age`, `Connection`, `Transfer-Encoding`, etc.
+- Basic-Auth headers: Pro/Enterprise. Cross-subdomain cookies impossible on `*.netlify.app` (Public Suffix List) — needs a custom domain.
+- Global only; per-branch via the build-command copy workaround.
+
+## Secrets Controller
+
+Mark a var secret via `--secret` (CLI), `is_secret: true` (API), or the UI. Enforced, non-customizable policy:
+
+- Values are **write-only** — no readable version after setting; the flag can't be removed to reveal a value.
+- Must be set to explicit deploy contexts and scopes; **cannot** have the `post processing` scope.
+- Only code on Netlify reads unmasked values; outside code gets masked. The `dev` context value is unmasked and exempt.
+- Secret scanning (smart detection: Personal/Pro/Enterprise) runs on the next build after marking a var secret. Resolve a detection by removing the value at the location in the deploy log, then redeploy. Safelist false positives via `SECRETS_SCAN_SMART_DETECTION_OMIT_VALUES` (comma-separated), then redeploy.
+
+**Sensitive variable policy (public repos only):** untrusted deploys (unrecognized authors) default to **Require approval**; alternatives are **Deploy without sensitive variables** or **Deploy without restrictions**. Not available for GitHub Enterprise Server / GitLab self-managed (treated as private).
+
+## Ignore builds
+
+```toml
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/blog"
+```
+
+- Exit `0` = no changes, **build stops**; exit `1` = changed, build continues.
+- Runs from base directory; uses fixed **Node.js 18** (not customizable); site `package.json` deps unavailable. Referenced file paths must start with `./`.
+- Won't cancel a build triggered by a build hook, regardless of exit code.
+
+Node.js variant:
+```js
+// ignore_build.js — build only non-debug branches
+process.exitCode = process.env.BRANCH.includes("debug") ? 0 : 1
+```
+
+## JavaScript SPAs
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"        # varies by framework
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200            # required for pushState routing to avoid 404s
+```
+
+Hashed/code-split filenames + atomic deploys can break asset refs (`Uncaught SyntaxError: Unexpected token`) — disable hashed filenames, use permalinks, or a service worker.
+
+## Monorepos
+
+Recommended: set the site's subdirectory as the **package directory** (keep `netlify.toml` there), leave base directory at repo root `/`, declare deps at the subdirectory level.
+
+- **Package directory is UI-only** (Build settings > Configure) — it cannot be set in `netlify.toml`. Base directory can be set in root-level `netlify.toml` (`[build] base`) and overrides the UI.
+- Use absolute paths relative to base: base `/frontend` + plugin at `/frontend/packages/my-app/plugins` → specify `/packages/my-app/plugins/...`.
+- Build only on subdirectory changes with an `ignore` command. CLI: `--filter <site>`. Netlify caches all `node_modules` regardless of where deps are declared.
+
+## Plugins, extensions, dev, templates
 
 ```toml
 [[plugins]]
-package = "@netlify/plugin-lighthouse"
-[plugins.inputs]
-  audits = ["performance", "accessibility"]
+  package = "@netlify/plugin-lighthouse"
+  [plugins.inputs]
+    breeds = ["pomeranian"]
+
+[[integrations]]           # extensions; install on team first
+  name = "abc-performance-extension"
+  [integrations.config]
+    output_path = "reports/perf.html"
+
+[dev]                      # Netlify Dev — NOT run in Bash; no `environment` key here
+  command = "yarn start"
+  targetPort = 3000        # if command + targetPort both set, framework must be "#custom"
+  port = 8888
+  publish = "dist"
+  [dev.https]
+    certFile = "cert.pem"
+    keyFile = "key.pem"
 ```
 
-## Image CDN
+`[dev]` has **no `environment` property** — set local env vars in `[context.dev.environment]` instead. `framework` values: `#auto` (default), `#static`, `#custom`.
 
+For Deploy-to-Netlify buttons use `[template]` / `[template.environment]`.
+
+Post-processing pretty URLs:
 ```toml
-[images]
-remote_images = ["https://example\\.com/.*"]
+[build.processing.html]
+  pretty_urls = true
 ```
 
-See the **netlify-image-cdn** skill for full Image CDN usage.
+<!-- TOML syntax reference: https://toml.io/en/ · Netlify config docs: https://docs.netlify.com/build/configure-builds/file-based-configuration.md -->
+
+<!-- system: agent-context/config/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (config)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Env vars set in `netlify.toml` are NOT available to functions or edge
+   functions at runtime — reading them there returns `undefined`. Set
+   runtime vars in the UI or with `netlify env:set`, not `netlify.toml`.
+2. Never put secrets in client-prefixed env vars (`VITE_`, `NEXT_PUBLIC_`,
+   `PUBLIC_`, ...) — they are inlined into the client bundle; `--secret`
+   does not protect them.
+3. When snapshotting env vars locally (`netlify env:list --plain > .env`),
+   keep `.env` gitignored — never commit it.
+4. State env-var scope interaction explicitly: a site variable scoped to
+   Builds does not shadow the shared variable for other scopes — precedence
+   resolves independently per scope (site beats shared only within the
+   scopes the site variable actually carries).

--- a/skills/netlify-database/SKILL.md
+++ b/skills/netlify-database/SKILL.md
@@ -1,286 +1,78 @@
 ---
 name: netlify-database
-description: Guide for using Netlify Database — the GA managed Postgres product built into Netlify. Use when a project needs any kind of dynamic, structured, or relational data. Covers provisioning via @netlify/database, Drizzle ORM (@beta) setup, migrations, preview branching, and safe production data handling. Blobs is only for file/asset storage — any dynamic data belongs in the database.
+description: Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing schema migrations, setting up Drizzle ORM, local dev with netlify dev, database branches for deploy previews, and migrating an existing Postgres project onto Netlify. Use when adding a database, building a contact form or CRUD API, writing SQL migrations, wiring up Drizzle, running netlify database commands, testing with a local Postgres, or switching from Neon/Supabase/RDS to Netlify Database.
 ---
 
 # Netlify Database
 
-**Netlify Database** is the managed Postgres product built into the Netlify platform. It is **GA** and is the default choice for any dynamic data in a Netlify project.
+Zero-config managed Postgres. Install `@netlify/database`, write migrations under `netlify/database/migrations/`, deploy — Netlify provisions the DB and applies migrations automatically. Queryable from Functions, Edge Functions, Builds, and Agent Runners.
 
-Install `@netlify/database` and Netlify auto-provisions a Postgres database for the site at deploy time. Each deploy preview gets its own isolated branch forked from production data. No Neon account, connection-string wiring, or claim flow — the database is a first-class Netlify primitive.
+## Modern client (reach for this)
 
-## Database vs Blobs
-
-Use **Netlify Database** for anything dynamic:
-
-- Any user-generated or app-generated records (posts, comments, orders, sessions, audit logs)
-- Structured data that will grow, be queried, or be joined
-- Key-value-style data read or written by application code at runtime
-
-Use **Netlify Blobs** only for **file and asset storage**: images, documents, exports, uploads, cached binary artifacts. Do not use Blobs as a dynamic data store — reach for Database instead. See `netlify-blobs/SKILL.md`.
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any database code — answers shape the schema, the seed data, and the query layer:
-
-- **What entities does the app need?** (Users, posts, orders, sessions — drives the schema in `db/schema.ts`.)
-- **Any seed data for the prototype?** (Test rows, default roles, sample content — these become a DML migration, not ad-hoc `INSERT`s against production.)
-- **Drizzle (recommended) or native driver?** (Drizzle for type-safe queries and generated migrations; native for raw SQL or a different query builder like Kysely.)
-
-**If you don't have preferences here, tell me roughly what the app does and I'll pick sensible defaults** — typically Drizzle with timestamp-prefix migrations and a starter schema for the entities the prompt implies.
-
-## CRITICAL: Install Drizzle from the `@beta` dist-tag
-
-The Netlify Database adapter for Drizzle ORM currently only exists on the `beta` release line of `drizzle-orm`. Install **both** `drizzle-orm` and `drizzle-kit` from the `@beta` dist-tag:
-
-```bash
-npm install drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-The default `latest` versions do not include the `drizzle-orm/netlify-db` adapter and will fail. If `drizzle-kit generate` errors about being outdated, or the `drizzle-orm/netlify-db` import fails to resolve, the install is missing `@beta`.
-
-The `@beta` tag only affects the installed version — imports are written as `drizzle-orm`, `drizzle-orm/pg-core`, and `drizzle-orm/netlify-db` without modification.
-
-## CRITICAL: Use the Netlify CLI for database operations
-
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`) that replaces hand-rolled scripts and direct API/UI work. Reach for these commands first before writing custom tooling. **Requires Netlify CLI 26.0.0+** — if a `netlify database` subcommand isn't recognized, run `npm install -g netlify-cli@latest`.
-
-The corollary: **never go around the CLI**, even for read-only work. Don't run `psql`/`pg_dump` or any raw Postgres client (use `netlify database connect --query "..."`), don't curl `https://api.netlify.com/...`, don't read auth tokens off disk for side-channel calls, and don't use `netlify api <method>` as a recovery hatch when provisioning fails — the supported recovery is under [If the first deploy fails to provision the database](#if-the-first-deploy-fails-to-provision-the-database).
-
-If the documented happy path doesn't work, [surface the failure and stop](#when-something-fails-surface-and-stop) — don't escalate to lower-level tools. Full command reference is in [Netlify CLI commands](#netlify-cli-commands-for-netlify-database) below.
-
-## When something fails, surface and stop
-
-When a `netlify` command fails, a deploy fails to provision the database, or any documented happy path errors out, the right action is to **report the failure to the user** with the deploy log URL, the exact error, and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools.
-
-Specific failure modes (like the first-deploy 401) get their own playbooks below. The general rule applies everywhere: a stuck agent surfacing context is far safer than one that wanders off.
-
-## CRITICAL: Never apply migrations to a Netlify-hosted database
-
-The only database you ever apply migrations to yourself is the **local development DB**. For any Netlify-hosted database — production or a deploy preview branch — **Netlify applies migrations automatically during the deploy**. Your job is to create migration files and commit them. The deploy does the rest.
-
-This means:
-
-- Use `netlify database migrations apply` for the local DB. Do NOT run `drizzle-kit migrate` against `NETLIFY_DB_URL` in any context.
-- Do NOT run `drizzle-kit push` at all. Generate a migration and let the deploy apply it.
-- Do NOT run raw DDL (`CREATE`, `ALTER`, `DROP`, `TRUNCATE`) via `netlify database connect`, `psql`, or any other direct connection. Schema changes go through migration files; out-of-band DDL drifts the migration history from the actual schema.
-- Do NOT export `NETLIFY_DB_URL` from a preview or production context and run a client against it. Migrations drift the moment anything touches the schema out-of-band.
-
-The one documented exception is a **one-time data import** during a provider switch — see `references/migration-from-extension.md`. Outside that specific flow, the rule is absolute: schema changes go through migration files, migration files get applied by the deploy.
-
-## Not the legacy "Netlify DB" extension
-
-The older **Netlify DB** extension (Beta) is **deprecated**. It is a separate product and must not be confused with Netlify Database. Do not recommend or install it for new projects.
-
-| | Netlify Database (GA, recommended) | Netlify DB extension (deprecated Beta) |
-|---|---|---|
-| Package | `@netlify/database` | `@netlify/neon` |
-| Env var | `NETLIFY_DB_URL` | `NETLIFY_DATABASE_URL` |
-| Setup | `netlify database init` or install the package — auto-provisioned at deploy | Historically `netlify db init` on older CLI versions, with a claim into the user's Neon account; that flow is no longer reachable from the current CLI |
-| Status | GA | Deprecated; new creation blocked as of April 2026 |
-
-If an existing project is already using the `@netlify/neon` extension, keep it working and encourage the user to switch. See `references/legacy-extension.md` for recognition and coexistence, and `references/migration-from-extension.md` for the full switching process (also covers switching from other external Postgres providers).
-
-## Provisioning
-
-The fastest path is `netlify database init` — an interactive setup that installs `@netlify/database`, lets the user pick Drizzle or raw SQL, writes `drizzle.config.ts` if needed, scaffolds a starter migration, applies it locally, and runs a sample query end-to-end:
-
-```bash
-netlify database init           # interactive
-netlify database init --yes     # accept defaults — for CI/agents
-```
-
-If you'd rather wire things up by hand, install the package directly:
-
-```bash
-npm install @netlify/database
-```
-
-Either way, the presence of `@netlify/database` in the dependency tree triggers provisioning on the next deploy. A database can also be created manually from the Netlify UI before first deploy, but the package + deploy path is the supported automation flow.
-
-### Provisioning workflow: preview-first
-
-The supported inner loop is **preview-first**, not `--prod`-first:
-
-1. **First deploy: `netlify deploy`** (no `--prod`). This provisions the database if needed, applies any pending migrations to the production branch, and produces a draft URL. Verify the deploy log shows `Netlify Database setup completed in <n>s` (and, if migrations exist, `Loading migrations from netlify/database/migrations directory`) before continuing.
-2. **User verifies on the draft URL** — and completes any dashboard-only setup along the way (e.g., enabling Identity if the project also uses it; see `netlify-identity/SKILL.md`).
-3. **Promote: `netlify deploy --prod`**.
-
-Why preview-first matters: the preview deploy provisions the database and applies migrations exactly the way the production deploy will, so a failure during preview is recoverable without prod ever entering a half-configured state. `--prod`-first works in the happy case but is harder to recover from when something goes wrong.
-
-### If the first deploy fails to provision the database
-
-**Symptom:** the build (or the Netlify Database setup extension inside the build) fails with a `401 Access Denied` on `createSiteDatabase`, typically on the very first deploy of a brand-new site. The deploy log shows the failure inside the extension's setup step.
-
-**If the failure happened on `netlify deploy --prod` as the very first deploy**, the first thing to try is the supported preview-first flow — run `netlify deploy` (no `--prod`). The failure has only been observed on `--prod`-first attempts on brand-new sites.
-
-**If a preview deploy also fails — or the original failure was already on a preview — report the failure to the user and stop.** Do not work around it. Specifically, do not:
-
-- Curl `https://api.netlify.com/...` directly
-- Run `netlify api createSiteDatabase` (or any other `netlify api` call to manually create what the platform was supposed to provision)
-- Pull auth tokens out of `~/Library/Preferences/netlify/config.json`
-- Connect via `psql` to "check on things"
-
-The recovery is to give the user the deploy log URL, the site URL, and the exact error, and let them decide what to do next (file a support issue, recreate the site, switch teams).
-
-## Drizzle ORM (recommended path)
-
-Drizzle is the recommended way to work with Netlify Database. Prefer Drizzle over writing raw SQL or hand-editing migration files — manual migrations are an edge case (see `references/migrations.md`).
-
-### Install
-
-```bash
-npm install @netlify/database drizzle-orm@beta
-npm install -D drizzle-kit@beta
-```
-
-### Schema file
-
-Create `db/schema.ts`. Define all tables here using Drizzle's schema builder.
-
-```typescript
-// db/schema.ts
-import { boolean, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
-
-export const items = pgTable("items", {
-  id: serial().primaryKey(),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  isActive: boolean("is_active").notNull().default(true),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
-
-export type Item = typeof items.$inferSelect;
-export type NewItem = typeof items.$inferInsert;
-```
-
-Use snake_case strings for column names (`"is_active"`, `"created_at"`) to match Postgres conventions. Drizzle variable names can be camelCase.
-
-### Drizzle client
-
-Create `db/index.ts`. The adapter on `drizzle-orm/netlify-db` picks the right driver for the runtime automatically.
-
-```typescript
-// db/index.ts
-import { drizzle } from "drizzle-orm/netlify-db";
-import * as schema from "./schema";
-
-export const db = drizzle({ schema });
-```
-
-The connection is configured automatically — no connection string needed. If your project uses native ESM with `.js` extensions on relative imports (`from "./schema.js"`), keep that style consistent here.
-
-### Drizzle Kit config
-
-Create `drizzle.config.ts` at the project root. Set `out` to `netlify/database/migrations` — that's the directory the deploy applies migrations from:
-
-```typescript
-// drizzle.config.ts
-import { defineConfig } from "drizzle-kit";
-
-export default defineConfig({
-  dialect: "postgresql",
-  schema: "./db/schema.ts",
-  out: "netlify/database/migrations",
-});
-```
-
-No `migrations` block is needed: `drizzle-kit generate` (the `@beta` line this skill pins) already defaults to timestamp prefixes, which keep filenames unique when branches generate migrations in parallel. Setting `migrations: { prefix: "timestamp" }` explicitly is harmless but redundant — and forcing a sequential `prefix: "index"` is what causes the parallel-branch collisions, so don't.
-
-### Package scripts
-
-```json
-{
-  "scripts": {
-    "db:generate": "drizzle-kit generate",
-    "db:migrate": "netlify database migrations apply"
-  }
-}
-```
-
-- `db:generate` writes a new migration file under `netlify/database/migrations/` from the current schema.
-- `db:migrate` applies pending migrations to the **local development database only**, via the CLI. Hosted migrations (preview branches, production) are applied by the deploy — never by this script.
-
-### Schema-change workflow
-
-1. Edit `db/schema.ts`.
-2. `npm run db:generate` — writes a new file into `netlify/database/migrations/`.
-3. Review the SQL.
-4. `npm run db:migrate` — applies it to the local development DB for testing.
-5. Commit the schema change and migration file together and push. The deploy applies the migration to the preview branch, then to production on publish.
-
-### Query patterns
-
-```typescript
-import { db } from "./db";
-import { items } from "./db/schema";
-import { eq, desc } from "drizzle-orm";
-
-// Select all
-const all = await db.select().from(items);
-
-// Select with condition
-const [one] = await db.select().from(items).where(eq(items.id, id)).limit(1);
-
-// Ordering and limit
-const recent = await db.select().from(items).orderBy(desc(items.createdAt)).limit(10);
-
-// Insert
-const [created] = await db.insert(items).values({ title: "New" }).returning();
-
-// Update
-const [updated] = await db.update(items).set({ title: "Updated" }).where(eq(items.id, id)).returning();
-
-// Delete
-await db.delete(items).where(eq(items.id, id));
-```
-
-Full migration workflow, expand-and-contract for breaking schema changes, and production DML migrations are in `references/migrations.md`.
-
-## Native driver (when Drizzle isn't a fit)
-
-When a project wants raw SQL, uses a different query builder (Kysely, etc.), or has a library that needs a `pg.Pool`, use the native driver exposed by `@netlify/database`.
-
-```bash
-npm install @netlify/database
-```
-
-```typescript
+```ts
 import { getDatabase } from "@netlify/database";
 
-const db = getDatabase();
-
-// Tagged template — parameters are safely bound, not interpolated
-const users = await db.sql`SELECT * FROM users WHERE active = ${true}`;
-
-// Insert with RETURNING
-const [user] = await db.sql`
-  INSERT INTO users (name, email)
-  VALUES (${name}, ${email})
-  RETURNING *
-`;
-
-// Bulk insert
-const rows = db.sql.values([
-  ["Ada", "ada@example.com"],
-  ["Bob", "bob@example.com"],
-]);
-await db.sql`INSERT INTO users (name, email) VALUES ${rows}`;
+const db = getDatabase();               // auto-selects connection for the runtime
+const userId = 42;
+const users = await db.sql`SELECT * FROM users WHERE id = ${userId}`;  // auto-parameterized
 ```
 
-Transactions go through `db.pool` so `BEGIN`, the queries, and `COMMIT`/`ROLLBACK` all run on the same connection:
+Own driver / ORM instead:
+```ts
+import { getConnectionString } from "@netlify/database";
+const connectionString = getConnectionString();  // correct branch for this env
+```
 
-```typescript
-import { getDatabase } from "@netlify/database";
+**Legacy — do NOT use for new code:** `import { neon } from "@netlify/neon"`. Superseded by `@netlify/database`. Replace `neon()` calls with the Drizzle `netlify-db` adapter or a Postgres driver via `getConnectionString()`. The legacy env var `NETLIFY_DATABASE_URL` is replaced by `NETLIFY_DB_URL`.
 
+## Where things go
+
+| What | Location |
+|------|----------|
+| Migrations | `netlify/database/migrations/` (SQL files or subdirs with `migration.sql`) |
+| Query code | Functions (`netlify/functions/`), Edge Functions |
+| Drizzle schema | `db/schema.ts` (convention) |
+| Drizzle client | `db/index.ts` (convention) |
+| Connection string | `NETLIFY_DB_URL` env var, or `getConnectionString()` |
+
+## Querying
+
+`getDatabase(options?)` returns a client with `sql` and `pool`. `options.connectionString` overrides the auto-provisioned one; `options.debug` enables logging.
+
+```ts
 const db = getDatabase();
+const active = await db.sql`SELECT * FROM users WHERE active = ${true}`;
+await db.sql`INSERT INTO users (name, email) VALUES (${"Ada"}, ${"ada@example.com"})`;
+await db.sql`UPDATE users SET name = ${"Ada Lovelace"} WHERE id = ${1}`;
+await db.sql`DELETE FROM users WHERE id = ${1}`;
+
+// Type the rows
+interface User { id: number; name: string; email: string; }
+const typed = await db.sql<User>`SELECT * FROM users`;
+
+// Stream
+for await (const row of db.sql`SELECT * FROM users`.stream()) { /* ... */ }
+for await (const chunk of db.sql`SELECT * FROM users`.chunked(100)) { /* ... */ }
+```
+
+`SQLTemplate` methods: `execute()` → `Promise<T[]>`, `stream()` → `AsyncGenerator<T>`, `chunked(n)` → `AsyncGenerator<T[]>`, `toSQL()` → raw SQL + params without executing.
+
+`sql` helpers:
+- `sql.identifier(value)` — safe table/column name. String, string[], or `{ schema, table, column, as }`.
+- `sql.values(rows)` — bulk-insert values list from a 2D array.
+- `sql.default` — the SQL `DEFAULT` keyword.
+- `sql.raw(value)` — **injects unparameterized SQL; bypasses injection protection. Only for trusted constants (e.g. `"DESC"`), never user input.**
+- `sql.unsafe(query, params?, { rowMode })` — raw query string with `$1` params; `rowMode` is `"array"` or `"object"`.
+
+### Transactions — use `pool`
+
+`db.pool` is a [`pg.Pool`](https://node-postgres.com/apis/pool). `BEGIN`/queries/`COMMIT` must run on the same connection:
+```ts
 const client = await db.pool.connect();
 try {
   await client.query("BEGIN");
-  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", [name, email]);
-  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [id, title]);
+  await client.query("INSERT INTO users (name, email) VALUES ($1, $2)", ["Ada", "ada@example.com"]);
+  await client.query("INSERT INTO posts (author_id, title) VALUES ($1, $2)", [1, "First post"]);
   await client.query("COMMIT");
 } catch (e) {
   await client.query("ROLLBACK");
@@ -290,76 +82,307 @@ try {
 }
 ```
 
-For third-party tools that need a raw connection string, import `getConnectionString` from `@netlify/database` — but prefer `getDatabase()` for application code.
+Own drivers:
+```ts
+import { getConnectionString } from "@netlify/database";
+import pg from "pg";
+const pool = new pg.Pool({ connectionString: getConnectionString() });
 
-### Manual migrations
-
-With the native driver, scaffold migration files via the CLI:
-
-```bash
-netlify database migrations new -d "create users table"
+// or the `postgres` driver via env var
+import postgres from "postgres";
+const sql = postgres(process.env.NETLIFY_DB_URL);
 ```
 
-This creates `netlify/database/migrations/<prefix>_<slug>/migration.sql` and prompts for the numbering scheme if it can't be detected from existing files. Open the file and write the SQL. The CLI auto-detects an existing scheme; for new projects it'll ask — choose `timestamp` unless you have a reason not to.
+## Drizzle ORM
 
-You can also write the file by hand if you prefer. Two layouts are supported:
+**Install both packages from `@beta` — required.** `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail.
+```bash
+npm install @netlify/database drizzle-orm@beta
+npm install -D drizzle-kit@beta
+```
 
-- **Flat:** `netlify/database/migrations/<prefix>_<slug>.sql`
-- **Subdirectory:** `netlify/database/migrations/<prefix>_<slug>/migration.sql` (what `migrations new` produces)
+`drizzle.config.ts` — you **MUST** set `out` to the Netlify migrations directory or Netlify won't apply generated migrations:
+```ts title="drizzle.config.ts"
+import { defineConfig } from "drizzle-kit";
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./db/schema.ts",
+  out: "netlify/database/migrations",   // NOT the default "drizzle"
+});
+```
 
-In both, `<prefix>` is digits (timestamp like `20260417143022` or sequential like `0001`) and `<slug>` is lowercase letters, numbers, hyphens, or underscores. Files apply in lexicographic order. See `references/migrations.md`.
+```ts title="db/schema.ts"
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+export const users = pgTable("users", {
+  id: serial().primaryKey(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  createdAt: timestamp().defaultNow(),
+});
+```
 
-Once a migration has been applied to any database, never modify it — roll forward with a new migration instead.
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";  // native adapter, auto-configured
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
 
-## Connection — don't reach for the env var
+```ts title="netlify/functions/api.ts"
+import { desc } from "drizzle-orm";
+import type { Config, Context } from "@netlify/functions";
+import { db } from "../../db";
+import { users } from "../../db/schema";
 
-`NETLIFY_DB_URL` is set automatically across builds, functions, edge functions, and local dev. Use the `getDatabase()` / `getConnectionString()` helpers above rather than reading it directly — only reach for the raw env var for third-party tools that demand a bare string.
+export default async (req: Request, context: Context) => {
+  if (req.method === "GET") {
+    const allUsers = await db.select().from(users).orderBy(desc(users.createdAt));
+    return Response.json(allUsers);
+  }
+  if (req.method === "POST") {
+    const { name, email } = await req.json();
+    const [user] = await db.insert(users).values({ name, email }).returning();
+    return Response.json(user, { status: 201 });
+  }
+  return new Response("Method not allowed", { status: 405 });
+};
 
-`NETLIFY_DB_URL` is intentionally different from the legacy extension's `NETLIFY_DATABASE_URL`. The two coexist so a project mid-migration doesn't break. Don't rename between them.
+export const config: Config = { path: "/api/users" };
+```
 
-## Preview branching
+Generate migrations after editing the schema: `npx drizzle-kit generate`.
 
-Each deploy preview runs against its own database branch forked from production data — schema and data changes in a preview don't affect production until the branch is merged and published. Migrations run against the preview branch first (failures fail the preview, not production), and ad-hoc preview edits (UI data browser or a direct client) don't propagate to production — always express production changes as migrations.
+**Never run `drizzle-kit push` against a Netlify-hosted database, and never run `drizzle-kit migrate` against `NETLIFY_DB_URL`.** Schema reaches hosted DBs only as committed migration files applied by the deploy. `generate` writes files; the deploy applies them.
 
-## Changing existing data — production or preview?
+## Migrations
 
-A request to change existing data — "rename this category", "fix the broken row for user X" — is **ambiguous about where it should land**: production, or only the current preview branch. Resolve that fork *before* changing anything: if the prompt didn't say, ask. When acting on someone's behalf, default to **not** touching production unless they explicitly asked.
+Files live in `netlify/database/migrations/`. Two formats:
+```text
+netlify/database/migrations/20260301143000_create_users.sql          # single SQL file
+netlify/database/migrations/20260318091500_add_posts/migration.sql   # subdir form
+```
 
-Once it's production-bound, express it as a **DML migration**, never a direct write:
+Naming: `<number>_<slug>` — `number` is digits (timestamp or `0001`…) defining order; `slug` is lowercase letters/numbers/hyphens/underscores. Sorted **lexicographically**, applied in order. **Use timestamp prefixes** (`netlify database migrations new` handles this) to avoid out-of-order rejection.
 
-- **Don't run the `UPDATE`/`INSERT`/`DELETE` against production** (or ad-hoc in a preview). Generate a DML migration in `netlify/database/migrations/` (raw SQL or Drizzle-generated) and commit it — the deploy applies it, like a schema migration.
-- Tell the user you created a data migration; merging the branch applies it to production. Have them **verify in the deploy preview first** (it runs against a forked copy of production data).
+```sql title="netlify/database/migrations/20260425103000_create_comments.sql"
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id),
+  author_id INTEGER NOT NULL REFERENCES users(id),
+  body TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
 
-Covers seed data, backfills, cleanups, CSV imports, and single-row fixes. Full detail in `references/migrations.md`.
+**When applied:**
+- Production deploy: applied immediately before publish; a failure blocks publish. With auto-publish off, Netlify waits for manual publish before applying.
+- Deploy preview: applied on every deploy before it goes live; a failure fails the deploy.
+- Local: **not** automatic — run `netlify database migrations apply` yourself.
 
-## Netlify CLI commands for Netlify Database
+**Migration footguns (all detected as drift / rejected):**
+- **Never edit an applied migration** — checksum drift: `migration "<name>" has been modified after being applied`. Write a new corrective migration.
+- **Never remove an applied migration** — `... has been removed after being applied`. Restore it.
+- **Out-of-order:** a prefix ≤ the highest applied version is rejected. Timestamps avoid this.
+- Prefer backwards-compatible migrations. Breaking changes (rename/drop column) → expand-and-contract across multiple deploys. New table / nullable column → single migration is fine.
 
-The CLI ships a complete database surface under `netlify database` (alias: `netlify db`). Requires CLI 26.0.0+. Most commands accept `--json` for machine-readable output — useful when scripting or reading results from an agent.
+Bring-your-own migration system: pick a directory **other than** `netlify/database/migrations` to avoid automatic detection, and you own applying to preview branches and production.
 
-Full per-command reference — `init`, `status`, `connect`, `migrations new` / `apply` / `pull` / `reset`, and `reset` — is in `references/cli-commands.md`. The one rule that applies across all of them: **never run DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`) through `connect`, `psql`, or any direct connection** — schema changes go through migration files.
-
-## Iterating on migrations
-
-When a migration you generated needs to change, what you do depends on whether it's been applied anywhere yet:
-
-- **Already applied** to any database (local dev DB, a preview branch, or production) → treat as immutable. Roll forward with a new migration that applies the correction.
-- **Only on disk** (not yet applied anywhere) → don't edit the SQL or snapshot files by hand. Run `netlify database migrations reset`, update `db/schema.ts`, then re-run `npm run db:generate`. Hand-editing desyncs Drizzle Kit's internal state and tends to produce broken migrations on the next generate.
+See `references/migrations.md`.
 
 ## Local development
 
-`netlify dev` runs against a local Postgres-compatible database — no remote connection, no risk to production. The local DB is the only one you migrate yourself (`netlify database migrations apply`).
+Local is **one** database that all code targets — branches are a deploy-time concept and don't exist locally. It's a real Postgres-compatible engine mirroring production, but single-process (not for load testing); auto-scale/sleep settings don't apply.
 
-## Common mistakes
+Start it — either path, state is interchangeable:
+```bash
+netlify dev                                    # CLI starts + tears down the local DB
+```
+Or the Vite plugin:
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import netlify from "@netlify/vite-plugin";
+export default defineConfig({ plugins: [netlify()] });
+```
 
-1. **Missing `@beta`** — `drizzle-orm`/`drizzle-kit` must be `@beta`; `latest` lacks the `drizzle-orm/netlify-db` adapter.
-2. **Wrong output dir** — set `out: "netlify/database/migrations"` in `drizzle.config.ts`; migrations elsewhere aren't applied by the deploy.
-3. **Self-applying hosted migrations** — never `drizzle-kit migrate`/`push` or DDL via `connect` against production/preview; commit migration files and let the deploy apply them.
+Common commands (while local DB is running):
+```bash
+netlify database migrations apply                        # apply pending locally
+netlify database migrations new -d "add users table"     # scaffold new migration
+netlify database migrations pull                          # overwrite local migrations from remote
+netlify database status                                   # enabled? installed? applied/pending migrations
+netlify database connect                                  # interactive SQL REPL
+netlify database connect --query "SELECT * FROM users LIMIT 10"
+netlify database reset                                    # drop all schemas/tables — LOCAL ONLY
+netlify database migrations reset                         # delete unapplied local migration files
+```
 
-## References
+External tools (works while `netlify dev` runs):
+```bash
+psql "$(netlify database connect --json | jq -r .connection_string)"
+```
 
-- [Migrations](references/migrations.md) — full migration workflow, expand-and-contract for breaking changes, and production DML
-- [CLI commands](references/cli-commands.md) — `init`, `status`, `connect`, and `migrations new` / `apply` / `pull` / `reset`
-- [Local development](references/local-dev.md) — running against a local Postgres-compatible database with `netlify dev`
-- [Operational footguns](references/operational-footguns.md) — client reuse, cold starts, preview-data (PII) exposure, legacy-extension deletion
-- [Legacy `@netlify/neon` extension](references/legacy-extension.md) — recognizing and coexisting with the older extension
-- [Migrating from the extension](references/migration-from-extension.md) — switching from `@netlify/neon` or other external Postgres, including the one-time data import
+See `references/local-dev.md`.
+
+## Setup
+
+New project: describe your app to Agent Runners at https://app.netlify.com/start, or `netlify create "<description>"` locally.
+
+Existing project:
+```bash
+netlify database init      # installs @netlify/database, picks Drizzle or raw SQL, scaffolds a migration
+netlify database init --yes # non-interactive (CI / agents)
+netlify dev
+```
+Manual: `npm install @netlify/database`, write a migration under `netlify/database/migrations/`, write a function, `netlify dev`, deploy.
+
+**If `@netlify/database` is NOT installed, Netlify will NOT auto-provision a database** — you'd have to create one manually from the UI **Database** menu. Install the package.
+
+## CLI reference (`netlify database`)
+
+Prereqs: Node ≥ 20.12.2, Netlify CLI ≥ 26.0.0 (`npm install -g netlify-cli`). All commands support `--json`.
+
+| Command | Purpose | Key flags |
+|---------|---------|-----------|
+| `init` | Set up DB in project | `-y, --yes` |
+| `status` | State: enabled, installed, connection string, applied/pending migrations | `-b, --branch`, `--show-credentials` |
+| `connect` | SQL REPL, or `--query` one-shot | `-q, --query`, `--json` |
+| `migrations apply` | Apply pending to local DB | `--to <name>` |
+| `migrations new` | Scaffold a migration | `-d, --description`, `-s, --scheme sequential\|timestamp` |
+| `migrations pull` | Overwrite local files from a branch | `-b, --branch`, `--force` |
+| `migrations reset` | Delete unapplied local migration files | `-b, --branch` |
+| `reset` | Drop all data/tables — **local only** | — |
+
+See `references/cli-commands.md`.
+
+## REST API
+
+Scoped to a site, rooted at `https://api.netlify.com/api/v1`, OAuth 2. Full reference: https://open-api.netlify.com.
+
+| Method + path | Purpose |
+|---------------|---------|
+| `POST /sites/{site_id}/database` | Create DB (returns existing conn string if present); `region` optional |
+| `GET /sites/{site_id}/database` | Get connection string |
+| `POST /sites/{site_id}/database/branch` | Create branch; body `deploy_id` (req), `parent_branch_id` (opt, defaults to production) |
+| `GET /sites/{site_id}/database/branch/{deploy_id}` | Get branch conn string (404 if none) |
+| `DELETE /sites/{site_id}/database/branch/{deploy_id}` | Delete a deploy's branch |
+| `POST /sites/{site_id}/database/snapshot` | Snapshot a branch (defaults production) |
+| `GET /sites/{site_id}/database/snapshots` | List snapshots |
+| `DELETE /sites/{site_id}/database/snapshot/{snapshot_id}` | Delete a snapshot |
+| `POST /sites/{site_id}/database/snapshot/{snapshot_id}/restore` | Restore snapshot to a branch (defaults production) |
+
+**Branch delete and snapshot restore are destructive and require explicit user confirmation first.** Snapshot restore is not a routine production-rollback lever.
+
+## Testing
+
+Bare Postgres for unit/integration tests (no functions):
+```ts title="db.test.ts"
+import { NetlifyDB } from "@netlify/database-dev";  // npm i -D @netlify/database-dev
+import { Client } from "pg";
+import { afterAll, beforeAll, expect, test } from "vitest";
+
+let db: NetlifyDB, connectionString: string;
+beforeAll(async () => {
+  db = new NetlifyDB();
+  connectionString = await db.start();
+  await db.applyMigrations("./netlify/database/migrations");
+});
+afterAll(async () => { await db.stop(); });
+
+test("inserts and reads a user", async () => {
+  const client = new Client({ connectionString });
+  await client.connect();
+  await client.query("INSERT INTO users (name) VALUES ($1)", ["Ada"]);
+  const { rows } = await client.query("SELECT name FROM users");
+  expect(rows).toEqual([{ name: "Ada" }]);
+  await client.end();
+});
+```
+`NetlifyDB(options?)`: `directory` (persist to disk; omit = in-memory), `port` (default random), `logger`.
+
+Full Netlify environment (functions/edge functions read `NETLIFY_DB_URL` as in production):
+```ts
+import { NetlifyDev } from "@netlify/dev";  // npm i -D @netlify/dev
+const netlifyDev = new NetlifyDev({ projectRoot: "./fixtures/my-project" });
+await netlifyDev.start();  // sets NETLIFY_DB_URL in the runtime
+// ...tests...
+await netlifyDev.stop();
+```
+
+## Database branches (deploy-time)
+
+Production deploys are the only deploys that touch the production database. Each deploy preview gets its own branch, seeded with a copy of production data at preview-creation time; schema/data changes there never affect production. Wired up automatically, no code changes.
+
+**Preview branches can contain production data, including PII — and preview deploy links are public. Warn the user before sharing a preview link.**
+
+## Runtime gotchas
+
+- **`Environment not configured`** (`getDatabase()` can't resolve a connection string): running outside Netlify, on **Functions in Lambda compatibility mode**, or an outdated CLI. Fix: pass `connectionString` explicitly.
+  ```ts
+  const db = getDatabase({ connectionString: "postgres://..." });
+  ```
+  Lambda compatibility mode is the one primitive where you must pass `connectionString` yourself.
+- **`database feature not available for this account`** — requires a Credit-based plan.
+- **`compute customization requires a Pro or higher plan`** — auto-scale / sleep settings need Pro+; Free/Personal use defaults.
+- **`branch limit reached: maximum <N> branches...`** — each active deploy preview consumes a branch; delete unneeded branches or upgrade.
+- **`database not found`** — no DB provisioned; run `netlify database init`.
+- **`cannot reset the production branch`** — reset is non-production only.
+
+## Constraints
+
+- **Plan:** Netlify Database is available on Credit-based plans only; active DBs consume credits for compute and bandwidth. Storage is free until July 1, 2026.
+- **Permissions:** only a Team Owner can delete a database; only Team Owners and Developers can view connection strings (`Access Denied` = insufficient role).
+- **Secrets:** connection strings contain username + password. Never commit them; store in a secret manager / env var provider.
+
+## Switch an existing Postgres project to Netlify Database
+
+Three phases: provision (baseline schema on a branch), rehearse (swap code, copy data into a preview branch, validate), cut over (import data into production, merge). Works from any Postgres source (Neon, Supabase, RDS, self-managed, legacy `@netlify/neon`). Uses `pg_dump`/`pg_restore` (versions matching the source). There is a brief data-loss window — writes to the source between final export and production deploy don't cross over.
+
+Phase 2/3 code swap (Drizzle):
+```ts title="db/index.ts"
+import { drizzle } from "drizzle-orm/netlify-db";
+import * as schema from "./schema";
+export const db = drizzle({ schema });
+```
+
+Full step-by-step (dump flags, rollback, cleanup): `references/migration-from-extension.md` and `references/legacy-extension.md`.
+
+<!-- Gaps: plan-tier naming (Credit-based vs Free/Personal/Pro) not reconciled in source; exact plan limits, permission tables, and snapshot UI flows live on pages outside this grouping. -->
+
+<!-- system: agent-context/database/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (database)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Production data changes are expressed as DML migrations — agents never
+   edit rows directly (UI row editing exists for humans; it is not an agent
+   surface).
+2. Preview branches can contain production data, including PII — and preview
+   deploy links are public. Warn before sharing.
+3. Use only documented surfaces: no raw psql against internal endpoints, no
+   `netlify api` scraping, no reading tokens from local CLI config files.
+4. Deep guides live in this skill: `references/operational-footguns.md`,
+   `references/migrations.md`, `references/local-dev.md`,
+   `references/cli-commands.md`, `references/migration-from-extension.md`,
+   `references/legacy-extension.md`.
+5. Schema changes reach hosted databases only as committed migration files
+   applied by the deploy. Never run `drizzle-kit push` in any form against a
+   Netlify-hosted database, never run `drizzle-kit migrate` against
+   `NETLIFY_DB_URL`, and never apply DDL via `netlify database connect` or
+   any direct connection.
+6. When a `netlify` command or a deploy fails, surface the exact error, the
+   deploy log URL, and the affected site/branch to the user and stop — do
+   not invent recovery commands or escalate to lower-level tools.
+7. First-deploy `401 Access Denied` on `createSiteDatabase`: if it happened
+   on a `--prod`-first deploy, retry preview-first (`netlify deploy`, no
+   `--prod`); if a preview also fails, report and stop. Never curl
+   `api.netlify.com`, run `netlify api createSiteDatabase`, or pull tokens
+   from local CLI config to work around it.
+8. A request to change existing data is ambiguous between production and the
+   preview branch — if the prompt didn't say, ask. When acting on someone's
+   behalf, default to not touching production.
+9. Destructive database operations — REST branch delete, snapshot restore,
+   any reset — require explicit user confirmation first. The body must not
+   present snapshot restore as a routine production-rollback lever.
+10. Pin: `drizzle-orm` and `drizzle-kit` must be installed from `@beta` —
+    `latest` lacks the `drizzle-orm/netlify-db` adapter and will fail. The
+    body may not soften this to a recommendation.

--- a/skills/netlify-deploy/SKILL.md
+++ b/skills/netlify-deploy/SKILL.md
@@ -1,153 +1,186 @@
 ---
 name: netlify-deploy
-description: Deploy, host, and publish web projects on Netlify with the Netlify CLI. Use when the user wants to deploy a site or repository to Netlify, link a local project to a Netlify site, ship a production or preview/draft deploy, set up Git-based continuous deployment, run a manual or local deploy, configure CI deploys, or troubleshoot a failed or misconfigured deploy. Also use to view or tail a deployed site's runtime logs — function and edge-function output, deploy logs — via `netlify logs` when debugging what a live site is doing (recent errors, recent activity, streaming output).
+description: Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons, drag-and-drop, and per-context netlify.toml build settings. Use when linking a repo, deploying from the CLI, setting up Deploy Previews or branch deploys, configuring deploy contexts, adding skew protection, fixing a failed or secrets-flagged deploy, or wiring build hooks and Deploy to Netlify buttons.
 ---
 
-# Netlify Deployment
+# Netlify deploy
 
-Install the CLI, link a project to a Netlify site, and deploy it — either through Git-based continuous deployment (the primary path) or a manual CLI upload (for prototypes and CI). Environment-variable management lives in the **netlify-config** skill; local development lives in the **netlify-frameworks** skill.
+## Deploy context config (netlify.toml, current form)
 
-## Installation
+Configure per-context build settings in `netlify.toml` at the repo root. Five predefined contexts: `production`, `deploy-preview`, `branch-deploy`, `preview-server`, `dev`. Branch names also work as custom contexts (a `staging` branch matches a `staging` context).
 
-```bash
-npm install -g netlify-cli    # Global (for local dev)
-npm install netlify-cli -D    # Local (for CI)
+```toml
+[context.production]
+  command = "make production"
+  [context.production.environment]
+    ACCESS_TOKEN = "super secret"
+  # Plugins context REQUIRES double brackets:
+  [[context.production.plugins]]
+    package = "@netlify/plugin-sitemap"
+
+[context.deploy-preview.environment]
+  ACCESS_TOKEN = "not so secret"
+
+[context.branch-deploy]
+  command = "make staging"
+
+[context.dev.environment]
+  NODE_ENV = "development"
+
+# Specific-branch context (overrides branch-deploy):
+[context.feature]
+  command = "make feature"
+
+[context."features/branch"]
+  command = "gulp"
 ```
 
-Requires Node.js 18.14.0+. You can also invoke the CLI without installing it using `npx netlify <command>`.
+Precedence: site globals < context overrides; production overrides globals when building production; more specific contexts (a named branch) override general ones (`branch-deploy`). Only explicitly-set options are overridden. File-based config overrides UI settings.
 
-## Authentication
+**Footgun — secrets in netlify.toml:** `netlify.toml` is committed to your repo. Do not put sensitive env values here, especially for public repos. Set secrets via the Netlify UI/CLI/API instead. Also: env vars declared in `netlify.toml` are NOT available to the deploy environment (Functions/Runtime/Post-processing scopes) — only UI/CLI/API-created vars are.
 
-```bash
-netlify login       # Opens browser for OAuth
-```
-
-For CI, set the `NETLIFY_AUTH_TOKEN` environment variable instead of logging in interactively. Generate a token from **User settings → Applications → Personal access tokens** in the Netlify UI.
-
-**CI also needs a site to target.** `NETLIFY_AUTH_TOKEN` only authenticates you — it does **not** select which site a deploy publishes to. In CI there is no linked `.netlify/state.json`, so also set `NETLIFY_SITE_ID` (the site's API/Project ID, shown as **Project ID** in the site's configuration) as an environment variable so `netlify deploy` knows where to publish. Without it, a CI deploy has no site to target and fails or tries to prompt. Locally this is handled by `netlify link`, which writes the site ID into `.netlify/state.json`; CI has no such file.
-
-Don't pre-check auth as a separate step. Run the real operation (`netlify deploy`, `netlify link`) directly; only if it fails with an authentication error do you surface `netlify login` (or setting `NETLIFY_AUTH_TOKEN`) as the fix.
-
-## Linking a Site
-
-Linking connects the local directory to a Netlify site and writes the site ID into `.netlify/state.json`.
+## CLI deploys
 
 ```bash
-# Interactive — pick an existing site
-netlify link
-
-# By Git remote (if the project has one)
-netlify link --git-remote-url https://github.com/org/repo
-
-# Create a new site
-netlify init           # With Git CI/CD setup
-netlify init --manual  # Without Git CI/CD
+netlify create              # new project from a natural-language prompt
+netlify deploy              # manual deploy, no continuous deployment
+netlify deploy --prod       # deploy directly to production
+netlify deploy --allow-anonymous   # temp deploy, claim within 1 hour
+npm update -g netlify-cli   # skew protection needs CLI v23.11.0+
 ```
 
-Run `netlify link` directly rather than pre-checking link status. If the command reports the project isn't linked to any site (or the site can't be found), that failure is the signal to link or create one with `netlify link` / `netlify init`.
+Manual deploys do NOT run a build command (exception: Netlify Drop builds for you when logged in). Anonymous deploys create a temporary project claimable within one hour; on claim it adopts the team's default visibility.
 
-**Always add `.netlify` to `.gitignore`** — every linking path (`netlify link`, `netlify init`, `netlify init --manual`) writes site state to `.netlify/state.json`, which shouldn't be committed. Mention this whenever you link or create a site.
+**Footgun — link writes `.netlify/state.json`:** every linking/create path writes `.netlify/state.json`. Add `.netlify` to `.gitignore` so it is never committed.
 
-## Deploying
+**Footgun — manual `--prod` on a Git-connected site:** the next push to the production branch silently replaces your hand-shipped deploy. Warn the user before running it; if the deploy must stay live, lock the published deploy.
 
-### Git-Based Deploys (Continuous Deployment) — primary path
+## Git continuous deployment
 
-The standard way to deploy on Netlify is to connect the site to a Git repository (set up with `netlify init`, or in the UI). Netlify then builds and deploys automatically on every push:
+Connect a Git repo (Git provider OAuth2 or the Netlify GitHub App). Netlify runs your build command and deploys on every push. Production deploys are triggered by pushes to the production branch (default `main`); Deploy Previews are built for pull/merge requests and agent runs.
 
-- **Push to the production branch → production deploy.**
-- **Open a pull request → deploy preview** with its own unique URL.
-- **Push to other branches → branch deploy**, but **only if branch deploys are enabled** — they are off by default. Turn them on (per branch or for all branches) in the site's build & deploy settings.
+## Deploy Previews & branch deploys
 
-The build runs on Netlify's servers, not your machine. Configure build settings (command, publish directory, base directory) in `netlify.toml` — see the **netlify-config** skill for the full configuration reference.
+- Deploy Previews build by default for PRs/MRs and agent runs. Base branch of a Deploy Preview must be a production branch or a branch with branch deploys enabled.
+- Branch deploys are OFF by default — a Developer/Owner must enable them: Project configuration > Build & deploy > Continuous Deployment > Branches and deploy contexts > Configure. Add individual branches, use a `features/*` prefix wildcard, or select **All**.
+- URL prefixes: branch deploys `<branch>--`; PR/MR previews `deploy-preview-<number>--`; agent previews `agent-<runID>--`; permalinks `<deployID>--`.
+- While the initial Deploy Preview builds, its URL returns `Not Found`.
 
-**`netlify.toml` overrides the UI.** File-based configuration in `netlify.toml` takes precedence over the equivalent build settings configured in the Netlify UI. When the same option is set in both places, the committed `netlify.toml` wins — editing that setting in the dashboard has no effect until you change the file and redeploy. This surprises people who tweak the build command, publish directory, or base directory in the UI and watch the old committed value keep applying on every deploy.
+**Deploy Preview entry path** — set in the PR/MR description (updates the PR comment link):
+```markdown
+@netlify /start/choose-your-path
+```
+Push a new (or empty) commit to regenerate the link. Once set in the PR/MR, you cannot override the entry path in the Netlify Drawer.
 
-**Monorepo config discovery order.** In a monorepo, Netlify searches for the `netlify.toml` in this order and uses the **first** one it finds: (1) the package directory, then (2) the base directory, then (3) the repository root. Put a site-specific `netlify.toml` in the package directory (the subdirectory that contains that site) so it takes precedence over any root-level config. A base directory set in a root-level `netlify.toml` also overrides the base directory configured in the UI.
+## Skip a deploy
 
-**The publish directory is resolved relative to the base directory.** When a `base` directory is configured, the publish directory is interpreted relative to that base, **not** the repository root. A top-level `publish = "dist"` combined with `base = "apps/web"` publishes `apps/web/dist`, not `dist` at the repo root. Set `publish` relative to the base so the built output is found.
+Add `[skip ci]` or `[skip netlify]` to a PR/MR title (skips the Deploy Preview) or anywhere in a commit message (skips branch/production deploy). For a multi-commit push, put it in the most recent commit. The next commit without the token deploys all skipped changes.
 
-### Manual / Local Deploys (No Git Required) — secondary path
+## Deploy to Netlify button
 
-Build the site, then upload the output directly with the CLI. This bypasses Netlify's build servers and is the right tool for prototypes, local-only projects with no Git remote, or a CI pipeline that builds elsewhere and uploads the artifact.
+Template code must be in a **public** GitHub.com or GitLab.com repo.
 
-```bash
-netlify deploy             # Draft deploy (preview URL)
-netlify deploy --prod      # Production deploy
-netlify deploy --dir=dist  # Specify the directory to upload
+```md title="Markdown"
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
 ```
 
-For sites with Git continuous deployment connected, prefer pushing to Git — a manual upload is the exception, not the default.
-
-**A manual `--prod` deploy is replaced by the next Git push.** If the same site also has Git continuous deployment connected, the next push to the production branch triggers a new build that auto-publishes and **replaces** your manually shipped `--prod` deploy — the hand-shipped build silently disappears from production. To keep a specific deploy live, **lock the published deploy** ("Stop auto publishing") from the site's Deploys list in the UI: while locked, new pushes still build but do not auto-publish until you unlock or manually publish. Mixing manual `--prod` deploys with Git CD on the same production branch is otherwise a race the next commit wins.
-
-### Deploy URLs are public by link
-
-Draft deploys (`netlify deploy`), Deploy Previews, branch deploys, and deploy permalinks each get a **unique URL that anyone with the link can open** — they are not private just because the URL is unguessable and unlisted. Don't treat a preview URL as a safe place for confidential or unreleased content on that basis alone. To actually restrict access, enable site protection in the UI (Password Protection, or Team/SSO protection). You can scope that protection to all deploys, or to non-production deploys only (Deploy Previews and branch deploys) while leaving production open. See the **netlify-access-control** skill for the full picture.
-
-## When a command fails, surface and stop
-
-When a `netlify` command or a deploy fails, **report the failure to the user** with the exact error, the deploy log URL (the CLI prints one), and the affected site/branch — and stop. Do not invent recovery commands or escalate to lower-level tools: do not curl `https://api.netlify.com/...`, do not run `netlify api <method>` as a recovery hatch, and do not read auth tokens off disk to force the operation through. If the documented happy path is broken, that's a platform-state problem the user needs to see.
-
-## Error Handling
-
-Common issues and what to do:
-
-**"Not logged in"**
-→ Run `netlify login` (or set `NETLIFY_AUTH_TOKEN` in CI).
-
-**"No site linked"**
-→ Run `netlify link` (existing site) or `netlify init` (new site).
-
-**"Build failed" / "Function bundling failed" / deploy marked failed**
-→ A failed deploy does **not** publish — the site keeps serving the last successful deploy, so it isn't down, and there's nothing to "roll back." The only way to get the new code live is to fix the failure and redeploy.
-→ Get the exact error from the deploy log (the CLI prints a log URL; the dashboard has the full build log), then address the actual cause — the build command or publish directory in `netlify.toml`, a missing dependency, or the function that failed to bundle — and re-run the deploy.
-→ Don't route around a failed build to force the site live: no `netlify api` publish/restore, no direct `https://api.netlify.com/...` calls, no reading auth tokens off disk, and don't ship a previous deploy in place of the failing one. If the log doesn't resolve it, report the exact error + log URL + affected site to the user and stop.
-→ Even if the user *asks* how to "roll back" or restore a previous deploy, correct the premise rather than complying: because the failed deploy never published, the previous deploy is still live and there is nothing to restore. Do **not** hand over `netlify api restoreSiteDeploy` / `publishDeploy` (or a dashboard rollback) as the answer — the fix is to resolve the build failure and redeploy.
-
-**"Secrets scanning found secrets" / deploy fails after a successful build**
-→ Netlify scans the build output and source for secret values (env-var values, known key formats) *after* the build succeeds and **fails the deploy** if it finds one — so an otherwise-green build can still fail here. Read the log: it names the offending key and where it appeared.
-→ If it's a real secret (an API/DB key that ended up in bundled or published output), that's a genuine leak — stop writing it into client/published files, and rotate the key if it was committed. Silencing the scanner over a real leak just ships the secret.
-→ If the flagged value is legitimately non-secret (e.g. a value that must ship to the browser), scope the exception narrowly with build environment variables: `SECRETS_SCAN_OMIT_KEYS` to exclude specific env-var keys, or `SECRETS_SCAN_OMIT_PATHS` to exclude specific paths. Prefer these over `SECRETS_SCAN_ENABLED=false`, which disables scanning across the entire build.
-
-**"Publish directory not found"**
-→ Run the build yourself (`netlify build`, which mimics the Netlify build environment, or the project's own build command) and look at which directory it actually emits — don't guess the output dir from the framework name, and don't just `ls` for a folder that isn't there.
-→ If the build itself **fails**, that's the real problem — surface the build error to the user and stop; don't change the `publish` path to paper over a broken build.
-→ Once the build succeeds, set the `publish` path (in `netlify.toml`, or `--dir`) to match that real output directory — remembering it's resolved relative to any configured `base` directory (see above).
-
-## Logs
-
-The simplest command is the right default: bare `netlify logs` shows recent logs from both the `functions` and `edge-functions` sources, covering roughly the last 10 minutes. Add flags only to scope or extend it:
-
-```bash
-netlify logs                                       # recent functions + edge-functions logs (~last 10m)
-netlify logs --follow                              # stream live
-netlify logs --source functions --function my-fn   # one function's logs
-netlify logs --source deploy --source functions    # include deploy logs (sources combine)
-netlify logs --since 24h                           # longer historical window
+URL parameters (query params; env vars go in the URL hash):
+```txt
+# require/set env vars via hash (values may be null; processed client-side, not logged)
+...?repository=REPO#SECRET_TOKEN=value&CUSTOM_LOGO=
+&fullConfiguration=true   # extra step to install SDK extensions + configure before deploy
+&base=blog                # alternate base dir for monorepos (repo still fully cloned)
+&create_from_path=examples/hello   # clone only this subdirectory
+&branch=beta-feature      # set production branch to this branch
 ```
 
-`--source` accepts `functions`, `edge-functions`, and `deploy`. This is the documented CLI logs surface — reach for it before the dashboard, and see [CLI commands](references/cli-commands.md) for more.
+File-based template config in root `netlify.toml` `[template]` section:
+```toml
+[template]
+  incoming-hooks = ["Contentful"]
+  required-extensions = ["supabase"]
+[template.environment]
+  SECRET_TOKEN = "change me for your secret token"   # label only; cannot set real values
+```
+`[template]` cannot set env var values (use the URL hash) or a base directory (use `base`). With an alternate `base`, the `netlify.toml` in the base directory wins over root config for that site's builds. `USAGE.md` at repo root shows extra instructions during the `fullConfiguration` flow.
 
-## Useful Commands
+## Drag and drop (Netlify Drop)
 
-| Command | Description |
-|---|---|
-| `netlify build` | Run the build locally (mimics the Netlify build environment) |
-| `netlify deploy` | Draft deploy (preview URL) |
-| `netlify deploy --prod` | Production deploy |
-| `netlify deploy --dir=<dir>` | Deploy a specific directory |
-| `netlify clone org/repo` | Clone, link, and set up in one step |
-| `netlify open` | Open the site in the Netlify dashboard |
-| `netlify logs` | Recent function + edge-function logs (see Logs above) |
+Drag a folder to https://app.netlify.com/drop. Logged in: Netlify detects the framework and builds before publishing (a pre-built output folder also works). Not logged in: files publish as-is. Update a drag-and-drop site by dropping the new output folder at the dropzone on the site's **Deploys** page (works for any non-Git site).
 
-## Related skills
+## Build hooks
 
-- **netlify-config** — `netlify.toml` (build settings, redirects, headers, deploy contexts) and environment-variable management (`env:set`, `env:get`, `env:list`, context scoping).
-- **netlify-frameworks** — framework adapter/plugin setup and local development (`netlify dev`, the Netlify Vite plugin).
-- **netlify-access-control** — restricting who can reach a site or its deploys.
+Build hooks give unique URLs to trigger builds/deploys. Builds from build hooks are treated as trusted and are NOT subject to the Deploy Request Policy.
 
-## References
+## Managing deploys
 
-- [CLI commands](references/cli-commands.md)
-- [Deployment patterns](references/deployment-patterns.md)
-- [netlify.toml guide](references/netlify-toml.md)
+- **Find:** Deploys tab; search by deploy ID or branch; filter by time frame, deploy context, and status.
+- **Lock (pause publishing):** on the Deploys list, **Lock to stop auto publishing**. New deploys still build but don't publish. **Unlock to start auto publishing** to resume. Use this to keep a specific deploy live.
+- **Cancel:** on the in-progress deploy's detail page, **Cancel deploy**.
+- **Retry:** builds from the branch HEAD — if HEAD moved past the original deploy SHA, it still builds from HEAD.
+- **Download:** deploy detail page — single file via **Deploy file browser**, or all files as ZIP via header **Download**.
+- **Delete:** Developer/Team Owner only. You cannot delete the currently-published deploy or one in progress. Permanent; does not reduce cost or preserve build minutes.
+
+Netlify auto-deletes deploys older than 30 days (90 days on paid plans); failed/canceled deploys are cleaned up on the same schedule. It never auto-deletes the published deploy, the most recent successful production deploy, or the most recent successful branch deploy per branch.
+
+**Fix a failed deploy:** a failed deploy never publishes — the previously published deploy stays live, so there is nothing to restore. Fix forward: use the **"Why did it fail?"** diagnosis above the deploy log, revert the offending commit, and let CI redeploy. Retry (optionally clearing cache) rebuilds from branch HEAD.
+
+## Skew protection
+
+Available on all plans. Routes requests to the server version that matches each client, avoiding version skew across deploys. Requires Netlify CLI v23.11.0+ for CLI deploys.
+
+- **Production context only.** Branch deploys, Deploy Previews, and permalinks bypass skew protection and serve the latest deploy for that context.
+- Framework support: Astro 5.15.0+ (on by default via the Netlify adapter); Next.js (optional; older versions need a config change). Framework maintainers add support via `netlify/v1/skew-protection.json`.
+- **Password protection:** works only if you protect non-production deploys only. Protecting production deploys (or all deploys) disables/ignores skew protection.
+- Netlify discards skew signals on hard navigation (`Sec-Fetch-Mode: navigate`, or `Sec-Fetch-Site` present and not `same-origin`).
+
+## Secrets scanning failures
+
+If a deploy fails secrets scanning and the flagged value is a real secret, that is a leak: stop shipping it in client/published output and rotate it. Never disable the scanner over a real leak. For genuine non-secrets, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` / `SECRETS_SCAN_OMIT_PATHS` — never `SECRETS_SCAN_ENABLED=false`.
+
+## Constraints
+
+- **54,000 files per directory** max — any directory in your publish dir over this limit fails the deploy. No limit on total files.
+- Deploys are atomic: only changed files upload; nothing goes live until the whole deploy is ready.
+- Only the published production deploy and most recent branch deploys are indexable; other previews get `X-Robots-Tag: noindex`.
+- Deploy Request Policy: private-repo deploys build only for recognized authors (Owners, Developers, Git Contributors; Marketplace bots count). Non-team-member deploys land as **Pending approval** until a Team Owner approves/matches them. Build-hook builds are exempt.
+- Retention limit is adjustable only on Enterprise (up to 365 days). Lock/unlock event notifications: Pro and Enterprise.
+
+## More
+
+Deep guides in this skill: `references/netlify-toml.md`, `references/cli-commands.md`, `references/deployment-patterns.md`.
+
+<!-- Gap: deploy-overview states failed/canceled deploys are deleted at 6 months, contradicting the 30/90-day cleanup figure used above; the 30/90-day value is stated here as the documented default. -->
+
+<!-- system: agent-context/deploy/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (deploy)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Agents do not roll back deploys: never call `restoreSiteDeploy` or
+   `publishDeploy` to restore an older deploy. Fix forward — revert the
+   commit and let CI deploy it.
+2. A failed deploy never publishes; on failure there is nothing to roll
+   back.
+3. Deep guides live in this skill: `references/netlify-toml.md`,
+   `references/cli-commands.md`, `references/deployment-patterns.md`.
+4. The frontmatter description must never advertise rollback or restore as a
+   capability — no "roll back", "restore a deploy", or equivalent.
+5. When the user asks to roll back or restore a previous deploy, correct the
+   premise rather than complying: after a failed deploy the previous deploy
+   is still live and there is nothing to restore; for a bad published deploy,
+   fix forward per rule 1. Do not hand over `restoreSiteDeploy` /
+   `publishDeploy` or a dashboard rollback as the answer.
+6. Always add `.netlify` to `.gitignore` when linking or creating a site —
+   every linking path writes `.netlify/state.json`, which must not be
+   committed. Mention it whenever you link.
+7. Secrets-scanning deploy failures: if the flagged value is a real secret,
+   that is a leak — stop shipping it in client/published output and rotate
+   it; never silence the scanner over a real leak. For genuinely non-secret
+   values, scope narrowly with `SECRETS_SCAN_OMIT_KEYS` /
+   `SECRETS_SCAN_OMIT_PATHS`, never `SECRETS_SCAN_ENABLED=false`.
+8. Before running a manual `netlify deploy --prod` on a site with Git CD
+   connected, warn the user that the next push to the production branch
+   silently replaces the hand-shipped deploy; suggest locking the published
+   deploy if it must stay live.

--- a/skills/netlify-edge-functions/SKILL.md
+++ b/skills/netlify-edge-functions/SKILL.md
@@ -1,180 +1,259 @@
 ---
 name: netlify-edge-functions
-description: Guide for writing Netlify Edge Functions. Use when building middleware, geolocation-based logic, request/response manipulation, authentication checks, A/B testing, or any low-latency edge compute. Covers Deno runtime, context.next() middleware pattern, geolocation, and when to choose edge vs serverless.
+description: Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use when adding request/response manipulation at the edge — auth middleware, geolocation redirects, A/B testing and personalization, content localization, redirects/rewrites, SSR at the edge, or transforming responses — or when configuring path routing, response caching, or edge error handling. Triggers on tasks like "add auth middleware", "geo-based redirect", "A/B testing at the edge", "rewrite requests", or editing files in netlify/edge-functions.
 ---
 
 # Netlify Edge Functions
 
-Edge functions run on Netlify's globally distributed edge network (Deno runtime), providing low-latency responses close to users.
+**Reach for this (modern):** default-export handler + inline `config` export with a narrowly-scoped `path`. Import types from `@netlify/edge-functions`.
 
-## Check the framework adapter first
+```ts
+import type { Config, Context } from "@netlify/edge-functions";
 
-For framework projects, check the framework reference (the **netlify-frameworks** skill) before hand-writing an edge function — framework adapters emit their own edge middleware, so the behavior you need may already be generated. A custom edge function that duplicates adapter-generated middleware causes conflicts.
+export default async (request: Request, context: Context) => {
+  // return Response | URL (rewrite) | undefined (continue chain)
+};
 
-## Syntax
+export const config: Config = { path: "/products/*" };
+```
 
-```typescript
+**Avoid:** import maps in `deno.json` (unsupported — use a separate file via `deno_import_map`). Do not hand-write a function your framework's adapter already generates (Next.js, Astro, Remix, SvelteKit, Nuxt, etc.) — check the framework adapter/reference first; duplicating adapter middleware causes conflicts.
+
+## File location
+
+- Default directory: `YOUR_BASE_DIRECTORY/netlify/edge-functions`.
+- Custom directory: `edge_functions` key under `[build]` in `netlify.toml`. Keep it **outside** the publish directory so source files aren't deployed.
+- `.js`/`.ts`/`.jsx`/`.tsx` all supported. If a `.ts` and `.js` file share a name, the `.ts` is ignored and the `.js` deploys.
+
+## ⚠️ A function without a route silently never runs
+
+Edge functions are **not** auto-assigned a URL. No `config` export and no `netlify.toml` declaration = deploys clean, no build error, no warning, never executes. If "my edge function does nothing," check the route first.
+
+## Request handling patterns
+
+Handler receives `(request: Request, context: Context)`. Return one of:
+- `Response` — respond directly (ends the chain; declared redirects for the path do not run)
+- `URL` — rewrite to a **same-site** URL with 200 status (address bar unchanged)
+- `undefined` / empty `return;` — bypass this function, continue the chain
+
+Netlify adds no headers to edge requests — use `context` for client info.
+
+### Redirect
+```ts
+export default async (req: Request, { cookies, geo }: Context) => {
+  if (geo.city === "Paris" && cookies.get("promo-code") === "15-for-followers") {
+    return Response.redirect(new URL("/subscriber-sale", req.url));
+  }
+};
+```
+
+### Rewrite (same-site only)
+```ts
+export default async (request: Request, { geo }: Context) => {
+  if (geo.city === "Paris") return new URL("/subscriber-sale", request.url);
+};
+```
+To reach another site or external content, use `fetch()` — rewrite via `URL` is same-site only.
+
+### Middleware transform
+```ts
+import type { Context } from "@netlify/edge-functions";
+
+export default async (request: Request, context: Context) => {
+  const response = await context.next();
+  const text = await response.text();
+  return new Response(text.toUpperCase(), response);
+};
+```
+`context.next()` runs the rest of the chain and returns the origin `Response`. Only call it if you need the response body (it costs latency otherwise).
+
+To transform a **different** path, use `fetch()` — but this starts a **new** request chain and re-runs any edge functions matching that path. Use `context.next()` to hit a static asset/serverless function at the same internal path without re-running edge functions.
+
+### Read the request body
+A body can only be read once. If you read it, pass a fresh request to `next()`:
+```ts
+export default async (req: Request, context: Context) => {
+  const body = await req.json();
+  if (!isValid(body.access_token)) return new Response("forbidden", { status: 403 });
+  return context.next(new Request(req, { body: JSON.stringify(body) }));
+};
+```
+
+### Conditional requests
+`next()` normally forces a full response. For client caching control:
+```ts
+const res = await next({ sendConditionalRequest: true });
+if (res.status === 304) return res;
+```
+
+## `Context` object
+
+- **`geo`** — `city`, `country {code,name}`, `subdivision {code,name}`, `latitude`, `longitude`, `timezone`, `postalCode`.
+- **`cookies`** — `get(name)`, `set(options)`, `delete(name|options)` (CookieStore web standard). ⚠️ Cross-subdomain cookies require a **custom domain** — `netlify.app` is on the Public Suffix List.
+- **`next(options?)` / `next(request, options?)`** — continue the chain; `options.sendConditionalRequest`.
+- **`params`** — path params, e.g. `/pets/:name` → `{ name: "winter" }`. Query string: use `request.url`.
+- **`ip`**, **`requestId`**, **`server.region`**.
+- **`site`** — `id`, `name`, `url`. **`account.id`**. **`deploy`** — `context`, `id`, `published`, `skewProtectionToken`.
+- **`waitUntil(promise)`** — run work after the response is sent (analytics, logs) without blocking it. Still subject to the CPU time limit.
+
+`Netlify.context` gives the same context inside the handler (`null` outside it).
+
+## Environment variables
+
+Access via `Netlify.env.get(name)` (also `has`, `set`, `delete`, `toObject`). `set`/`delete` are invocation-scoped only — they do **not** persist; use the Netlify env API to update.
+
+```ts
+const value = Netlify.env.get("MY_IMPORTANT_VARIABLE");
+```
+
+⚠️ **Gotchas:**
+- Variables in `netlify.toml` are **NOT** available to edge functions.
+- Scope must include **Functions** to reach runtime. **Build**-scoped vars are build-only — embed them at build time if needed.
+- Values are frozen at deploy time. Change a var → new deploy required. Deploy Previews/branch deploys use their deploy-time values.
+
+## Configuration / routing
+
+Config via inline `config` export or `netlify.toml`. Properties:
+- **`path`** — `URLPattern` string or array; must start with `/`. e.g. `["/", "/products/*"]`.
+- **`excludedPath`** — exclude routes from `path`; must start with `/`. e.g. `["/*.css", "/*.js"]`.
+- **`pattern`** / **`excludedPattern`** — regex alternatives to `path`/`excludedPath`.
+- **`method`** — string or array of HTTP methods (inline only).
+- **`header`** — object of header conditions: `true` (present), `false` (absent), or a regex string on the value. Names case-insensitive; multiple same-name values matched as comma-joined list.
+- **`cache`** — `"manual"` to opt into caching.
+- **`onError`** — error handling (see below).
+
+### ⚠️ Scope `path` narrowly
+
+`path: "/*"` intercepts **every** request including static assets — adds latency to each and **bills an edge invocation** for each. Match only the paths you need.
+
+### netlify.toml (for ordering / multiple functions on a path)
+```toml
+[[edge_functions]]
+  path = "/admin"
+  function = "auth"
+
+[[edge_functions]]
+  path = "/admin"
+  function = "injector"
+  cache = "manual"
+```
+Header matching uses an `[edge_functions.header]` sub-table.
+
+### Execution order
+Config-file declarations run before inline; framework-generated before user; non-cached before cached. Within `netlify.toml`: top-to-bottom. Within inline: **alphabetical by file name**. To control order, prefer `netlify.toml`. If the same function is declared both inline and in toml, they merge and inline fields win.
+
+Caveats: a function on the **target** of a static rewrite does **not** run for rewritten requests. If a function returns a `Response`, redirects for that path are skipped.
+
+## Response caching (opt-in)
+
+### ⚠️ Both parts or neither
+Cache headers on the `Response` do **nothing** without `cache: "manual"` in config — and `cache: "manual"` without headers still caches nothing. You need **both**:
+
+```ts
 import type { Config, Context } from "@netlify/edge-functions";
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello from the edge!");
+  return new Response("Hello world", {
+    headers: { "cache-control": "public, s-maxage=3600" },
+  });
 };
 
-export const config: Config = {
-  path: "/hello",
-};
+export const config: Config = { cache: "manual", path: "/hello" };
 ```
 
-Place files in `netlify/edge-functions/`. Uses `.ts`, `.js`, `.tsx`, or `.jsx` extensions.
+- Use caching only for endpoint-style responses reusable across clients (e.g. shared SSR HTML). **Never** for middleware, routing, or per-client personalization.
+- Cached responses do **not** count toward invocations.
+- ⚠️ A cached function **shadows real static files**: `cache:"manual"` on `/*` makes `/cat.png` serve the function, not the static file.
+- Supported headers: `Cache-Control`, `CDN-Cache-Control`, `Netlify-CDN-Cache-Control`, `Expires`, `Vary`, `Netlify-Vary`. Headers must be set inline in code.
+- New deploy in the same context voids `s-maxage`/`max-age`/`Expires` (atomic deploys).
+- No local caching — cache headers are ignored under `netlify dev`.
 
-## Config Object
+## Error handling (`onError`, inline only)
 
-```typescript
-export const config: Config = {
-  path: "/api/*",                    // URLPattern path(s)
-  excludedPath: "/api/public/*",     // Exclusions
-  method: ["GET", "POST"],           // HTTP methods
-  onError: "bypass",                 // "fail" (default), "bypass", or "/error-page"
-  cache: "manual",                   // Enable response caching
-};
+- **`"fail"`** (default) — generic error page, stops the chain.
+- **`"/custom-path"`** — rewrite to a same-site path (starts with `/`), served without invoking that path's edge functions.
+- **`"bypass"`** — skip the erroring function, continue the chain.
+
+Guidance: fail **closed** for critical logic (auth); fail **open** for progressive enhancement (localization → `bypass`).
+
+## Runtime & modules
+
+Deno runtime with many standard Web APIs (`fetch`/`Request`/`Response`/`URL`, `console`, `atob`/`btoa`, `TextEncoder`/`Decoder`(`Stream`), Web Crypto `crypto.randomUUID/getRandomValues/subtle`, `WebSocket`, timers, Streams API, `URLPattern`, `Performance`).
+
+- **Node built-ins:** `import { randomBytes } from "node:crypto"` (`node:` prefix).
+- **Deno modules:** URL import, e.g. `import React from "https://esm.sh/react"`.
+- **npm packages (beta):** `npm install` then import by name. ⚠️ Packages needing native binaries (Prisma) or runtime dynamic imports (cowsay) may fail — prefer `node:` built-ins / Deno URLs.
+- **Import maps:** separate file only (not `deno.json`), declared via `deno_import_map` in `[functions]`.
+
+### SSR at the edge (.tsx)
+```tsx
+import React from "https://esm.sh/react";
+import { renderToReadableStream } from "https://esm.sh/react-dom/server";
+import type { Config, Context } from "@netlify/edge-functions";
+
+export default async function handler(req: Request, context: Context) {
+  const stream = await renderToReadableStream(
+    <html><body><h1>Hello {context.geo.country?.name}</h1></body></html>
+  );
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/html" } });
+}
+
+export const config: Config = { path: "/hello" };
 ```
 
-**Scope `path` narrowly — `path: "/*"` intercepts every request, including static assets.** A `/*` match runs the edge function on every CSS, JS, image, and font request, not just your HTML pages — adding latency to each asset and billing an edge invocation for it. Match only the routes you need (e.g. `path: "/"`, `path: "/app/*"`), or keep a broad path but exclude static assets with `excludedPath` (e.g. `excludedPath: ["/*.css", "/*.js", "/*.png", "/*.woff2"]`).
+## Edge vs serverless
 
-**Cache headers on an edge response do nothing without `cache: "manual"`.** Setting `Cache-Control` (or any cache header) on the `Response` an edge function returns has no effect unless the function also opts in with `config.cache = "manual"`. It's both or neither: without the flag the response is never cached, no matter what headers you set.
-
-## Declaring edge functions: inline config vs netlify.toml
-
-An edge function runs only if it is bound to a path. Bind it either with an inline `export const config = { path: ... }` in the function file (shown above), or with an `[[edge_functions]]` entry in `netlify.toml` that names the file:
-
-```toml
-[[edge_functions]]
-  path = "/admin/*"
-  function = "auth"        # runs netlify/edge-functions/auth.ts
-```
-
-**A file in `netlify/edge-functions/` with no path binding still deploys, but silently never runs.** There is no build error and no warning — nothing routes a request to it, so it is never invoked. If an edge function "isn't doing anything," first confirm it declares a `path` inline or has a matching `[[edge_functions]]` entry.
-
-### Chaining multiple edge functions on one path
-
-When several edge functions match the same path, they run as a chain in this order:
-
-1. Functions declared in `netlify.toml` run first, **in the order they appear** in the file (top to bottom).
-2. Functions declared inline (via `export const config`) run next, **in alphabetical order by filename**.
-3. Functions configured for caching (`cache: "manual"`) always run after non-caching ones.
-
-To guarantee a specific order (e.g. an auth gate that must run before a personalization rewrite), declare the functions in `netlify.toml` in the order you want — don't depend on inline config, whose order is alphabetical by filename and easy to get wrong. Declaring the same function both inline and in `netlify.toml` merges them into an inline declaration (inline config wins), which forfeits the deterministic `netlify.toml` ordering.
-
-## Edge functions run before redirects
-
-In Netlify's request chain, edge functions execute **before** redirect and rewrite rules (`[[redirects]]`, `_redirects`). Two consequences bite often:
-
-- An edge function is matched against the **original** requested URL, not a redirect/rewrite destination. Scope its `path` to the URL the client actually requests — an edge function declared on the *target* of a rewrite will not fire for requests that only reach that target via the rewrite.
-- If an edge function returns a `Response`, the request chain stops there and redirect rules for that path **never run**. Return `context.next()` (or `undefined`) if you want redirects to still apply.
-
-## Middleware Pattern
-
-Use `context.next()` to invoke the next handler in the chain and optionally modify the response:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  // Before: modify request or short-circuit
-  if (!isAuthenticated(req)) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  // Continue to origin/next function
-  const response = await context.next();
-
-  // After: modify response
-  response.headers.set("x-custom-header", "value");
-  return response;
-};
-```
-
-Return `undefined` to pass through without modification:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  if (!shouldHandle(req)) return; // continues to next handler
-  return new Response("Handled");
-};
-```
-
-## Geolocation and IP
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const { city, country, subdivision, timezone } = context.geo;
-  const ip = context.ip;
-
-  if (country?.code === "DE") {
-    return Response.redirect(new URL("/de", req.url));
-  }
-};
-```
-
-Local dev with mocked geo: `netlify dev --geo=mock --country=US`
-
-## Cookies
-
-Read and write cookies through the `context.cookies` helper instead of hand-parsing the `Cookie` header or building `Set-Cookie` strings:
-
-```typescript
-export default async (req: Request, context: Context) => {
-  const bucket = context.cookies.get("bucket");            // read from the request
-  context.cookies.set({ name: "bucket", value: "a" });     // set on the response
-  context.cookies.delete("legacy_session");                // tell the client to delete it
-  return context.next();
-};
-```
-
-- `cookies.get(name)` — reads a named cookie from the incoming request.
-- `cookies.set(options)` — sets a cookie on the outgoing response (same option shape as the web `CookieStore.set` standard).
-- `cookies.delete(name)` — instructs the client to delete the cookie.
-
-## Environment Variables
-
-Use `Netlify.env` (not `process.env` or `Deno.env`):
-
-```typescript
-const secret = Netlify.env.get("API_SECRET");
-```
-
-## Module Support
-
-- **Node.js builtins**: `import { randomBytes } from "node:crypto";`
-- **npm packages**: Install via npm and import by name
-- **Deno modules**: URL imports (e.g., `import X from "https://esm.sh/package"`)
-
-For URL imports, use an import map:
-
-```json
-// import_map.json
-{ "imports": { "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts" } }
-```
-
-```toml
-# netlify.toml
-[functions]
-  deno_import_map = "./import_map.json"
-```
-
-## When to Use Edge vs Serverless
-
-| Use Edge Functions for | Use Serverless Functions for |
-|---|---|
-| Low-latency responses | Long-running operations (up to 15 min) |
-| Request/response manipulation | Complex Node.js dependencies |
-| Geolocation-based logic | Database-heavy operations |
-| Auth checks and redirects | Background/scheduled tasks |
-| A/B testing, personalization | Tasks needing > 512 MB memory |
+Edge for low-latency request/response manipulation, geolocation, auth checks/redirects, A/B personalization. Serverless for long-running work (up to 15 min), heavy Node deps, database-heavy operations, background/scheduled tasks, or memory above 512 MB.
 
 ## Limits
 
-| Resource | Limit |
-|---|---|
-| CPU time | 50 ms per request |
-| Memory | 512 MB per deployed set |
-| Response header timeout | 40 seconds |
-| Code size | 20 MB compressed |
+- Code size: **20 MB** compressed (bundle).
+- Memory: **512 MB** per deployed set.
+- CPU execution: **50 ms** per request (excludes waiting on resources; `waitUntil` work still counts).
+- Response header timeout: **40 s**.
+- Invocations/month vary by plan; cached responses don't count.
+
+## Local dev, deploy, monitor
+
+```bash
+npm install netlify-cli -g
+netlify dev      # runs edge functions on local requests at :8888
+```
+- Geo mocking: `--geo=mock` (San Francisco) or `--geo=mock --country=XX`. Debug: `--edge-inspect` / `--edge-inspect-brk`.
+- Manual deploys require CLI **12.2.8+** (older versions error). Deploys are atomic.
+- Logs: **Logs & Metrics > Edge Functions** in the UI; each `console` log names the emitting function. Filter by name/path (glob) and time. Retention ≥24h (7 days on some plans).
+
+## Feature limitations
+
+- Split Testing enabled → edge functions do **not** run.
+- Custom Headers (incl. basic auth headers) do **not** apply to edge functions.
+- Prerendering does **not** apply to paths served by an edge function.
+- Multiple framework plugins generating edge functions may collide.
+- Not part of Netlify's HIPAA-compliant offering.
+
+<!-- system: agent-context/edge-functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (edge-functions)
+
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-edge-functions skill; owned
+by the skills maintainer.
+
+1. Check the framework's adapter/reference first: a custom edge function that
+   duplicates adapter-generated middleware causes conflicts. Only hand-write
+   an edge function when the framework doesn't already generate one for the
+   job.
+2. Scope `path` narrowly. `path: "/*"` intercepts every request — including
+   static assets — adding latency to each one and billing an edge invocation
+   for it.
+3. An edge function without a route (no config export, no netlify.toml
+   declaration) still deploys, but silently never runs: no build error, no
+   warning. When "my edge function does nothing", check the route first.
+4. Choose edge vs serverless by workload shape: edge functions for low-latency
+   request/response manipulation, geolocation logic, auth checks/redirects,
+   and A/B personalization; serverless functions for long-running work (up to
+   15 min), heavy Node.js dependencies, database-heavy operations,
+   background/scheduled tasks, or memory needs above 512 MB.
+5. Cache headers on an edge response do nothing without `cache: "manual"` in
+   config — it's both or neither. Setting `Cache-Control` on the returned
+   `Response` has no effect unless the function also opts in.

--- a/skills/netlify-forms/SKILL.md
+++ b/skills/netlify-forms/SKILL.md
@@ -1,195 +1,196 @@
 ---
 name: netlify-forms
-description: Guide for using Netlify Forms for HTML form handling. Use when adding contact forms, feedback forms, file upload forms, or any form that should be collected by Netlify. Covers the data-netlify attribute, spam filtering, AJAX submissions, file uploads, notifications, and the submissions API.
+description: Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam, and sends notifications. Use when adding a contact form, lead-capture form, file-upload form, or newsletter signup to a Netlify site; wiring AJAX form submission; setting up a custom thank-you page; adding a honeypot or reCAPTCHA to a form; getting forms working in Next.js, Nuxt, SvelteKit, Astro, or Gatsby; reading form submissions via the Netlify API; or debugging missing submissions and forms that silently fail to register.
 ---
 
 # Netlify Forms
 
-Netlify Forms collects HTML form submissions without server-side code. Form detection must be enabled in the Netlify UI (Forms section).
+Mark a form for detection with `data-netlify="true"` (or the bare `netlify` attribute — equivalent) on the `<form>` tag. Forms are detected by **parsing the final built HTML at deploy time** — there is no runtime API call or backend code. Client-side/JS-rendered/SSR forms are NOT in the built HTML and are never detected on their own; they require a static skeleton file (see below).
 
-> **Enabling detection only affects future deploys.** Netlify scans for forms at deploy time, so turning on (or re-enabling) form detection does **not** rescan your current live deploy. After enabling detection you must trigger a new deploy/build before an already-published form is registered and starts collecting submissions.
+Prerequisite: form detection must be enabled once in the Netlify UI (Forms > **Enable form detection**). Takes effect on the next deploy.
 
-## Basic Setup
-
-Add `data-netlify="true"` and a unique `name` to the form:
+## Static HTML form
 
 ```html
 <form name="contact" method="POST" data-netlify="true">
-  <label>Name: <input type="text" name="name" /></label>
-  <label>Email: <input type="email" name="email" /></label>
-  <label>Message: <textarea name="message"></textarea></label>
-  <button type="submit">Send</button>
+  <p><label>Your Name: <input type="text" name="name" /></label></p>
+  <p><label>Your Email: <input type="email" name="email" /></label></p>
+  <p><label>Message: <textarea name="message"></textarea></label></p>
+  <p><button type="submit">Send</button></p>
 </form>
 ```
 
-Netlify's build system detects the form and injects a hidden `form-name` input automatically. For a custom success page, add `action="/thank-you"` to the form tag. Use paths without `.html` extension — Netlify serves `thank-you.html` at `/thank-you` by default, and the `.html` path returns 404.
+- `name` sets the form name in the UI and **must be unique per site**.
+- At deploy, Netlify strips the `data-netlify`/`netlify` attribute and injects `<input type="hidden" name="form-name" value="contact" />`.
+- Add an `<input name="email">` so the notification email's `Reply-to` is set to the submitter.
 
-## JavaScript-Rendered Forms (React, Vue, SSR Frameworks)
+## JS-rendered / SSR / framework forms (Next.js, Nuxt, SvelteKit, Astro, Gatsby)
 
-For forms rendered by JavaScript frameworks (React, Vue, Astro, TanStack Start, Next.js, SvelteKit, Remix, Nuxt), Netlify's build parser cannot detect the form in static HTML. You MUST create a static HTML skeleton file for build-time form detection:
+Two required pieces:
 
-> **Form detection parses prerendered HTML only.** A `data-netlify` form is registered only if it appears in HTML produced at build time. On an Astro route that is server-rendered on demand (`export const prerender = false`, or an `output: "server"` route), the form is generated per request and is never scanned at build — so it is never registered. Put the form on a prerendered page, or add the static skeleton file below.
-
-Create a static HTML file in `public/` (e.g. `public/__forms.html`) containing a hidden copy of each form:
+**1. Static skeleton file `public/__forms.html`** — a hidden copy of each form with `data-netlify="true"`, a hidden `form-name` input, and every field the component submits, with names matching **exactly** (Netlify validates field names against the registered form). Without this file, submissions silently fail.
 
 ```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" />
-      <input type="email" name="email" />
-      <textarea name="message"></textarea>
-      <input name="bot-field" />
-    </form>
-  </body>
-</html>
+<!-- public/__forms.html -->
+<form name="pizzaOrder" data-netlify="true" hidden>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" />
+</form>
 ```
 
-**Rules:**
-- The form `name` must exactly match the `form-name` value used in your component's fetch call
-- Include every field your component submits — Netlify validates field names against the registered form
-- Without this file, Netlify cannot detect the form and submissions will silently fail
-
-Your component must also include a hidden `form-name` input:
+**2. The rendered form** carries a matching hidden `form-name` input:
 
 ```jsx
-<form name="contact" method="POST" data-netlify="true">
-  <input type="hidden" name="form-name" value="contact" />
-  {/* ... fields ... */}
+<form name="pizzaOrder" method="post" data-netlify="true" onSubmit={handleSubmit}>
+  <input type="hidden" name="form-name" value="pizzaOrder" />
+  <input name="order" type="text" onChange={handleChange} />
+  <input type="submit" />
 </form>
 ```
 
-## AJAX Submissions
+**⚠️ SSR POST target:** In SSR apps, `fetch("/")` is intercepted by the SSR catch-all function and never reaches form processing. POST to the static skeleton file itself — `/__forms.html` — not `/` or an arbitrary path.
 
-> **Netlify Forms does not accept JSON.** The submission body must be `application/x-www-form-urlencoded` (encode the fields with `URLSearchParams`) or `multipart/form-data` (a raw `FormData` object, for file uploads). A `fetch` that sends `JSON.stringify(...)` with `Content-Type: application/json` is silently **not** recorded as a submission — always send URL-encoded key/value pairs (or `FormData`), never JSON.
+**⚠️ Astro on-demand routes:** Routes with `export const prerender = false` or `output: "server"` are never scanned at build time, so their forms are never registered. Put the form on a prerendered page, or rely on the static skeleton file.
 
-### Vanilla JavaScript
+**Next.js Runtime v5 (Next.js 13.5+):** extract form definitions to the static skeleton file and submit via AJAX rather than full-page navigation. See https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview#v5-breaking-changes
 
-```javascript
-const form = document.querySelector("form");
-form.addEventListener("submit", async (e) => {
-  e.preventDefault();
-  const formData = new FormData(form);
-  await fetch("/", {
+## AJAX submission
+
+```js
+const handleSubmit = event => {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  fetch("/__forms.html", {   // static sites may POST to "/"; SSR must target the skeleton file
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(formData).toString(),
-  });
+    body: new URLSearchParams(formData).toString()
+  })
+    .then(() => alert("Thank you for your submission"))  // or navigate("/thank-you")
+    .catch(error => alert(error));
+};
+document.querySelector("form").addEventListener("submit", handleSubmit);
+```
+
+- **Body MUST be URL-encoded. JSON is NOT supported.**
+- If the rendered form has no hidden `form-name` input, you MUST include a `form-name` field in the POST body.
+- The honeypot field name and `g-recaptcha-response` (if used) must be in the body — automatic with `FormData()`.
+
+## File uploads
+
+Add `type="file"`; optionally `enctype="multipart/form-data"` on the `<form>`. For AJAX file uploads, **do NOT set a `Content-Type` header** — let the browser set it (with the multipart boundary).
+
+```js
+document.forms.fileForm.addEventListener("submit", event => {
+  event.preventDefault();
+  fetch("/", { body: new FormData(event.target), method: "POST" })  // no headers
+    .then(() => { /* success */ });
 });
 ```
 
-> **SSR frameworks (TanStack Start, Next.js, SvelteKit, Remix, Nuxt):** The `fetch` URL must target the static skeleton
-> file path (e.g. `"/__forms.html"`), **not** `"/"`. In SSR apps, `fetch("/")` is intercepted by the SSR catch-all
-> function and never reaches Netlify's form processing middleware. See the React example and troubleshooting section below.
+Limits: one file per field (use multiple fields for multiple files) · 8 MB max request size · 30 s upload timeout · after form deletion, uploaded files stay at their direct URL for 24 h. PII uploads need extra security (Very Good Security integration).
 
-### React Example
+## Custom success page
 
-```tsx
-function ContactForm() {
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    // For SSR apps, use the skeleton file path instead of "/" (e.g. "/__forms.html")
-    const response = await fetch("/__forms.html", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(formData as any).toString(),
-    });
-    if (response.ok) {
-      // Show success feedback
-    }
-  };
+Add an `action` path relative to site root, starting with `/`. **Use extensionless paths** — Netlify serves `thank-you.html` at `/thank-you`; the `.html` path returns 404.
 
-  return (
-    <form name="contact" method="POST" data-netlify="true" onSubmit={handleSubmit}>
-      <input type="hidden" name="form-name" value="contact" />
-      <input type="text" name="name" placeholder="Name" />
-      <input type="email" name="email" placeholder="Email" />
-      <textarea name="message" placeholder="Message" />
-      <button type="submit">Send</button>
-    </form>
-  );
-}
+```html
+<form name="contact" action="/thank-you" method="POST" data-netlify="true"></form>
 ```
 
-> **SSR troubleshooting:** If form submissions appear to succeed (200 response) but nothing shows in the Netlify Forms
-> UI, the POST is likely being intercepted by the SSR function. Ensure `fetch` targets the skeleton file path (e.g.
-> `"/__forms.html"`), not `"/"`. The skeleton file path routes through the CDN origin where Netlify's form handler runs.
+Custom success *alert* is only possible via AJAX (substitute the redirect with your own logic).
 
-## Spam Filtering
+## Spam prevention
 
-Netlify uses Akismet automatically. Add a honeypot field for extra protection:
+All submissions are filtered by Akismet. Passed → **Verified submissions**; flagged → **Spam submissions**. Honeypot/reCAPTCHA failures are rejected and appear in neither list.
+
+**Honeypot:** add `netlify-honeypot="bot-field"` to the `<form>` and include a CSS-hidden field of that name. Any value entered → submission quietly rejected.
 
 ```html
 <form name="contact" method="POST" netlify-honeypot="bot-field" data-netlify="true">
-  <p style="display:none">
-    <label>Don't fill this out: <input name="bot-field" /></label>
-  </p>
-  <!-- visible fields -->
+  <p class="hidden"><label>Don’t fill this out: <input name="bot-field" /></label></p>
+  <!-- real fields -->
 </form>
 ```
 
-For reCAPTCHA, add `data-netlify-recaptcha="true"` to the form and include `<div data-netlify-recaptcha="true"></div>` where the widget should appear.
+**Netlify reCAPTCHA 2:** add `data-netlify-recaptcha="true"` to the `<form>` AND an empty `<div data-netlify-recaptcha="true"></div>` where it renders. Only ONE Netlify-provided challenge per page — for multiple, use custom reCAPTCHA. For JS-rendered forms, also add the `div` to the static skeleton file.
 
-By default Netlify provisions and verifies the reCAPTCHA for you — do **not** add a site key/secret or load Google's reCAPTCHA script yourself. To use **your own** reCAPTCHA v2 keys, keep the same `data-netlify-recaptcha="true"` markup and set the credentials as Netlify environment variables: `SITE_RECAPTCHA_KEY` (the site key, scoped to Builds and Runtime) and `SITE_RECAPTCHA_SECRET` (the secret, scoped to Runtime). Netlify picks these up automatically — the secret stays server-side as an env var (never hardcoded in client code), and you still don't render the widget with Google's own script or build a custom Function to verify the token.
+**Custom reCAPTCHA 2:** your own reCAPTCHA snippet + `data-netlify-recaptcha="true"` on the `<form>`, plus env vars:
+- `SITE_RECAPTCHA_KEY` — site key (scopes: Builds + Runtime)
+- `SITE_RECAPTCHA_SECRET` — secret (scope: Runtime)
 
-> **Spam submissions are silent.** Akismet-flagged submissions are moved to a separate **Spam** list in the Forms UI — they do **not** appear in the verified submissions list and do **not** trigger email/Slack notifications. Submissions caught by a honeypot field or a failed reCAPTCHA challenge are discarded entirely and never appear in either list. So a "missing" legitimate submission is usually a false-positive spam classification, not a delivery bug: check the Spam list (or the Submissions API with `?state=spam`) and mark it verified — do not build a custom Function to "recover" it or disable spam filtering as a first resort.
+## Email notifications & subject line
 
-## File Uploads
+Default sender: `formresponses@netlify.com`. Set subject via a hidden `subject` input **or** the Netlify UI (Configuration > Notifications) — **not both; the HTML value always overrides the UI.**
 
 ```html
-<form name="upload" enctype="multipart/form-data" data-netlify="true">
-  <input type="text" name="name" />
-  <input type="file" name="attachment" />
-  <button type="submit">Upload</button>
-</form>
+<input type="hidden" name="subject" value="New lead from %{formName} (%{submissionId})" />
 ```
 
-For AJAX file uploads, use `FormData` directly — do **not** set `Content-Type` (the browser sets it with the correct boundary):
+Variables: `%{formName}`, `%{siteName}`, `%{submissionId}`. Forms created before **May 5, 2023** carry a `[Netlify]` subject prefix — remove it by adding the `data-remove-prefix` attribute to the `subject` input.
 
-```javascript
-await fetch("/", { method: "POST", body: new FormData(form) });
-```
+Set up notifications (email/webhook/Slack) in the UI: Configuration > Notifications > Form submission notifications > **Add notification**.
 
-**Limits:** 8 MB max request size, 30-second timeout, one file per input field.
+## Reading submissions via the API
 
-## Notifications
+Use only documented surfaces. Do NOT invent `api.netlify.com` endpoints or read tokens from local CLI config files. Reference: https://open-api.netlify.com/#tag/submission/operation/listFormSubmissions
 
-Configure in the Netlify UI under **Project configuration > Notifications**:
+- **Page through results using the `Link` header** — code that reads only the first response silently drops the rest.
+- `listFormSubmissions` returns data from old/removed fields no longer shown in the UI.
+- Query spam with `?state=spam`.
 
-- **Email**: Auto-sends on submission. Add `<input type="hidden" name="subject" value="Contact form" />` for custom subject lines.
-- **Slack**: Via Netlify App for Slack.
-- **Webhooks**: Trigger external services on submission.
+## Submission summary (field order matters)
 
-## Submissions API
+The UI summary is derived from field **type**, not name:
+- **Title**: first non-hidden text `<input>` that isn't email-like (`type="email"`, or name matching `email`/`mail`/`from`/`twitter`/`sender`); falls back to a field named `title` or `subject`.
+- **Body**: first `<textarea>`.
 
-Access submissions programmatically:
+Field order in the HTML affects what appears in the summary.
 
-```
-GET /api/v1/forms/{form_id}/submissions
-Authorization: Bearer <PERSONAL_ACCESS_TOKEN>
-```
+## Debugging missing submissions
 
-Key endpoints:
+- **First suspect: Akismet false positive.** A missing legitimate submission is usually spam-flagged — check the **Spam** list (or API `?state=spam`) and mark it verified. Do NOT build a custom recovery function or disable spam filtering as a first resort.
+- Test submissions get flagged as spam: use a real email (not `test@test.com`), write full sentences, don't hammer from one IP.
+- No submissions at all: confirm form detection is enabled and redeploy.
+- SSR/JS forms silently failing: verify the static skeleton file exists with exactly-matching field names and that AJAX targets the skeleton file, not `/`.
+- Missing old-field data: the UI shows only fields from the last deployed form version. Mark old fields `hidden` instead of removing them to keep them visible; old data remains available via `listFormSubmissions`.
 
-| Action | Method | Path |
-|---|---|---|
-| List forms | GET | `/api/v1/sites/{site_id}/forms` |
-| Get submissions | GET | `/api/v1/forms/{form_id}/submissions` |
-| Get spam | GET | `/api/v1/forms/{form_id}/submissions?state=spam` |
-| Delete submission | DELETE | `/api/v1/submissions/{id}` |
+## Constraints
 
-### Pagination
+- Deleting a form is permanent: future submissions return `404`, past submissions become unavailable. Export CSV first.
+- Submitted code is sanitized (`<script>` → escaped entities).
+- For PII, export and delete data regularly.
+- Data is stored in Netlify's database, not accessible except via UI/API/CSV.
 
-The Netlify API paginates any response over 100 items (100 per page by default). Pass `?page=` (1-based) and optionally `?per_page=` (max 100), and follow the `Link` response header — it carries the `rel="next"` and `rel="last"` page URLs. To sync **every** submission, page through until there is no `rel="next"` link (or a page returns fewer than `per_page` items). A single request does **not** return all submissions once a form has more than 100 — code that reads only the first response silently drops the rest.
+<!-- system: agent-context/forms/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (forms)
 
-## Use only documented surfaces
+These are org conventions and field-learned guardrails, not docs facts — they
+are merged into the rendered skill by ctx-gen and are never generated.
+Extracted from the previous hand-written netlify-forms skill; owned by the
+skills maintainer.
 
-To manage forms or read submissions programmatically, use the documented `netlify` CLI or the Submissions API above with an explicit personal access token supplied via an environment variable. Do **not** go around the documented surface:
-
-- **Do not curl `https://api.netlify.com/...`** with an invented endpoint shape, and do **not** run `netlify api <method>` as a recovery hatch when a documented path fails.
-- **Do not read the token** out of `~/Library/Preferences/netlify/config.json` (or anywhere on disk) — it comes from the configured env var.
-
-If a documented path fails, report the exact error and context to the user and stop.
+1. In SSR apps (Next.js, Nuxt, SvelteKit, etc.), `fetch("/")` is intercepted
+   by the SSR catch-all function and never reaches Netlify's form processing.
+   POST the AJAX submission to the static skeleton file itself (e.g.
+   `/__forms.html`), not to an arbitrary path.
+2. Use only documented surfaces: do not curl `https://api.netlify.com/...`
+   with an invented endpoint shape, and do not read tokens out of local CLI
+   config files (`~/Library/Preferences/netlify/config.json`).
+3. When reading submissions via the API, page through results (`Link`
+   header); code that reads only the first response silently drops the rest.
+4. For JS-rendered and SSR forms, always create the static skeleton file
+   `public/__forms.html`: a hidden copy of each form with
+   `data-netlify="true"`, a hidden `form-name` input, and every field the
+   component submits — names matching exactly (Netlify validates field names
+   against the registered form). Without this file, submissions silently fail.
+5. Astro routes rendered on demand (`export const prerender = false`, or
+   `output: "server"` routes) are never scanned at build time, so their forms
+   are never registered. Put the form on a prerendered page or rely on the
+   static skeleton file.
+6. A "missing" legitimate submission is usually an Akismet false positive:
+   check the Spam list (or the API with `?state=spam`) and mark it verified.
+   Do not build a custom recovery function or disable spam filtering as a
+   first resort.
+7. For custom success pages, use extensionless `action` paths (`/thank-you`,
+   not `/thank-you.html`) — Netlify serves `thank-you.html` at `/thank-you`
+   and the `.html` path returns 404.

--- a/skills/netlify-frameworks/SKILL.md
+++ b/skills/netlify-frameworks/SKILL.md
@@ -1,116 +1,241 @@
 ---
 name: netlify-frameworks
-description: Guide for deploying web frameworks on Netlify. Use when setting up a framework project (Vite/React, Astro, TanStack Start, Next.js, Nuxt, SvelteKit, Remix) for Netlify deployment, configuring adapters or plugins, running a framework project locally with Netlify's platform features, or troubleshooting framework-specific Netlify integration. Covers what Netlify needs from each framework, how adapters handle server-side rendering, and the general local development options (`netlify dev` versus the Netlify Vite plugin family).
+description: Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and env vars. Use when setting up or fixing a framework deploy (Next.js / Astro / Nuxt / SvelteKit / Remix / React Router / TanStack Start / SolidStart / Gatsby / Angular / Vite / Express / Hydrogen / Hugo / Eleventy / Vue / React), adding SSR or edge functions or middleware wired to Netlify context, fixing SPA redirect and catch-all rules, setting a build command or publish directory, or debugging "why isn't my env var updating" and framework build failures.
 ---
 
-# Frameworks on Netlify
+Route framework-specific deep work to the guides in this skill: `references/astro.md`, `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`, `references/tanstack.md`, `references/vite.md`.
 
-Netlify supports any framework that produces static output. For frameworks with server-side capabilities (SSR, API routes, middleware), an adapter or plugin translates the framework's server-side code into Netlify Functions and Edge Functions automatically.
+## Env vars: modern rules (read first)
 
-## How It Works
+Env values are injected **at build time**. Any change (client- or server-side) requires a **redeploy** — editing a var in the UI/CLI does NOT reach the live site or already-deployed functions until a new build runs.
 
-During build, the framework adapter writes files to `.netlify/v1/` — functions, edge functions, redirects, and configuration. Netlify reads these to deploy the site. You do not need to write Netlify Functions manually when using a framework adapter for server-side features.
+**Never use a client prefix for secrets.** Client-prefixed vars are inlined into the browser bundle:
+`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`.
 
-## Detecting Your Framework
+Client-embed prefixes by framework: CRA `REACT_APP_`, Gatsby `GATSBY_`, Next `NEXT_PUBLIC_`, Nuxt `NUXT_ENV_`, Vue CLI `VUE_APP_`.
 
-Check these files to determine the framework:
+**Scopes:** build-time access needs **Builds** scope; SSR/DSG runtime access needs **both Functions and Builds**. `netlify.toml` is read only during build — functions cannot read it at runtime; set runtime vars in UI/CLI/API.
 
-| File | Framework |
-|---|---|
-| `astro.config.*` | Astro |
-| `next.config.*` | Next.js |
-| `nuxt.config.*` | Nuxt |
-| `vite.config.*` + `react-router` | Vite + React (SPA or Remix) |
-| `vite.config.*` + `@tanstack/react-start` | TanStack Start |
-| `svelte.config.*` | SvelteKit |
-
-## Framework Reference Guides
-
-Each framework has specific adapter/plugin requirements and local dev patterns:
-
-- **Vite + React (SPA or with server routes)**: See [references/vite.md](references/vite.md)
-- **Astro**: See [references/astro.md](references/astro.md)
-- **TanStack Start**: See [references/tanstack.md](references/tanstack.md)
-- **Next.js**: See [references/nextjs.md](references/nextjs.md)
-- **Nuxt**: See [references/nuxt.md](references/nuxt.md)
-- **SvelteKit**: See [references/sveltekit.md](references/sveltekit.md)
-
-## Local Development
-
-Running a framework project locally with Netlify's platform features (environment variables, Functions, Edge Functions) generally comes from one of two places:
-
-### `netlify dev`
-
-```bash
-netlify dev
-```
-
-Wraps the framework's own dev server and adds:
-- Environment variable injection
-- Functions and Edge Functions
-- Redirects and headers processing
-
-Works with any framework — run `netlify dev` in place of the framework's native dev command (e.g. instead of `npm run dev`).
-
-Custom dev-server wiring — a non-standard `command`, a `port`/`targetPort`, or the `framework` key — goes in `netlify.toml`'s `[dev]` block; see the **netlify-config** skill for the full syntax. One easy-to-miss rule: if you set both a custom `command` and a `targetPort`, `framework` must be `"#custom"`, otherwise Netlify Dev runs its own detector and silently ignores your command.
-
-### Netlify Vite plugin family (Vite-based frameworks)
-
-For frameworks built on Vite, a Netlify Vite plugin exposes platform primitives (Functions, Blobs, DB, environment variables) directly inside the framework's own dev server, so no `netlify dev` wrapper is needed — run the framework's normal dev command (e.g. `npm run dev`) once the plugin is registered in `vite.config.ts`.
-
-- Vite-based projects (React SPA, SvelteKit, Remix): `@netlify/vite-plugin` — see [references/vite.md](references/vite.md)
-- TanStack Start: `@netlify/vite-plugin-tanstack-start` — see [references/tanstack.md](references/tanstack.md)
-
-The per-framework reference guides may also document other local dev options (e.g. `netlify dev`) — check the guide for your framework for setup specifics.
-
-### Running a single command with the Netlify environment loaded
-
-```bash
-netlify dev:exec <cmd>
-```
-
-Loads the Netlify environment (env vars, etc.) for a single command without starting a dev server — useful for scripts, tests, or one-off tasks that need Netlify-managed environment variables.
-
-## General Patterns
-
-### Client-Side Routing (SPA)
-
-For single-page apps with client-side routing, add a catch-all redirect:
-
+Netlify build variables can't be used as values in the UI or `netlify.toml` env sections. Set them inline before the build command:
 ```toml
-# netlify.toml
-[[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+[build]
+  command = "REACT_APP_CONTEXT=$CONTEXT npm run build"
 ```
 
-> **Remove this catch-all when you adopt an SSR adapter.** A `/* → /index.html` rule left over from an SPA setup will shadow your server routes: user-defined redirects in `netlify.toml`/`_redirects` take precedence over the routes a framework adapter generates, so every request — including SSR pages and API/function routes — is served the static `index.html` with a 200. When you migrate a client-rendered app to SSR, delete the SPA catch-all.
+## SPA redirects and the SSR catch-all footgun
 
-### Custom 404 Pages
+SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.html` for `pushState`:
+```
+/* /index.html 200
+```
 
-- **Static sites**: Create a `404.html` in your publish directory. Netlify serves it automatically for unmatched routes.
-- **SSR frameworks**: Handle 404s in the framework's routing (the adapter maps this to Netlify's function routing).
+**Remove any SPA catch-all when adopting an SSR adapter.** A leftover `/* → /index.html 200` silently serves static `index.html` for SSR pages and API routes — user redirects beat adapter-generated routes.
 
-### Environment Variables in Frameworks
+## Local dev with platform emulation (no Netlify CLI)
 
-Each framework exposes environment variables to client-side code differently:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
 
-| Framework | Client prefix | Access pattern |
-|---|---|---|
-| Vite / React | `VITE_` | `import.meta.env.VITE_VAR` |
-| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_VAR` |
-| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_VAR` |
-| Nuxt | `NUXT_PUBLIC_` | `useRuntimeConfig().public.var` |
+| Framework | Plugin/module | Run |
+|-----------|---------------|-----|
+| Astro (5.12+) | built-in (Netlify Vite plugin auto-loaded) | `astro dev` |
+| Nuxt | `@netlify/nuxt` | `nuxt dev` |
+| React Router | `@netlify/vite-plugin` | `react-router dev` |
+| SolidStart 2 | `@netlify/vite-plugin` | `vite dev` |
+| TanStack Start | `@netlify/vite-plugin-tanstack-start` | (vite) |
+| Vite | `@netlify/vite-plugin` | `npx vite` |
 
-In server-side code, prefer `Netlify.env.get("VAR")` to read environment variables. `process.env.VAR` also works inside Netlify Functions, but Edge Functions expose only `Netlify.env.get` — the portable form keeps server code working in both.
+Still need `netlify dev` (Netlify CLI) for: Gatsby generated functions (run `netlify build` first), Angular SSR local test (`netlify serve`), and frameworks without a Vite plugin.
 
-**Never use a client prefix (`VITE_`, `PUBLIC_`, `NEXT_PUBLIC_`, `NUXT_PUBLIC_`) for secrets.** Client-prefixed variables are inlined into the client bundle and exposed to the browser.
+**`netlify dev` gotcha:** with both a custom `command` and a `targetPort` in `[dev]`, you must set `framework = "#custom"` — otherwise the detector runs and your custom command is silently ignored.
 
-### Environment Variable Changes Require a Redeploy
+## Build settings by framework
 
-Client-prefixed vars (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, `NUXT_PUBLIC_`) are **inlined into the client bundle at build time** — their values are compiled into the JavaScript shipped to the browser. Editing one in the Netlify UI or CLI has no effect on the live site until a new build runs. The same applies server-side: Netlify injects environment variables at build time, so changing a value in the dashboard does **not** propagate to already-deployed functions on the next request. Any env var change — client- or server-side — requires a redeploy to take effect. If a value looks stale after you changed it, trigger a new deploy.
+| Framework | Build command | Publish |
+|-----------|---------------|---------|
+| Angular (standard) | `ng build --prod` | `dist/YOUR_PROJECT_NAME` |
+| Astro | `astro build` | `dist` |
+| Create React App | `react-scripts build` | `build` |
+| Eleventy | `eleventy` | `_site` |
+| Gatsby | `gatsby build` | `public` |
+| Hugo | `hugo` | `public` |
+| Hydrogen | `remix vite:build` | `dist/client` |
+| Next.js (SSR/hybrid) | `next build` | `.next` |
+| Next.js (static export) | `next build && next export` | `out` (`NETLIFY_NEXT_PLUGIN_SKIP=true`) |
+| Nuxt 3 | `nuxt build` | `dist` |
+| Nuxt 2 | `nuxt generate` | `dist` |
+| React Router | `react-router build` | `build/client` |
+| Remix (Vite) | `remix vite:build` | `build/client` |
+| SolidStart 2 (Vite plugin) | `vite build` | `dist/client` |
+| SolidStart 2 (Nitro) | `vite build` | `dist` |
+| SolidStart 1.x | `vinxi build` | `dist` |
+| SvelteKit | `vite build` | `build` |
+| TanStack Start (1.132.0+) | `vite build` | `dist/client` |
+| Vite | `vite build` | `dist` |
+| Vue CLI | `vue-cli-service build` | `dist` |
 
-### Runtime File Reads in Adapter-Generated Functions
+Detection suggests these; override in `netlify.toml` or UI (project configuration > Build & deploy > Continuous deployment > Build settings).
 
-When an adapter turns your server code into a Netlify Function, only traced module dependencies are bundled. Arbitrary files you read from disk at runtime — a local JSON/Markdown data file, an email template, an `fs.readFile()` target — are **not** uploaded with the function unless you declare them. Such a read succeeds under `npm run dev` (the whole project is on disk) but throws `ENOENT` in production. Declare the files so they ship with the function: in Next.js set `outputFileTracingIncludes` in `next.config`; for a hand-written Netlify Function use `included_files` in its `config`. Never assume the project filesystem is present at function runtime.
+## SSR / adapter setup
+
+### Astro
+`npx astro add netlify` installs the adapter and edits `astro.config.mjs`. Adapter needed for SSR and out-of-the-box Image CDN for `<Image />`. SSR → Netlify Functions; middleware → Edge Functions. Adapter-less deploy only if no server features and no Image CDN need. Skew protection from 5.15.0.
+
+### Next.js (13.5+ only)
+Zero-config via the OpenNext adapter (`@netlify/plugin-nextjs`). Do NOT pin the version — Netlify auto-updates each build. Treat the legacy adapter as read-only history, never a recommendation.
+Adapter provisions: serverless function for SSR/ISR/PPR/route handlers/Server Actions; Edge Function for Middleware; Full Route + Data Cache; Image CDN with `next/image`.
+Skew protection is opt-in: set `NETLIFY_NEXT_SKEW_PROTECTION=true`, redeploy. No automatic support for client `fetch` — direct calls with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`. Details in `references/nextjs.md`.
+
+### SvelteKit
+```bash
+npm install -D @sveltejs/adapter-netlify
+```
+```js
+import adapter from '@sveltejs/adapter-netlify';
+export default { kit: { adapter: adapter() } };
+```
+Replace `@sveltejs/adapter-auto` with the specific import. SSR routes → a `render` function.
+- `split: true` → one function per route. **Incompatible with Edge Functions** (`edge: false` or omit).
+- `edge: true` → SSR in a Deno edge function; can't combine with `split`.
+- **Redirects NOT supported in `netlify.toml`** — use `_redirects`.
+- Edge functions don't work locally with `netlify dev` for SvelteKit.
+
+### React Router (7+)
+New: `npx create-react-router@latest --template netlify/react-router-template`. Existing:
+```bash
+npm install @netlify/vite-plugin-react-router
+```
+Add `netlifyReactRouter()` to Vite plugins. Default target = Serverless Functions.
+**Edge (Deno):** needs plugin v2.1.1+, set `edge: true`, and you **must** create `app/entry.server.tsx`:
+```typescript
+export { default } from 'virtual:netlify-server-entry'
+```
+Exclude your own function paths: `netlifyReactRouter({ edge: true, excludedPaths: ['/api/*'] })`.
+**Moving back to Serverless:** remove `edge: true` AND delete `app/entry.server.tsx`.
+Middleware (React Router v7.9.0+, plugin v2.0.0+): opt in via `future.v8_middleware`; import `netlifyRouterContext` from `@netlify/vite-plugin-react-router/serverless` (or `/edge` when `edge: true`); access `context.get(netlifyRouterContext)`.
+
+### Remix
+New: `npx create-remix@latest --template netlify/remix-template` (CLI prompts functions vs Edge Functions). Manual (Remix Vite required):
+```bash
+npm install --save-dev @netlify/remix-adapter
+```
+Add `netlifyPlugin()` from `@netlify/remix-adapter/plugin` to Vite plugins.
+
+### Nuxt
+SSR via Nitro, automatic on Nuxt 3. Local parity via `@netlify/nuxt` (`npx nuxi module add @netlify/nuxt`).
+- SSR on Edge Functions requires a different Nitro deployment preset (not auto-detected).
+- pnpm + Nuxt 3: set `PNPM_FLAGS=--shamefully-hoist`.
+- `nuxt/image` auto-uses Netlify Image CDN; set remote domains in `nuxt.config.ts`.
+
+### SolidStart
+SolidStart 2 builds on Vite — **no SolidStart-specific adapter**. Install `@netlify/vite-plugin`:
+```ts
+import netlify from "@netlify/vite-plugin";
+import { solidStart } from "@solidjs/start/config";
+import { defineConfig } from "vite";
+export default defineConfig({
+  plugins: [solidStart(), netlify({ build: { enabled: true } })],
+});
+```
+Publish `dist/client`. SSR routes, server functions, middleware → Netlify Functions, zero extra config.
+**Nitro alternative:** add `nitro()`, use plain `netlify()` (no `build.enabled`), publish `dist`.
+SolidStart 1: Nitro auto-configures; optionally set `preset: "netlify"` in `app.config.ts`; `vinxi build` / `dist`.
+
+### TanStack Start
+React (and Solid.js) full-stack; SSR/Server Routes/Server Functions/middleware → serverless functions.
+```bash
+npm install -D @netlify/vite-plugin-tanstack-start
+```
+Add `netlify()` to Vite plugins alongside `tanstackStart()`; `vite build` / `dist/client` (1.132.0+). Netlify CLI deploys require netlify-cli 17.31+. Older versions: see `references/tanstack.md`.
+
+### Gatsby
+- **5.12.0+ (adapter):** auto-detects and installs `gatsby-adapter-netlify` (zero-config). Generates functions `SSR`, `DSG`. No Essential Gatsby plugin needed.
+- **5.11.0 or earlier (Essential Gatsby plugin):** auto-installs `@netlify/plugin-gatsby`; also manually install `gatsby-plugin-netlify` (required for SSR, Gatsby redirects, asset caching). Generates `__api`, `__ssr`, `__dsg`, `__ipx`. Skip via `NETLIFY_SKIP_GATSBY_FUNCTIONS` (all) / `NETLIFY_SKIP_API_FUNCTION` / `NETLIFY_SKIP_SSR_FUNCTION` / `NETLIFY_SKIP_DSG_FUNCTION`.
+- Gatsby 5 requires Node 18.
+- Large sites: set `GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE` to load datastore from CDN (avoids max function deploy size; slower first SSR/DSG load).
+- Image CDN: set `NETLIFY_IMAGE_CDN=true` (Contentful/Drupal/WordPress source plugins). **Not supported on 5.12.x with adapter — upgrade to 5.13.0+.**
+- `StaticImage` and `gatsby-transformer-sharp` don't work for SSR/DSG — host images on a CDN.
+
+### Angular
+SSR auto-configured via an Edge Function. Suggested dev: `ng serve` / `4200`.
+- **SSR pages are NOT subject to `_redirects` or `netlify.toml` redirects** — SSR uses Edge Functions that run before redirects. Use Angular's built-in redirects.
+- Access `Request`/`Context` in SSR via `netlify.request` / `netlify.context` providers (from `@netlify/edge-functions`); unavailable client-side or during prerendering. Test locally with `netlify serve`.
+- `NgOptimizedImage` auto-uses Image CDN; set `remote_images` (array of regex) under `[images]` in `netlify.toml`.
+
+### Express
+Node 18.14.0+. Deploy as a Netlify Function via `serverless-http`:
+```bash
+npm i express serverless-http @netlify/functions @types/express
+```
+```ts
+// netlify/functions/api.ts
+import express, { Router } from "express";
+import serverless from "serverless-http";
+const api = express();
+const router = Router();
+router.get("/hello", (req, res) => res.send("Hello World!"));
+api.use("/api/", router);
+export const handler = serverless(api);
+```
+```toml
+[functions]
+  external_node_modules = ["express"]
+  node_bundler = "esbuild"
+[[redirects]]
+  force = true
+  from = "/api/*"
+  status = 200
+  to = "/.netlify/functions/api/:splat"
+```
+No frontend: set a placeholder build command (e.g. `echo Building Functions`). All Function limits apply; not recommended as background/scheduled functions.
+
+### Hydrogen
+Shopify stack on React Router 7. **SSR only on Netlify Edge Functions — Netlify Functions NOT officially supported.** Node 24+. Use the starter:
+```bash
+npm create @shopify/hydrogen@latest -- --template https://github.com/netlify/hydrogen-template
+cp .env.example .env && npm run dev
+```
+
+## Static-site gotchas
+
+### Hugo
+Set `HUGO_VERSION` (any release after 0.19) in `[build.environment]` — a missing/mismatched version causes `exit code: 255`. Install themes as **git submodules** (`git submodule add ...`), not `git clone`.
+
+### Eleventy
+`eleventy` / `_site`. **Build plugins require editing `.gitignore`: change `node_modules` to `**/node_modules/**`** — otherwise Netlify plugins and Eleventy collide on `.netlify/plugins/node_modules/` and the build errors.
+
+## Vite meta-framework support matrix
+Astro (auto on 5.12+), Nuxt (via `@netlify/nuxt`), TanStack Start (via `@netlify/vite-plugin-tanstack-start`), React Router, SolidStart — all **full**. SvelteKit — **experimental**.
+
+## Deploy via CLI (Express, Nuxt, React, Vite)
+```sh
+npm install netlify-cli -g
+netlify init
+```
+Follow prompts to create/link the site and set build settings.
+
+<!-- Node version floors (18.14.0+) are stated per-framework where documented; no cross-framework build-image default is given in sources. -->
+
+<!-- system: agent-context/frameworks/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (frameworks)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Per-framework deep guides live in this skill: `references/astro.md`,
+   `references/nextjs.md`, `references/nuxt.md`, `references/sveltekit.md`,
+   `references/tanstack.md`, `references/vite.md` — route framework-specific
+   work there before improvising.
+2. Next.js: modern runtime (v5, Next ≥13.5) only — treat the legacy adapter
+   as read-only history, never a recommendation.
+3. Remove any SPA catch-all (`/* → /index.html 200`) when adopting an SSR
+   adapter — user redirects beat adapter-generated routes, so a leftover
+   catch-all silently serves static `index.html` for SSR pages and API routes.
+4. Any env var change — client- or server-side — requires a redeploy. Values
+   are injected at build time; editing one in the UI/CLI does not reach the
+   live site or already-deployed functions until a new build runs.
+5. `netlify dev` with both a custom `command` and a `targetPort` requires
+   `framework = "#custom"` in the `[dev]` block — otherwise the detector runs
+   and the custom command is silently ignored.
+6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
+   `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
+   client-prefixed vars are inlined into the browser bundle.

--- a/skills/netlify-functions/SKILL.md
+++ b/skills/netlify-functions/SKILL.md
@@ -1,286 +1,348 @@
 ---
 name: netlify-functions
-description: Guide for writing Netlify serverless functions. Use when creating API endpoints, background processing, scheduled tasks, or any server-side logic using Netlify Functions. Covers modern syntax (default export + Config), TypeScript, path routing, background functions, scheduled functions, streaming, and method routing.
+description: Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API endpoint or backend route, adding a contact form handler, wiring auth or Identity signup/login hooks, building streaming or AI-proxy responses, scheduling cron jobs, running long background jobs (batch processing/scraping), reacting to deploy or form events, setting up rate limiting or region/memory config, or reading environment variables and secrets inside a function. Covers file locations, the Request/Context/Response handler shape, path routing, config options, and local testing with netlify dev.
 ---
 
 # Netlify Functions
 
-## Modern Syntax
+Reach for the modern default-handler API (`.mts` TypeScript). Export a default async handler taking a web `Request` and a Netlify `Context`, returning a web `Response`. Avoid the legacy AWS Lambda handler shape unless writing Go or migrating old code (see Legacy at the end).
 
-Always use the modern default export + Config pattern. Never use the legacy `exports.handler` or named `handler` export.
+## File locations
 
-```typescript
-import type { Context, Config } from "@netlify/functions";
+- Default directory: `netlify/functions/` (relative to base directory). Keep it **outside** your publish directory or source files ship as static assets.
+- A function is one file or a subdirectory whose entry file is named `index` or matches the subdirectory name. All of these create a function `hello`:
+  - `netlify/functions/hello.mts`
+  - `netlify/functions/hello/hello.mts`
+  - `netlify/functions/hello/index.mts`
+- Use `.mts` (TS) / `.mjs` (JS) for ES modules. `.cts`/`.cjs` force CommonJS; `.ts`/`.js` follow the nearest `package.json` `"type"`.
+
+## Minimal function
+
+No `config` export. Serves at `/.netlify/functions/hello`.
+
+```ts title="netlify/functions/hello.mts"
+import type { Context } from "@netlify/functions"
 
 export default async (req: Request, context: Context) => {
-  return new Response("Hello, world!");
-};
-
-export const config: Config = {
-  path: "/api/hello",
-};
+  return new Response("Hello, world!")
+}
 ```
 
-The handler receives a standard Web API `Request` and returns a `Response`. The second argument is a Netlify `Context` object.
+Install types: `npm install @netlify/functions` (required for TS types; optional for JS).
 
-The bare default export shown above is the recommended form. The default export can also be an object with a `fetch` method — prefer this form only if (1) other functions in the project already use it, or (2) the function also subscribes to platform events (see [Event Handlers](#event-handlers) below), since events are exposed as named handlers on the same object:
+Read env vars and secrets with `Netlify.env.get()`:
 
-```typescript
+```ts
+const apiKey = Netlify.env.get("STRIPE_SECRET_KEY")
+```
+
+Never hardcode secrets. For the variable to exist at runtime its scope must include **Functions**. Variables set in `netlify.toml` are NOT available to functions. Values are frozen per deploy — change them and redeploy to apply.
+
+**Response headers are set in code** on the returned `Response`. `[[headers]]` in `netlify.toml`, `_headers`, and redirect header rules apply ONLY to static CDN responses, not function responses. Do not add CORS headers unless explicitly requested.
+
+## Custom path routing
+
+Set `config.path` to route to custom URLs. When set, the function serves ONLY at that path — not at `/.netlify/functions/<name>`.
+
+```ts title="netlify/functions/travel.mts"
+import type { Config, Context } from "@netlify/functions"
+
+export default async (req: Request, context: Context) => {
+  const { city, country } = context.params
+  return new Response(`You're visiting ${city} in ${country}!`)
+}
+
+export const config: Config = {
+  path: "/travel-guide/:city/:country",
+}
+```
+
+- Multiple paths: `path: ["/cats", "/dogs"]`.
+- Patterns: `path` supports [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) syntax — `path: ["/sale/*", "/item/:sku"]`. Named groups land on `context.params`. For the query string use `req.url`.
+- `excludedPath`: carve exceptions, e.g. `excludedPath: ["/product/*.css"]` with `path: "/product/*"`.
+- `preferStatic: true`: let a real static file at the URL win.
+- `method`: restrict methods, e.g. `method: ["GET", "POST"]`.
+
+## Fetchable module shape (alternative)
+
+Equivalent to the bare handler; carries `config` inline and lets you add event handlers.
+
+```ts
+import type { NetlifyFunction } from "@netlify/functions"
+
 export default {
-  fetch(req: Request, context: Context) {
-    return new Response("Hello, world!");
-  },
-};
+  fetch: (req, context) => new Response("Hello, world!"),
+  config: { path: "/hello" },
+} satisfies NetlifyFunction
 ```
 
-## File Structure
+## Context object
 
-Place functions in `netlify/functions/`:
+Second handler argument (or `getContext()` from `@netlify/functions` when out of handler scope — throws outside a request; wrap in try/catch).
 
-```
-netlify/functions/
-  _shared/           # Non-function shared code (underscore prefix)
-    auth.ts
-    db.ts
-  items.ts           # -> /.netlify/functions/items (or custom path via config)
-  users/index.ts     # -> /.netlify/functions/users
-```
+- `context.params` — named path params.
+- `context.geo` — `city`, `country.code/name`, `latitude`, `longitude`, `subdivision`, `timezone`, `postalCode`.
+- `context.ip` — client IP string.
+- `context.cookies` — `get(name)` / `set(options)` / `delete(name|options)`. Cross-subdomain cookies need a custom domain (`netlify.app` is on the Public Suffix List).
+- `context.site` — `id`, `name`, `url`. `context.deploy` — `context`, `id`, `published`, `skewProtectionToken`. `context.account.id`. `context.server.region`. `context.requestId`.
+- `context.waitUntil(promise)` — run work after the response is sent (analytics, logs) without blocking. Billing/log duration counts until the promise settles. Available for functions deployed on/after 2025-03-20.
 
-Use `.ts` or `.mts` extensions. If both `.ts` and `.js` exist with the same name, the `.js` file takes precedence.
+⚠️ Under `netlify dev`, `context.geo` and `context.ip` are **mocked** — placeholder values that never change. Don't conclude geo code is broken locally. Exercise branches with `netlify dev --geo=mock --country=DE` and verify on a real deploy.
 
-## Path Routing
+## Config object
 
-Define custom paths via the `config` export:
+Export `const config` (or the `config` property of a Fetchable module):
 
-```typescript
-export const config: Config = {
-  path: "/api/items",                    // Static path
-  // path: "/api/items/:id",            // Path parameter
-  // path: ["/api/items", "/api/items/:id"], // Multiple paths
-  // excludedPath: "/api/items/special", // Excluded paths
-  // preferStatic: true,                // Don't override static files
-};
-```
+- `path` / `excludedPath` — `string | string[]`, must start with `/`.
+- `method` — one method or array.
+- `preferStatic` — `boolean`.
+- `background` — `boolean` (see Background).
+- `schedule` — cron string (see Scheduled). Mutually exclusive with `path`/`excludedPath`.
+- `rateLimit` — `{ action: 'rate_limit'|'rewrite', aggregateBy: 'domain'|'ip'|[...], to?, windowSize, windowLimit }`.
+- `memory` / `vcpu` — see below; mutually exclusive.
+- `region` — airport code; see below.
 
-Without a `path` config, functions are available at `/.netlify/functions/{name}`. Setting a `path` makes the function available **only** at that path.
+## Integrations
 
-Access path parameters via `context.params`:
+```ts title="netlify/functions/users.mts"
+import type { Config } from "@netlify/functions"
+import { getDatabase } from "@netlify/database"
 
-```typescript
-// config: { path: "/api/items/:id" }
-export default async (req: Request, context: Context) => {
-  const { id } = context.params;
-  // ...
-};
-```
+const db = getDatabase()
 
-## Method Routing
-
-```typescript
-export default async (req: Request, context: Context) => {
-  switch (req.method) {
-    case "GET":    return handleGet(context.params.id);
-    case "POST":   return handlePost(await req.json());
-    case "DELETE": return handleDelete(context.params.id);
-    default:       return new Response("Method not allowed", { status: 405 });
-  }
-};
-
-export const config: Config = {
-  path: "/api/items/:id",
-  method: ["GET", "POST", "DELETE"],
-};
-```
-
-## Background Functions
-
-For long-running tasks (up to 15 minutes). The client receives an immediate `202` response; return values are ignored.
-
-Enable background mode by setting `background: true` in config:
-
-```typescript
 export default async (req: Request) => {
-  await someLongRunningTask();
-};
+  const users = await db.sql`SELECT id, email FROM users LIMIT 10`
+  return Response.json({ users })
+}
+
+export const config: Config = { path: "/users" }
+```
+
+Blobs: `import { getStore } from "@netlify/blobs"`; `getStore("uploads").set(key, await req.blob())`.
+
+`purgeCache()` from `@netlify/functions` invalidates the edge cache from inside a function:
+
+```ts
+import { purgeCache } from "@netlify/functions"
+
+export default async () => {
+  await purgeCache({ tags: ["products"] }) // omit tags to purge all
+  return new Response("Purged!", { status: 202 })
+}
+```
+
+## Streaming responses
+
+Return a `ReadableStream` as the `Response` body. Limits: **60s execution, 20 MB response**.
+
+```ts
+export default async (req: Request) => {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${Netlify.env.get("OPENAI_API_KEY")}`,
+    },
+    body: JSON.stringify({ model: "gpt-4o-mini", stream: true, messages: [/* ... */] }),
+  })
+  return new Response(res.body, { headers: { "content-type": "text/event-stream" } })
+}
+```
+
+To build a stream manually, `new ReadableStream({ start(controller) { controller.enqueue(...); controller.close() } })`.
+
+## Background functions (long-running)
+
+`config.background: true`. Client gets an immediate `202`; the return value is discarded; runs up to **15 minutes**. No streaming. Retries: on invocation error, retry after 1 min, then again 2 min later. Send results somewhere other than the client.
+
+```ts title="netlify/functions/process.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  // Long-running work. Client already has its 202.
+}
+
+export const config: Config = { background: true, path: "/process" }
+```
+
+Limits: background payload **256 KB**. Legacy `-background` filename suffix still works but prefer `config.background`.
+
+## Scheduled functions (cron)
+
+`config.schedule` with a cron expression, executed in **UTC**. The request body is JSON with `next_run` (ISO-8601). Inline config is TS/JS only — Go must use `netlify.toml`.
+
+Always compute the UTC time for the target local hour. E.g. 9 AM ET → `"0 13 * * *"` UTC (note this shifts by an hour across DST; pick the UTC offset you need). Prefer explicit cron over `@daily`/`@hourly` shortcuts, which can't target a specific local hour.
+
+```ts title="netlify/functions/daily-digest.mts"
+import type { Config } from "@netlify/functions"
+
+export default async (req: Request) => {
+  const { next_run } = await req.json()
+  console.log("Next invocation at:", next_run)
+}
 
 export const config: Config = {
-  path: "/process",
-  background: true,
-};
+  schedule: "0 13 * * *", // 9 AM ET (EST); UTC
+}
 ```
 
-Store results externally (Netlify Blobs, database) for later retrieval.
+Via `netlify.toml` (all languages):
 
-The legacy filename convention (`process-background.ts`) is still supported, but new functions should use `config.background`.
-
-## Region
-
-Functions deploy to `cmh` (Ohio) by default for new sites. This is a deliberate choice: US East is centrally located for an international audience, has a broad provider ecosystem, and gives most projects the lowest overall latency without any configuration. Sites created before October 4, 2023 may have a different default region — check Project configuration > Build & deploy > Continuous deployment > Functions region to confirm.
-
-Do NOT override `config.region` unless the user has stated a specific reason — for example, a database or backend service in another region with measurable roundtrip savings, a data-residency requirement, or an audience concentrated in one region whose compute dependencies (database, backend services) also live in that region.
-
-Two constraints to be aware of before adding `config.region`:
-
-- A function runs in exactly one region. Don't try to deploy the same function to multiple regions — if the user wants geo-routing, route between distinct functions with an edge function instead.
-- For framework adapter–generated functions (Next.js, Astro, Nuxt, etc.) the region must be set site-wide in the Netlify UI, not via `config.region` in code. The generated files can't carry per-function config.
-
-Region values are IATA airport codes — for example `cmh` (Columbus/Ohio, the default), `dub` (Dublin), and `fra` (Frankfurt). See [Region](https://docs.netlify.com/build/functions/configuration#region) for the full list of supported regions and details.
-
-## Memory or vCPU
-
-Functions run with 1024 MB of memory and a proportional amount of compute by default. The default fits most workloads, and raising it has a direct cost impact: function billing scales linearly with the configured size.
-
-Do NOT set `config.memory` or `config.vcpu` speculatively. Only reach for them when:
-
-- The workload is known to be memory- or compute-intensive (AI inference, image/PDF manipulation, large payload processing, CPU-bound work).
-- The function is hitting out-of-memory errors or timeouts caused by the function's own work, rather than by waiting on an external service or database.
-
-`memory` and `vcpu` configure the same underlying resource and are mutually exclusive — set one, not both. Set `memory` as a number of megabytes (e.g. `memory: 2048`) or as a string with a unit (e.g. `'2gb'` or `'2048mb'`, case-insensitive), within the 1024–4096 MB range. Adjusting them is available only on Credit-based Pro and Enterprise plans; on other plans these settings have no effect. See [Memory or vCPU](https://docs.netlify.com/build/functions/configuration#memory-or-vcpu) for accepted values and the exact mapping.
-
-## Scheduled Functions
-
-Run on a cron schedule (UTC timezone):
-
-```typescript
-export default async (req: Request) => {
-  const { next_run } = await req.json();
-  console.log("Next invocation at:", next_run);
-};
-
-export const config: Config = {
-  schedule: "@hourly", // or cron: "0 * * * *"
-};
+```toml
+[functions."daily-digest"]
+  schedule = "0 13 * * *"
 ```
 
-Shortcuts: `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`. Scheduled functions have a **30-second timeout** and only run on published deploys.
+Constraints: **30s limit** (use background for longer); only fire on **published deploys** (not Deploy Previews/branch deploys — invoke manually with **Run now**); no URL invocation; no streaming; no request payloads/POST data; incompatible with Split Testing. All extensions supported **except** `@reboot` and `@annually`.
 
-**Testing and triggering.** A scheduled function does **not** fire on its cron schedule under `netlify dev` — the local dev server never runs the schedule, so waiting for the clock will appear to do nothing. Test it by invoking it directly: `netlify functions:invoke <name>` calls the function once, on demand. In production a scheduled function also has **no public HTTP URL** — it is not reachable at `/.netlify/functions/{name}` and cannot be triggered by an external HTTP request; it runs only on its schedule. If you also need to trigger the same work over HTTP (a manual "run now" or a webhook), expose that logic through a separate ordinary HTTP function and share the implementation rather than trying to POST to the scheduled function.
+## Platform-event functions
 
-## Streaming Responses
+Export a default object with handlers named after events. They always run in the background — no response to a client. Combine with `fetch` in the same function. Every handler is fully typed; import event types from `@netlify/functions`.
 
-Return a `ReadableStream` body for streamed responses (up to 20 MB):
-
-```typescript
-export default async (req: Request) => {
-  const stream = new ReadableStream({ /* ... */ });
-  return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream" },
-  });
-};
-```
-
-## Event Handlers
-
-A function can subscribe to platform events by exporting an object instead of a function as its default. Each event has a named handler property:
-
-```typescript
-import type { DeploySucceededEvent, UserSignupEvent } from "@netlify/functions";
+```ts title="netlify/functions/on-deploy.mts"
+import type { DeploySucceededEvent, DeployFailedEvent } from "@netlify/functions"
 
 export default {
   deploySucceeded(event: DeploySucceededEvent) {
-    console.log(`Deploy ${event.deploy.id} succeeded`);
+    console.log(`Deploy ${event.deploy.id} succeeded for ${event.site.name}`)
   },
-
-  userSignup(event: UserSignupEvent) {
-    return {
-      user: {
-        ...event.user,
-        appMetadata: { ...event.user.appMetadata, roles: ["member"] },
-      },
-    };
+  deployFailed(event: DeployFailedEvent) {
+    console.log(`Deploy ${event.deploy.id} failed: ${event.deploy.errorMessage}`)
   },
-};
+}
 ```
 
-A single function can declare multiple handlers; multiple functions can also subscribe to the same event.
+**Deploy events** (`event.deploy`, `event.site`; return `void`): `deployBuilding`, `deploySucceeded`, `deployFailed`, `deployDeleted`, `deployLocked`, `deployUnlocked`.
 
-**Available handlers:**
+**Identity events** (`event.user`, only `id` guaranteed):
 
-| Handler | Trigger |
-|---|---|
-| `fetch` | HTTP request (equivalent to a bare function default export) |
-| `deployBuilding` / `deploySucceeded` / `deployFailed` / `deployDeleted` / `deployLocked` / `deployUnlocked` | Deploy lifecycle |
-| `userSignup` / `userLogin` / `userValidate` / `userModified` / `userDeleted` | Identity lifecycle |
-| `formSubmitted` | Form submission verified |
+| Handler | Can deny? | Can mutate? |
+|---|---|---|
+| `userValidate` | Yes | Yes |
+| `userSignup` | Yes | Yes |
+| `userLogin` | Yes | Yes |
+| `userModified` | Yes | Yes |
+| `userDeleted` | No | No |
 
-### Identity handlers: deny an action
+- Deny: call `event.deny()` inside the handler → end user gets `401`. First function to deny aborts the chain.
+- Mutate: return `{ user: {...} }` to persist changes; return `undefined` to pass through.
 
-`userSignup`, `userLogin`, `userValidate`, and `userModified` can reject the action by calling `event.deny()`. The end user receives a 401; no observability error is produced (unlike throwing).
+**Form events**: `formSubmitted` → `event.data` (object keyed by field name). Return `void`.
 
-```typescript
-export default {
-  userLogin(event: UserLoginEvent) {
-    if (!event.user.email?.endsWith("@example.com")) {
-      return event.deny();
-    }
-  },
-};
+Multiple functions can handle the same event (all run). Netlify signs each event (JWS) and verifies before invoking, blocking external requests. Legacy filename convention (file named after the event, payload via `await req.json()` → `payload`) still works but prefer typed handlers.
+
+## Region
+
+⚠️ Do NOT override `config.region` unless the user states a specific reason (co-located DB/backend, data residency, regional audience). The default `cmh` (US East, Ohio) is deliberate.
+
+When justified — e.g. an EU-resident database:
+
+```ts
+export const config: Config = { path: "/eu-data", region: "dub" }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain.
+Airport codes (self-serve): `cmh`, `dub`, `fra`, `gru`, `iad`, `lhr`, `nrt`, `pdx`, `sfo`, `sin`, `syd`, `yul`. Support-assisted: `cdg`, `mxp`. Each function runs in exactly one region (no multi-region geo-routing). Region selection needs Pro/Enterprise. Framework-adapter-generated functions can't take `export const config` — set region at project level in the UI. After changing region, **redeploy**. Function-level region beats the site-level UI setting.
 
-## Context Object
+## Memory / vCPU
 
-| Property | Description |
-|---|---|
-| `context.params` | Path parameters from config |
-| `context.geo` | `{ city, country: {code, name}, latitude, longitude, subdivision, timezone, postalCode }` |
-| `context.ip` | Client IP address |
-| `context.cookies` | `.get()`, `.set()`, `.delete()` |
-| `context.deploy` | `{ context, id, published }` |
-| `context.site` | `{ id, name, url }` |
-| `context.account.id` | Team account ID |
-| `context.requestId` | Unique request ID |
-| `context.waitUntil(promise)` | Extend execution after response is sent |
+⚠️ Do NOT set `config.memory` or `config.vcpu` speculatively — billing scales linearly with size. Raise them only for known memory/compute-intensive work (AI inference, image/PDF, large JSON/CSV) or observed OOM/timeouts caused by the function's own work.
 
-**`context.geo` and `context.ip` are mocked under `netlify dev`.** Locally these return placeholder values, not your real location or client IP, so a value that looks "stuck" on a default country does not mean your geo code is broken — real geolocation is populated only for deployed functions. To exercise geo branching locally, start dev with the geo flags: `netlify dev --geo=mock --country=DE` forces mock data (`--geo=mock`) and sets the mock country (`--country`). Don't conclude `context.geo` is broken because local values never change.
+When justified (e.g. observed OOM processing large PDFs):
 
-## Environment Variables
-
-Prefer `Netlify.env.get` inside functions:
-
-```typescript
-const apiKey = Netlify.env.get("API_KEY");
+```ts
+export const config: Config = { path: "/heavy", memory: "2gb" } // or memory: 2048
 ```
 
-`process.env` is also valid inside Functions and reads the same variables — prefer `Netlify.env.get` for cross-runtime and edge portability (a function you later move to an Edge Function keeps working, since Edge Functions expose **only** `Netlify.env.get`, not `process.env`).
+- `memory`: 1024–4096 MB. `vcpu`: 0.5–2.0 (0.5 → 1024 MB, 2.0 → 4096 MB). Mutually exclusive; Netlify sizes the other automatically. Needs Credit-based Pro/Enterprise. Via `netlify.toml`: `[functions.heavy]\n  memory = "2gb"`.
 
-**Environment variables have a small total size budget.** Functions run on AWS Lambda, which caps the *combined* size of all environment variables at roughly 4 KB. A single large value — a service-account JSON credential, a PEM private key, a big config blob — can blow past that on its own and break the deploy or the function at runtime. Do not store large payloads in environment variables; keep only small secrets and config (API keys, connection strings) there and move anything large into a bundled file, Netlify Blobs, or a fetch at runtime. There is no Netlify setting that raises this cap.
+## Bundling & files on disk
 
-## Reading Files at Runtime
-
-Only a function's own code and the modules it `import`s are bundled and deployed. A file the function opens from disk at runtime — `fs.readFile`/`readFileSync` on a template, a JSON data file, a WASM binary, a fixture — is **not** part of the bundle unless you declare it. This is a classic "works locally, ENOENT in production" trap: under `netlify dev` the function reads the file straight from your working tree, but the deployed function only contains what was bundled.
-
-Declare runtime-read files with `included_files` in `netlify.toml` so they ship with the function:
+⚠️ Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM) are **not bundled**: works under `netlify dev`, ENOENT in production. Prefer importing static data as a module. Otherwise declare it in `netlify.toml`:
 
 ```toml
 [functions]
-  included_files = ["netlify/functions/templates/**"]
-
-# or scope it to one function:
-[functions."render-email"]
-  included_files = ["netlify/functions/templates/welcome.html"]
+  included_files = ["files/*.md"]
+  external_node_modules = ["package-1"]
 ```
 
-When the data is static, prefer importing it as a module (`import data from "./data.json"`) so bundling is automatic; reach for `included_files` for files you must read from the filesystem at runtime.
+⚠️ The combined env-var limit is **~4 KB** for ALL functions (they run on AWS Lambda) — no Netlify setting raises it. Keep large payloads (service-account JSON, PEM keys) out of env vars; use a bundled file, Blobs, or a runtime fetch.
 
-## Resource Limits
+JS-only esbuild: `[functions]\n  node_bundler = "esbuild"`.
 
-| Resource | Limit |
-|---|---|
-| Synchronous timeout | 60 seconds |
-| Background timeout | 15 minutes |
-| Scheduled timeout | 30 seconds |
-| Memory | 1024 MB default; configurable 1024–4096 MB (see [Memory or vCPU](#memory-or-vcpu)) |
-| Buffered payload | 6 MB |
-| Streamed payload | 20 MB |
+## Limits (not configurable)
 
-## Framework Considerations
+- Synchronous execution: **60s**. Scheduled: **30s**. Background: **15 min**.
+- Buffered request/response payload: **6 MB** (binary is Base64-encoded, ~30% overhead → effective **4.5 MB** binary limit).
+- Streamed response: **20 MB**. Background payload: **256 KB**.
 
-Frameworks with server-side capabilities (Astro, Next.js, Nuxt, SvelteKit, TanStack Start) typically generate their own serverless functions via adapters. You usually do not write raw Netlify Functions in these projects — the framework adapter handles server-side rendering and API routes. Write Netlify Functions directly when:
+## Local testing & deploy
 
-- Using a client-side-only framework (Vite + React SPA, vanilla JS)
-- Adding background or scheduled tasks to any project
-- Building standalone API endpoints outside the framework's routing
+- Most frameworks emulate functions in their dev server. Vite frameworks (Astro, Nuxt, TanStack Start, React Router): install `@netlify/vite-plugin` and run the dev server. Next.js and anything else: use the [Netlify CLI](https://docs.netlify.com/api-and-cli-guides/cli-guides/local-development/) (`netlify dev`).
+- Scheduled functions don't fire on a schedule locally — invoke once with `netlify functions:invoke <name>`.
+- Deploy: push to Git for continuous deployment, or use the Netlify CLI/API.
+- Logs & metrics live in the Netlify UI; stream with the CLI.
 
-See the **netlify-frameworks** skill for adapter setup.
+## Node runtime version
+
+Runtime follows the build's Node.js version (fallback: Node.js 24). Override by setting env var `AWS_LAMBDA_JS_RUNTIME` (e.g. `nodejs24.x`) via UI/CLI/API — **not** `netlify.toml` — then redeploy. ES modules: `__dirname`/`__filename` unavailable, use `import.meta.url`; named imports of CommonJS packages fail, use a default import.
+
+## Legacy / Go (avoid unless needed)
+
+Go must use the [Lambda-compatible API](https://docs.netlify.com/build/functions/lambda-compatibility/?fn-language=go); Go routing/region/memory are set in `netlify.toml`. For migrating Lambda-style JS/TS, `@netlify/aws-lambda-compat` wraps an AWS handler:
+
+```ts
+import { withLambda } from "@netlify/aws-lambda-compat"
+import type { HandlerContext, HandlerEvent, HandlerResponse } from "@netlify/aws-lambda-compat"
+
+export default withLambda(async (event: HandlerEvent, context: HandlerContext): Promise<HandlerResponse> => {
+  const name = event.queryStringParameters?.name ?? "World"
+  return { statusCode: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ name }) }
+})
+```
+
+Lambda-compat mode enforces the 4 KB env-var limit; [upgrade to modern functions](https://developers.netlify.com/guides/migrating-to-the-modern-netlify-functions/) to remove it.
+
+<!-- system: agent-context/functions/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (functions)
+
+These are org conventions, not docs facts — they are merged into the rendered
+skill by ctx-gen and are never generated. Extracted from the previous
+hand-written netlify-functions skill; owned by the skills maintainer.
+
+1. Use TypeScript (`.mts`) when possible.
+2. Access environment variables via `Netlify.env.get()` (prefer it over
+   `process.env` for consistency).
+3. Never add CORS headers unless explicitly requested.
+4. Store secrets in environment variables, never in code.
+5. `context.geo` and `context.ip` are mocked under `netlify dev` — placeholder
+   values, not the real location or client IP. Don't conclude geo code is
+   broken because local values never change; exercise branches with
+   `netlify dev --geo=mock --country=DE` and verify on a deploy.
+6. Do NOT set `config.memory` or `config.vcpu` speculatively. Raise them only
+   for known memory/compute-intensive work or observed OOM/timeouts caused by
+   the function's own work — billing scales linearly with size.
+7. Do NOT override `config.region` unless the user has stated a specific
+   reason (co-located database/backend, data residency, regional audience).
+   The `cmh` default is a deliberate choice.
+8. Files read from disk at runtime (`fs.readFile` on templates, JSON, WASM)
+   are not bundled: works under `netlify dev`, ENOENT in production. Prefer
+   importing static data as a module; otherwise declare the file with a
+   scoped `included_files` entry in `netlify.toml`.
+9. The ~4 KB combined environment-variable limit applies to ALL functions
+   (they run on AWS Lambda), not just Lambda-compat mode. Keep large payloads
+   (service-account JSON, PEM keys) out of env vars — use a bundled file,
+   Blobs, or a runtime fetch. No Netlify setting raises this cap.
+10. The body's FIRST function example must be the minimal default: no
+    `config` export at all, stating the function serves at
+    `/.netlify/functions/<name>`. Custom `path` routing appears only in a
+    later example — agents imitate the first example they see.
+11. Never demonstrate `memory`, `vcpu`, or `region` in a generic example —
+    show them only attached to an explicit stated reason (observed OOM,
+    co-located backend, data residency).
+12. Scheduled-function examples use a real cron expression with the UTC
+    conversion spelled out (e.g. 9 AM ET → `"0 13 * * *"` UTC, noting DST) —
+    never only `@hourly`/`@daily` shortcuts, which can't target a specific
+    local hour.
+13. The body must state that `[[headers]]` in netlify.toml, `_headers`, and
+    redirect header rules apply ONLY to static CDN responses — response
+    headers for a function are set in code on the returned `Response`.

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -1,464 +1,293 @@
 ---
 name: netlify-identity
-description: Use when the task involves authentication, user signups, logins, password recovery, OAuth providers, role-based access control, or protecting routes and functions. Always use `@netlify/identity` for new projects; `netlify-identity-widget` and `gotrue-js` still work but are no longer recommended.
+description: Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social login (Google/GitHub/GitLab/Bitbucket), server-side user verification in Functions, role-based access control (RBAC), admin user management, and Identity event hooks. Use when adding a login/signup flow, "add social login", gating content by user role, protecting a function or page behind auth, assigning roles at signup, customizing auth emails, or handling OAuth/confirmation/recovery callbacks. Not for locking an entire site to a company/team — that is netlify-access-control.
 ---
 
 # Netlify Identity
 
-Netlify Identity is a user management service for signups, logins, password recovery, user metadata, and role-based access control. It is built on [GoTrue](https://github.com/netlify/gotrue) and issues JSON Web Tokens (JWTs).
+Auth and user management for a Netlify site without requiring visitors to be Netlify users. Package: `@netlify/identity`.
 
-**Always use `@netlify/identity` for new projects.** `netlify-identity-widget` and `gotrue-js` still work and are maintained, but are no longer the recommended choice. `@netlify/identity` provides a unified, headless TypeScript API that works in both browser and server contexts (Netlify Functions, Edge Functions, SSR frameworks).
+**Reach for `@netlify/identity`.** Do NOT use the legacy `netlify-identity-widget` or `gotrue-js` for new work — same capabilities, simpler API, built-in server-side support.
 
-## Identity is app-level — don't confuse it with site access control
+## Footguns — read first
 
-Netlify Identity manages **your app's end users** (signups, logins, roles) and issues the `nf_jwt` cookie. It is a different layer from **Secure Access / Password Protection**, which gates *who can load the site at all* (Basic shared-password is Pro+; team-login/SAML gating is Enterprise), and from **Team/Org SAML SSO**, which controls *who can log in to the Netlify dashboard*. The same provider can appear in more than one (Google, say): Google as an Identity OAuth provider signs in *app users*; Google as a SAML IdP signs in *Netlify team members*. They are unrelated systems with separate sessions, which is where the confusion comes from.
-
-If the task involves "lock this site to my company," "only employees can access it," password protection, or SSO at the site/team level, **read the `netlify-access-control` skill first** to pick the right layer. This skill covers the app-level user-management layer only.
-
-## Dashboard configuration (user handoff required)
-
-**All Identity instance configuration is dashboard-only — there is no public API.** The agent owns the code, deploys, and the handoff checklist; the user owns flipping dashboard settings. Outside of a Netlify Agent Runner deploy, the Identity instance must be enabled in the dashboard before any auth flow will work. If you write Identity code first and only discover this when `/.netlify/identity/signup` 404s after a production deploy, that's wasted work — surface the dashboard handoff up front instead.
-
-**Dashboard URL pattern:** `https://app.netlify.com/projects/<project-slug>/configuration/identity` (it's under project configuration — not under Integrations, and not a top-level sidebar item).
-
-### Dashboard-only operations
-
-- **Enable Identity** — turns the Identity instance on for the site. **Required** before any auth flow works.
-- **Registration mode** — Open (anyone can sign up, the default) or Invite only.
-- **Autoconfirm** — ON skips the email-confirmation step on signup; OFF requires the new user to click a confirmation email before they can log in.
-- **External providers** — Add Google / GitHub / GitLab / Bitbucket. The "Use Netlify's app" option means no `client_id`/`secret` needed — good for prototypes. Adding an OAuth provider does NOT disable email/password — email/password is always available unless the front-end omits it.
-- **Custom email templates / SMTP** — advanced; out of scope for typical prototypes.
-
-There is no CLI command and no public API for any of these. **Do not** curl `https://api.netlify.com/...` to flip toggles, **do not** read auth tokens out of `~/Library/Preferences/netlify/config.json`, and **do not** probe for an undocumented endpoint. Give the user the dashboard URL and exact checklist instead.
-
-### Agent/user sequence
-
-1. Agent asks any missing auth-shape questions before scaffolding.
-2. Agent writes the Identity code and runs a draft deploy.
-3. User enables Identity and any OAuth providers in the dashboard using the handoff checklist.
-4. Agent verifies the draft URL and then runs the production deploy.
-
-### Recommended settings per use case
-
-| Use case | Registration | Autoconfirm | External providers |
-|---|---|---|---|
-| Prototype / demo | Open | ON | as requested |
-| Production with email signup | Open or Invite per product | OFF (real email confirmation) | configured with custom email templates / SMTP as needed |
-
-### Handoff checklist
-
-When the dashboard work is needed, give the user a copy-pasteable checklist **between the draft deploy and the production deploy** — not after the prod deploy fails:
-
-```
-Before this works end-to-end, flip these in the Netlify dashboard at
-https://app.netlify.com/projects/<your-slug>/configuration/identity:
-
-- [ ] Identity → Enable
-- [ ] Registration → Open (default) or Invite only
-- [ ] Autoconfirm → ON for prototypes; OFF for prod with email confirmation
-- [ ] External providers → Add Google (etc.) with "Use Netlify's app"
-
-Tell me when these are flipped and I'll run the production deploy.
-```
-
-## Before you build
-
-If the prompt didn't already specify, ask the user a few short questions before scaffolding any auth code — the answers shape both the dashboard config above and the auth UI you'll write:
-
-- Should the whole site be locked so only your company/team can even load it (a perimeter), should it be public with per-user accounts inside the app, or both? This decides whether Netlify Identity alone is enough or you also need site-level access control — if "company-only" or "both" comes up, check the `netlify-access-control` skill before scaffolding.
-- Which sign-in methods should this app expose: email/password, OAuth, or both?
-- Which parts of the app need authenticated access: the whole app, specific routes, or only specific actions?
-- Who can create accounts: public signup or invite-only?
-- Should new email/password users be able to log in immediately for a prototype (Autoconfirm ON), or confirm by email first for production (Autoconfirm OFF)?
-- Which OAuth providers should be enabled (Google, GitHub, GitLab, Bitbucket)?
-
-**If you don't have preferences here, tell me what you want overall and I'll pick sensible defaults** — typically email/password + Google OAuth, autoconfirm ON, registration Open for a prototype.
-
-Asking these *after* coding causes rework — both the auth UI shape and the dashboard config fall out of these answers.
-
-## When something fails, surface and stop
-
-If a deploy fails, an Identity callback 404s, an OAuth flow doesn't return, or `/.netlify/identity/*` is unreachable — report the failure to the user with the deploy log URL, the exact error, and the site URL, then stop. Do not curl the Netlify API to "fix" the Identity instance, do not invent recovery commands, do not bypass the dashboard. Identity instance state has no public API to repair; the recovery is to hand the user the dashboard URL, the setting to check, and the observed failure.
-
-## Never hardcode secrets
-
-Never hardcode secrets. Identity URLs, GoTrue endpoints, and OAuth `client_id`/`secret` values do not belong in client or server code — configure OAuth credentials in the Netlify dashboard, not the frontend, and store anything sensitive as a Netlify environment variable (mark it secret). The Identity **admin token** is not one of these: you don't set or read it — the Netlify Functions runtime injects it automatically for `admin.*` calls made inside a Function (see [Authorization and sessions](references/authorization-and-sessions.md)). Never hardcode an admin token or expose admin operations to the browser.
+- **Identity does not work under `netlify dev`.** Test auth flows on a deploy — Deploy Previews work. Local `netlify dev` cannot exercise `/.netlify/identity/*`.
+- **Never build a from-scratch third-party OAuth flow beside Identity** — no provider app registration in code, no `client_id`/`secret` in code, no custom callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`. Raw OAuth beside Identity is the single most common source of rework.
+- **Identity config has no public API — dashboard only.** Never curl `api.netlify.com` to flip/inspect Identity settings, never read tokens from `~/Library/Preferences/netlify/config.json`, never probe undocumented endpoints.
+- **RBAC redirects without a fallback = raw 404.** A visitor lacking the role gets a bare 404 with no way to log in. Always add a fallback rule.
+- **Server-side `login()`/`signup()`/`logout()` need CSRF protection.** Call `verifyRequestOrigin(req)` first, or an attacker can log a victim into the attacker's account.
+- **Site-gating** ("lock this site to my company", employees-only) → route to **netlify-access-control** first. Identity is the app-level user layer only.
+- **On failure** (callback 404s, `/.netlify/identity/*` unreachable, OAuth doesn't return): surface the error, the dashboard URL, and the setting to check — then stop. Do not invent recovery commands.
 
 ## Setup
+
+Identity must be enabled in the dashboard first (no API): **Project configuration > Identity** (`https://app.netlify.com/projects/{site_name}/configuration/identity`) → **Enable Identity**.
 
 ```bash
 npm install @netlify/identity
 ```
 
-The Identity instance must be enabled in the dashboard first (see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above). The one exception: a deploy created by a Netlify Agent Runner session that includes Identity code auto-enables the instance.
+HTTPS is required. On a custom domain, get HTTPS/SSL working before integrating Identity.
 
-### Local Development
+## Client / universal auth
 
-Identity does **not** currently work with `netlify dev`. You must deploy to Netlify to test Identity features. Use `npx netlify deploy` for preview deploys during development. This limitation may be resolved in a future release.
+```ts
+import { signup, login, logout, getUser, oauthLogin, handleAuthCallback } from '@netlify/identity'
 
-## Quick Start
+// Sign up — sends a confirmation email by default (skippable via autoconfirm setting)
+const user = await signup('jane@example.com', 'securepassword', { full_name: 'Jane Doe' })
 
-Log in from the browser:
+// Log in / log out
+await login('jane@example.com', 'securepassword')
+await logout()
 
-```typescript
-import { login, getUser } from '@netlify/identity'
+// Current user — null if not logged in (works in browser + server)
+const u = await getUser()
+if (u) console.log(u.email)
 
-const user = await login('user@example.com', '<password>')
-console.log(`Hello, ${user.name}`)
-
-// Later, check auth state
-const currentUser = await getUser()
+// OAuth — redirects browser to provider login
+oauthLogin('github') // 'google' | 'github' | 'gitlab' | 'bitbucket'
 ```
 
-Protect a Netlify Function:
+**Callback handling is mandatory.** Call `handleAuthCallback()` on your landing page. It processes ALL token types in the URL hash — OAuth redirect, email confirmation, password recovery, invite. Without it, confirmation links and OAuth redirects never complete.
 
-```typescript
-// netlify/functions/protected.mts
+```ts
+import { handleAuthCallback } from '@netlify/identity'
+
+const result = await handleAuthCallback()
+if (result) console.log(result.type, result.user.email) // may be falsy if nothing to process
+```
+
+Other client functions:
+- `recoverPassword()` — complete a password reset (alternative to letting `handleAuthCallback()` handle the `recovery_token`).
+- `acceptInvite()` — complete invite acceptance (alternative to `handleAuthCallback()` handling `invite_token`).
+- `refreshSession()` — refresh token/session so newly-assigned roles take effect.
+
+**Don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns.
+
+## Server-side (Functions / Edge Functions)
+
+Handlers are modern v2 functions: `export default async (req, context) => {}`. **v1 `export { handler }` is not supported** for `getUser()`/`login()`/`admin.*`.
+
+```ts
 import { getUser } from '@netlify/identity'
-import type { Context } from '@netlify/functions'
+import type { Context } from '@netlify/functions'      // or '@netlify/edge-functions' for Edge
 
 export default async (req: Request, context: Context) => {
   const user = await getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
+  if (!user.roles.includes('admin')) return new Response('Forbidden', { status: 403 })
   return Response.json({ id: user.id, email: user.email })
 }
 ```
 
-`getUser()` reads the request's `nf_jwt` cookie automatically — no argument is needed in a function or edge function. Server-side auth (`getUser`, `login`, `admin.*`) requires a **modern v2 function** (`export default`); v1 Lambda-compatible functions (`export { handler }`) are not supported.
+`getUser()` works in browser, Netlify Functions, and Edge Functions.
 
-## Core API
+**CSRF — always guard exposed `login`/`signup`/`logout` endpoints:**
 
-Import and use headless functions directly:
+```ts title="netlify/functions/login.ts"
+import { login, verifyRequestOrigin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-```typescript
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  signup,
-  oauthLogin,
-  onAuthChange,
-  getSettings,
-} from '@netlify/identity'
-```
-
-### Login
-
-```typescript
-import { login, AuthError } from '@netlify/identity'
-
-async function handleLogin(email: string, password: string) {
-  try {
-    const user = await login(email, password)
-    showSuccess(`Welcome back, ${user.name ?? user.email}`)
-  } catch (error) {
-    if (error instanceof AuthError) {
-      // Bad credentials → GoTrue returns 400 (invalid_grant) server-side; in the
-      // browser the status is undefined, so fall back to the message there.
-      showError(error.status === 400 ? 'Invalid email or password.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  verifyRequestOrigin(req)   // throws 403 on Origin mismatch; supports { allowedOrigins }
+  const { email, password } = await req.json()
+  await login(email, password)
+  return new Response(null, { status: 302, headers: { Location: '/dashboard' } })
 }
 ```
 
-### Signup
+### admin — Netlify Functions ONLY
 
-After signup, check `user.emailVerified` to determine if the user was auto-confirmed or needs to confirm their email.
+`admin.*` uses a short-lived admin token and runs **only in Netlify Functions** — NOT browser, NOT Edge Functions.
 
-```typescript
-import { signup, AuthError } from '@netlify/identity'
+```ts
+import { admin } from '@netlify/identity'
+import type { Context } from '@netlify/functions'
 
-async function handleSignup(email: string, password: string, name: string) {
-  try {
-    const user = await signup(email, password, { full_name: name })
-    if (user.emailVerified) {
-      // Autoconfirm ON — user is logged in immediately
-      showSuccess('Account created. You are now logged in.')
-    } else {
-      // Autoconfirm OFF — confirmation email sent
-      showSuccess('Check your email to confirm your account.')
-    }
-  } catch (error) {
-    if (error instanceof AuthError) {
-      showError(error.status === 403 ? 'Signups are not allowed.' : error.message)
-    }
-  }
+export default async (req: Request, context: Context) => {
+  const users = await admin.listUsers()   // array of users
+  return Response.json({ total: users.length })
 }
 ```
 
-### Logout
+- `admin.listUsers()` — array of users.
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
 
-```typescript
-import { logout } from '@netlify/identity'
+### Session cookies
+JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.
 
-await logout()
-```
+### The `User` object
+`id`, `email`, `roles` (array from `app_metadata.roles`, included in the JWT).
 
-### OAuth
+## Identity event functions
 
-**When Netlify Identity is the goal, never build a from-scratch third-party OAuth flow.** Don't tell the user to go register their own Google/GitHub OAuth app, don't ask for a `client_id`/`secret`, and don't write your own `/auth/callback` token-exchange handler. Identity already brokers the OAuth handshake: the provider is enabled in the dashboard with the **"Use Netlify's app"** option (no credentials needed — see the handoff checklist above), and your code just calls `oauthLogin(provider)` + `handleAuthCallback()`. Scaffolding raw OAuth alongside Identity is the single most common source of rework in this flow — it produces two competing auth systems that then have to be untangled by hand. Custom OAuth credentials exist only to *brand* the consent screen, and even then they're pasted into the dashboard, not wired into app code.
+Functions the platform invokes automatically on Identity events (you don't call them).
 
-OAuth is a two-step flow: `oauthLogin(provider)` redirects away from the site, then `handleAuthCallback()` processes the redirect when the user returns.
+**Modern typed-handler syntax** — export a default object with a method per event. Typed handlers require `@netlify/functions` ≥ 5.2.0.
 
-```typescript
-import { oauthLogin } from '@netlify/identity'
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
-// Step 1: Redirect to provider (navigates away — never returns)
-function handleOAuthClick(provider: 'google' | 'github' | 'gitlab' | 'bitbucket') {
-  oauthLogin(provider)
+export default {
+  userSignup(event: UserSignupEvent) {
+    console.log(`New signup: ${event.user.email}`)
+  },
 }
 ```
 
-Providers must be enabled in the dashboard before `oauthLogin()` works — see [Dashboard configuration](#dashboard-configuration-user-handoff-required) above. Registration is Open by default, so OAuth users can create accounts without any extra signup-related configuration; only the provider itself must be enabled.
+Handlers and triggers:
 
-Email/password is always available as a login method — there is **no "Email provider" toggle** in Identity settings, only External providers for OAuth. To restrict users to OAuth-only, omit the email/password form from your UI; the front-end is the gate.
-
-### Handling Callbacks
-
-Always call `handleAuthCallback()` on page load in any app that uses OAuth, password recovery, invites, or email confirmation. It processes all callback types via the URL hash.
-
-```typescript
-import { handleAuthCallback, AuthError } from '@netlify/identity'
-
-async function processCallback() {
-  try {
-    const result = await handleAuthCallback()
-    if (!result) return // No callback hash — normal page load
-
-    switch (result.type) {
-      case 'oauth':
-        showSuccess(`Logged in as ${result.user?.email}`)
-        break
-      case 'confirmation':
-        showSuccess('Email confirmed. You are now logged in.')
-        break
-      case 'recovery':
-        // User is authenticated but must set a new password
-        showPasswordResetForm(result.user)
-        break
-      case 'invite':
-        // User must set a password to accept the invite
-        showInviteAcceptForm(result.token)
-        break
-      case 'email_change':
-        showSuccess('Email address updated.')
-        break
-    }
-  } catch (error) {
-    if (error instanceof AuthError) showError(error.message)
-  }
-}
-```
-
-### Auth State
-
-```typescript
-import { getUser, onAuthChange, AUTH_EVENTS } from '@netlify/identity'
-
-// Check current user (never throws — returns null if not authenticated)
-const user = await getUser()
-
-// Subscribe to auth state changes (returns unsubscribe function)
-const unsubscribe = onAuthChange((event, user) => {
-  switch (event) {
-    case AUTH_EVENTS.LOGIN:
-      console.log('Logged in:', user?.email)
-      break
-    case AUTH_EVENTS.LOGOUT:
-      console.log('Logged out')
-      break
-    case AUTH_EVENTS.TOKEN_REFRESH:
-      break
-    case AUTH_EVENTS.USER_UPDATED:
-      console.log('Profile updated:', user?.email)
-      break
-    case AUTH_EVENTS.RECOVERY:
-      console.log('Password recovery initiated')
-      break
-  }
-})
-```
-
-### Settings-Driven UI
-
-You cannot see a project's live Identity configuration while you are writing the code — there is no API, MCP tool, or CLI command that reports whether Identity is enabled or which providers are on; that state lives in the dashboard. So **don't hard-code which providers exist.** Call `getSettings()` at startup and render the signup form and OAuth buttons from what it returns, so the UI matches whatever the user actually enabled — and a provider you assumed was on but isn't won't render a dead button. (`getSettings()` hits `/.netlify/identity/settings` and works against any origin serving the page, including localhost under `netlify dev`, which proxies to the live service — but it can't tell you anything pre-run, so ask the user what's configured while you're still scaffolding.)
-
-```typescript
-import { getSettings } from '@netlify/identity'
-
-const settings = await getSettings()
-// settings.autoconfirm — boolean
-// settings.disableSignup — boolean
-// settings.providers — Record<AuthProvider, boolean>
-
-if (!settings.disableSignup) showSignupForm()
-
-for (const [provider, enabled] of Object.entries(settings.providers)) {
-  if (enabled) showOAuthButton(provider)
-}
-```
-
-## Minimal React Example
-
-```tsx
-import { useEffect, useState } from 'react'
-import {
-  getUser,
-  handleAuthCallback,
-  login,
-  logout,
-  oauthLogin,
-  onAuthChange,
-} from '@netlify/identity'
-
-function App() {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    ;(async () => {
-      await handleAuthCallback()
-      setUser(await getUser())
-      setLoading(false)
-    })()
-    return onAuthChange((_event, currentUser) => setUser(currentUser))
-  }, [])
-
-  const handleLogin = async (email, password) => {
-    const currentUser = await login(email, password)
-    setUser(currentUser)
-  }
-
-  const handleGoogleLogin = () => oauthLogin('google')
-
-  const handleSignOut = async () => {
-    await logout()
-    setUser(null)
-  }
-
-  if (loading) return <p>Loading...</p>
-  // Render login form or user details based on `user` state
-}
-```
-
-## Error Handling
-
-`@netlify/identity` throws two error classes:
-
-- **`AuthError`** — Thrown by auth operations. Has `message`, optional `status` (HTTP status code), and optional `cause`.
-- **`MissingIdentityError`** — Thrown when Identity is not configured in the current environment.
-
-`getUser()` and `isAuthenticated()` never throw — they return `null` and `false` respectively on failure.
-
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid login credentials — wrong email/password (GoTrue `invalid_grant`) |
-| 401 | Missing, invalid, or expired bearer token on an authenticated endpoint |
-| 403 | Action not allowed (e.g., signups disabled) |
-| 422 | Validation error (e.g., weak password, malformed email) |
-| 404 | User or resource not found |
-
-Note: in the browser, `login()` surfaces gotrue-js failures as an `AuthError` with `status` **undefined** (the HTTP status isn't propagated), so don't branch on `status` for bad-credentials UX there — fall back to `error.message`. Server-side (`login()` in a Function) passes the real status through, so `400` is reliable.
-
-## Identity Event Functions
-
-Functions can subscribe to Identity lifecycle events by exporting an object whose properties are named event handlers. See the **netlify-functions** skill for the full event-handler pattern.
-
-The typed handler API below (the `userSignup`/`userValidate`/… object export, the typed `*Event` types, and `event.deny()`) requires **`@netlify/functions` ≥ 5.2.0** — it isn't present in 5.1.x. On older installs, use the legacy filename convention described at the end of this section.
-
-**Available identity handlers:**
-
-| Handler | Trigger |
+| Handler | Fires when |
 |---|---|
-| `userValidate` | User attempts to sign up. Can deny. |
-| `userSignup` | User completes signup. Can deny or mutate. |
-| `userLogin` | User logs in. Can deny or mutate. |
-| `userModified` | User profile is updated. Can deny or mutate. |
-| `userDeleted` | User is deleted. Notification only. |
+| `userValidate` | User attempts signup, before account creation — block by email domain, rate-limit, custom validation. |
+| `userSignup` | Signup completes (email or external). Fires *after* email confirmation if confirmation is enabled. Assign roles, sync, notify. |
+| `userLogin` | User logs in — track logins, sync, block a user. |
+| `userModified` | Profile updated. |
+| `userDeleted` | User deleted (notification only). |
 
-Each handler receives a typed event with a parsed `user` object (camelCase fields: `appMetadata`, `userMetadata`, `confirmedAt`, etc.).
+**Deny an action:** call `event.deny()` from `userValidate`/`userSignup`/`userLogin`/`userModified` (NOT `userDeleted`). User gets a `401`; no observability error. With multiple subscribers, the first `event.deny()` aborts the chain.
 
-### Mutate the user
+```typescript title="netlify/functions/identity.mts"
+import type { UserValidateEvent } from "@netlify/functions"
 
-Return `{ user: ... }` to substitute the user record before it's persisted. This is the common pattern for role assignment at signup.
+export default {
+  userValidate(event: UserValidateEvent) {
+    if (!event.user.email?.endsWith("@example.com")) return event.deny()
+  },
+}
+```
 
-```typescript
-// netlify/functions/identity.mts
-import type { UserSignupEvent } from '@netlify/functions'
+**Assign roles at signup** — return `{ user: {...} }` to mutate the persisted record. Payload fields are **camelCase** (`appMetadata`, `userMetadata`, `confirmedAt`).
+
+```typescript title="netlify/functions/identity.mts"
+import type { UserSignupEvent } from "@netlify/functions"
 
 export default {
   userSignup(event: UserSignupEvent) {
     return {
-      user: {
-        ...event.user,
-        appMetadata: {
-          ...event.user.appMetadata,
-          roles: ['member'],
-        },
-      },
+      user: { ...event.user, appMetadata: { ...event.user.appMetadata, roles: ["member"] } },
     }
   },
 }
 ```
 
-### Deny an action
+**Background mode** — action completes immediately, handler runs async:
 
-Call `event.deny()` to reject a signup, login, validation, or modification. The end user receives a 401. Do not throw — `event.deny()` is the canonical denial mechanism and does not produce an error in observability.
+```typescript title="netlify/functions/identity.mts"
+import type { Config, UserLoginEvent } from "@netlify/functions"
 
-```typescript
-import type { UserValidateEvent } from '@netlify/functions'
-
-export default {
-  userValidate(event: UserValidateEvent) {
-    if (!event.user.email?.endsWith('@example.com')) {
-      return event.deny()
-    }
-  },
-}
+export default { userLogin(event: UserLoginEvent) { /* async tracking */ } }
+export const config: Config = { background: true }
 ```
 
-If multiple functions subscribe to the same event, the first to call `event.deny()` aborts the chain — subsequent functions are not invoked.
+Event types from `@netlify/functions`: `UserValidateEvent`, `UserSignupEvent`, `UserLoginEvent`, `UserModifiedEvent`, `UserDeletedEvent`, `Config`.
 
-### Legacy filename convention
+## Registration & providers (dashboard)
 
-The previous syntax — files named `identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, exporting `handler` and signaling denial via non-2xx response — still works. New functions should prefer the typed handler syntax above.
+- **Registration preferences** — **Open** (default: any visitor signs up via `signup()`) or **Invite only** (all new users, including external-provider logins, must be invited first).
+- **Confirmation:** open registration sends a confirmation email; skip via **Emails > Confirmation template > Configure** (allow signup without verifying email / autoconfirm).
+- **External providers** — enable Google/GitHub/GitLab/Bitbucket under **Registration > External providers**. Set your own client ID/secret for branded OAuth (your app name shows on the provider screen). No email confirmation for external-provider signup, but Invite-only still requires an invite.
+- **Invitations** — **Project configuration > Identity > Users**; Netlify team users with any role can invite. Invite link carries an `invite_token` → process with `handleAuthCallback()` or `acceptInvite()`.
 
-## Roles and Authorization
+## Roles & metadata
 
-### First Admin User
+Stored on the User object; edit in **Identity > Users > Edit settings**:
+- **Name** — user-editable: `user_metadata.full_name`.
+- **Email** — user-editable; triggers email-change confirmation; changes login credentials: `user_metadata.email`.
+- **Roles** — NOT user-editable: `app_metadata.roles`. Read via `getUser()`.
 
-The first admin user cannot be created through code alone. You must direct the user to set it up through the Netlify UI:
+Set roles: at signup via `userSignup` handler returning `{ user: {...} }`; for existing users via `admin.updateUser()` in a Function. **Role changes take effect on next login or token refresh**, not immediately (they don't invalidate the current JWT — client can `refreshSession()`).
 
-1. Go to **Project configuration > Identity** in the Netlify dashboard (`https://app.netlify.com/projects/<project-slug>/configuration/identity`)
-2. Click **Invite users** and enter the admin user's email address
-3. After the user accepts the invite, click the user in the Identity list to open their detail page
-4. In the **Roles** field, add the `admin` role and save
+## Role-based access control (redirect rules)
 
-Once the first admin exists, subsequent users can be managed programmatically using Identity event functions (e.g., assigning roles in `identity-signup`) or role-based redirects.
+Enforced at the CDN edge (no origin round trip). Add a `Role` parameter to redirect rules.
 
-- **`app_metadata.roles`** — Server-controlled. Only settable via the Netlify UI, admin API, or Identity event functions. Never let users set their own roles.
-- **`user_metadata`** — User-controlled. Users can update via `updateUser({ data: { ... } })`.
+```
+# _redirects — ALWAYS include a fallback or non-admins get a raw 404
+/admin/*  /admin/:splat  200!  Role=admin
+/admin/*  /login         401!
 
-### Role-Based Redirects
+# multiple roles, comma-chained
+/private/* /private/:splat  200!  Role=editor,admin
+```
 
 ```toml
 # netlify.toml
 [[redirects]]
   from = "/admin/*"
   to = "/admin/:splat"
+  force = true
   status = 200
-  conditions = { Role = ["admin"] }
-
-[[redirects]]
-  from = "/admin/*"
-  to = "/"
-  status = 302
+  conditions = {Role = ["editor", "admin"]}
 ```
 
-Rules are evaluated top-to-bottom. The `nf_jwt` cookie is read by the CDN to evaluate role conditions.
+Netlify Identity roles resolve at `app_metadata.roles`.
 
-## References
+### External JWT provider (Enterprise; alternative to Identity)
+You may use Identity **OR** an external JWT provider, **not both** — you cannot authenticate third-party JWT tokens while Identity is enabled. Set the secret at **Project configuration > Access & security > Visitor access > JWT secret** (project-level overrides team-level default).
 
-- [Advanced patterns](references/advanced-patterns.md) — password recovery, invite acceptance, email change, session hydration, SSR integration
-- [Authorization and sessions](references/authorization-and-sessions.md) — where role gating is actually enforced (server-side vs client-side / SPA navigation), admin operations being Functions-runtime-only, and why a role change doesn't apply until the JWT refreshes
+- Tokens must be **HS256**; header requires `"alg": "HS256"`, `"typ": "JWT"`.
+- Payload requires `exp` (future Unix Epoch); other fields optional.
+- External-provider roles resolve at `app_metadata.authorization.roles`. Different path → contact support for a custom role path (support-configured, not self-service).
+
+## Emails (Pro+ for customization)
+
+Default sender `no-reply@netlify.com`. Custom sender (Pro+): set SMTP hostname/port/username/password under **Emails > Outgoing email address** (use SendGrid/Mailjet/etc. for volume).
+
+Custom templates (Pro+): publish HTML to a path on your deployed project, set the path (relative to domain, starting `/`) under **Emails**. Rules: inline CSS only, absolute image links, NO `<html>`/`<head>`/`<body>` tags. Keep template variables intact — don't let your build rewrite them.
+
+Go template variables: `{{ .Email }}`, `{{ .NewEmail }}` (email-change only), `{{ .SiteURL }}`, `{{ .ConfirmationURL }}`, `{{ .Token }}`. Custom link form: `{{ .SiteURL }}/path/#confirmation_token={{ .Token }}` (also `invite_token`, `recovery_token`, `email_change_token`).
+
+## Audit log (Pro+)
+
+**Project configuration > Identity > Identity audit log**. Search with a required scope prefix: `author:[string]` or `action:[string]`. Action names: `login`, `logout`, `user_signedup`, `user_deleted`, `user_modified`, `token_revoked`, `token_refreshed`, `user_recovery_requested`, `user_invited`.
+
+## Plan gating
+
+- Identity itself: all credit-based plans, no extra cost. Unlimited active + invite-only users, custom OAuth credentials, Functions integration — all plans.
+- **Pro+ only:** custom outgoing email, custom email templates, Identity audit log.
+- **Enterprise only:** external JWT providers.
+
+## Deep guides
+
+- `references/advanced-patterns.md` — SSR / session hydration.
+- `references/authorization-and-sessions.md`.
+
+## Legacy (avoid for new work)
+
+- `netlify-identity-widget` / `gotrue-js` — superseded by `@netlify/identity`.
+- Legacy event-function filenames (`identity-validate.ts`, `identity-signup.ts`, `identity-login.ts`, `-background` suffix) still work but prefer typed handlers. Legacy denial = return non-2xx status; new code uses `event.deny()`.
+
+<!-- getSettings() referenced in house rules but not documented in sources; its return shape/signature is not specified in the intermediate. -->
+
+<!-- system: agent-context/identity/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (identity)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. Deep guides live in this skill: `references/advanced-patterns.md`
+   (SSR/session hydration) and `references/authorization-and-sessions.md`.
+2. Identity does not work under `netlify dev` — test auth flows on deploys
+   (Deploy Previews work).
+3. Identity configuration has no public API — it is dashboard-only. Never curl
+   `api.netlify.com` to flip or inspect Identity settings, never read auth
+   tokens from `~/Library/Preferences/netlify/config.json`, never probe for
+   undocumented endpoints.
+4. On failure (callback 404s, `/.netlify/identity/*` unreachable, OAuth flow
+   doesn't return), surface the error, the dashboard URL, and the setting to
+   check — then stop. Do not invent recovery commands.
+5. Never build a from-scratch third-party OAuth flow when Identity is in play —
+   no provider app registration, no `client_id`/`secret` in code, no custom
+   callback token exchange. Use `oauthLogin()` + `handleAuthCallback()`;
+   raw OAuth beside Identity is the single most common source of rework.
+6. Server-side `getUser()`/`login()`/`admin.*` require modern v2 functions
+   (`export default`) — v1 `export { handler }` is not supported. Typed
+   Identity event handlers (`UserSignupEvent`, `event.deny()`) require
+   `@netlify/functions` ≥ 5.2.0; older installs use the legacy filenames.
+7. Don't hard-code which auth providers exist — call `getSettings()` at
+   startup and render the signup form and OAuth buttons from what it returns.
+8. Site-gating requests ("lock this site to my company", employees-only)
+   route to the netlify-access-control skill first — Identity is the
+   app-level user layer only.

--- a/skills/netlify-image-cdn/SKILL.md
+++ b/skills/netlify-image-cdn/SKILL.md
@@ -1,99 +1,157 @@
 ---
 name: netlify-image-cdn
-description: Guide for using Netlify Image CDN for image optimization and transformation. Use when serving optimized images, creating responsive image markup, setting up user-uploaded image pipelines, or configuring image transformations. Covers the /.netlify/images endpoint, query parameters, remote image allowlisting, clean URL rewrites, and composing uploads with Functions + Blobs.
+description: Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use when adding responsive images, generating thumbnails, converting formats (avif/webp/png), cropping to aspect ratios, tuning image quality, creating blurred placeholders, allowlisting remote image domains, serving user-uploaded images, or wiring framework image components (Next.js, Astro, Nuxt, Angular, Gatsby) to Netlify. Triggers on tasks like "optimize images", "add image thumbnails", "resize images on the fly", "serve images from an external domain", or "add blur placeholders".
 ---
 
 # Netlify Image CDN
 
-Every Netlify site has a built-in `/.netlify/images` endpoint for on-the-fly image transformation. No configuration required for local images.
+Transform images by requesting `/.netlify/images` with query parameters. No function or file authoring required — it's a built-in edge endpoint.
 
-## Basic Usage
-
-```html
-<img src="/.netlify/images?url=/photo.jpg&w=800&h=600&fit=cover&q=80" />
+```bash
+# resize + crop to a 50px square, retain left side, convert to webp at q=80
+curl -vs 'https://mysitename.netlify.app/.netlify/images?url=/owl.jpeg&fit=cover&w=50&h=50&position=left&fm=webp&q=80'
 ```
 
-## Query Parameters
+There is no legacy/deprecated form — the endpoint above is the only programmatic surface. Use framework image components where available (below) rather than hand-building URLs.
 
-| Param | Description | Values |
+## Endpoint & query parameters
+
+`GET /.netlify/images?url=<source>&...`
+
+| Param | Values | Notes |
 |---|---|---|
-| `url` | Source image path (required) | Relative path or absolute URL |
-| `w` | Width in pixels | Any positive integer |
-| `h` | Height in pixels | Any positive integer |
-| `fit` | Resize behavior | `contain` (default), `cover`, `fill` |
-| `position` | Crop alignment (with `cover`) | `center` (default), `top`, `bottom`, `left`, `right` |
-| `fm` | Output format | `avif`, `webp`, `jpg`, `png`, `gif`, `blurhash` |
-| `q` | Quality (lossy formats) | 1-100 (default: 75) |
+| `url` | relative path or full remote URL | **REQUIRED**. Only required param. |
+| `w` | integer px | width |
+| `h` | integer px | height |
+| `fit` | `contain` (default), `cover`, `fill` | resize behavior |
+| `position` | `center` (default), `top`, `bottom`, `left`, `right` | only applies when `fit=cover` |
+| `fm` | `avif`, `jpg`, `png`, `webp`, `gif`, `blurhash` | output format; `webp`/`gif` can be animated |
+| `q` | integer `1`–`100` (default `75`) | only for `avif`, `jpg`, `gif`, `webp` |
 
-When `fm` is omitted, Netlify auto-negotiates the best format based on browser support (preferring `webp`, then `avif`).
+### `fit` behavior
 
-### `fm=blurhash` returns a string, not an image
+| `fit=` | aspect ratio kept | crops excess | returns exact dimensions |
+|---|---|---|---|
+| `contain` | yes | no | no — one dimension may be smaller |
+| `cover` | no | yes | yes — scaled proportionally, then cropped |
+| `fill` | no | no | yes — stretched/squished if needed |
 
-`fm=blurhash` is special: the response body is a short BlurHash **text string**, not image bytes. Pointing an `<img src>` (or CSS `background-image`) straight at a `/.netlify/images?...&fm=blurhash` URL does not work — the browser receives text and has nothing to render. Use it as a placeholder workflow instead: obtain the blurhash string ahead of time (server-side, in a data loader, via a `fetch`, or at build time), decode it with a BlurHash decoder library into a rendered placeholder (a canvas or a data-URI), and show that while the real image loads. The real, displayable image is a **separate** `/.netlify/images` request **without** `fm=blurhash`.
+- **`fit=cover` requires BOTH `w` and `h`.** Supplying only one silently misbehaves.
+- `contain` with one dimension calculates the other to preserve aspect ratio.
 
-## Remote Image Allowlisting
+### Format & content negotiation
 
-External images must be explicitly allowed in `netlify.toml`:
+- Source-only request (just `url`, no size/format): image is unchanged in size/shape but **still reformatted** to `avif`/`webp` based on the browser's `Accept` header.
+- No `fm` specified → `webp` if accepted, else `avif` if accepted, else original.
+- `fm=blurhash` returns a BlurHash **text string, not image bytes.** Pointing `<img src>` or a CSS background at it renders nothing. Fetch the string server-side/ahead of time, decode it client-side with a BlurHash library (https://blurha.sh), then load the real image as a separate request without `fm=blurhash`.
+
+### Response codes
+
+- Invalid transformation param values → `404`.
+- Valid, new transformation → `200` with content + `content-type`.
+- Previously transformed → `304`.
+
+## Remote source images
+
+Remote `url` values require allowlisting the domain in `netlify.toml`:
 
 ```toml
 [images]
-remote_images = ["https://example\\.com/.*", "https://cdn\\.images\\.com/.*"]
+  remote_images = ["https://my-images.com/.*", "https://animals.more-images.com/[bcr]at/.*"]
 ```
 
-Values are regex patterns.
+Then percent-encode the remote URL and request it:
 
-A remote source URL that does **not** match any `remote_images` pattern is rejected with a **404** — Netlify does not fetch or proxy it. This is a strict allowlist, not a fallback: there is no automatic proxying of arbitrary external hosts. Add the host (as an escaped regex) to `remote_images` *before* referencing it through `/.netlify/images`, or every transform request for that source will 404. (Local images on the same site never need allowlisting.)
-
-When referencing an allow-listed remote image, **percent-encode the source URL** before placing it in the `url` parameter:
-
-```html
-<!-- source: https://cdn.example.com/marketing/banner.jpg -->
-<img src="/.netlify/images?url=https%3A%2F%2Fcdn.example.com%2Fmarketing%2Fbanner.jpg&w=800&fm=webp&q=80" />
+```js
+const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/owl.jpeg")}`;
 ```
 
-Percent-encode the source value (e.g. with `encodeURIComponent`) whenever it contains characters that would otherwise be read as Image CDN params — `?`, `&`, `=`, `#`, or whitespace. This applies to remote URLs and relative paths alike (a filename or user-generated key can contain them too, e.g. `url=/uploads/a%26b.jpg`). Basic paths without those characters don't need encoding.
+- **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
+- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
-## Clean URL Rewrites
+## Reusable transformations (redirects)
 
-Create user-friendly image URLs with redirects:
+Reuse the same params across many images via a redirect:
 
+`_redirects`:
+```
+/transform-small/* /.netlify/images?url=/:splat&w=50&h=50 200
+```
+
+`netlify.toml`:
 ```toml
-# Basic optimization
 [[redirects]]
-from = "/img/*"
-to = "/.netlify/images?url=/:splat"
-status = 200
-
-# Preset: thumbnail
-[[redirects]]
-from = "/img/thumb/:key"
-to = "/.netlify/images?url=/uploads/:key&w=150&h=150&fit=cover"
-status = 200
-
-# Preset: hero
-[[redirects]]
-from = "/img/hero/:key"
-to = "/.netlify/images?url=/uploads/:key&w=1200&h=675&fit=cover"
-status = 200
+  from = "/transform-small/*"
+  to = "/.netlify/images?url=/:splat&w=50&h=50"
+  status = 200
 ```
 
-## Local Development
+Then `GET /transform-small/owl.jpeg` yields a 50×50 transform. **Avoid cross-site redirects for transformations** — they hurt performance.
 
-`/.netlify/images` is a Netlify platform endpoint — it does **not** exist in a framework's own dev server. Running `vite`, `next dev`, `astro dev`, etc. directly will **404** on `/.netlify/images`, and `[images]` allowlisting and your image redirects won't apply either. Run `netlify dev` for local work: it emulates the Image CDN endpoint, remote-image allowlisting, and redirect rules, so image URLs resolve locally the same way they do in production. A 404 on `/.netlify/images` locally almost always means a framework dev server is being run directly instead of `netlify dev` — the URL itself is fine.
+## Custom headers (caching)
 
-## Caching
-
-- Transformed images are cached at the CDN edge automatically
-- Cache invalidates on new deploys
-- Set cache headers on source images to control caching:
-
-```toml
-[[headers]]
-for = "/uploads/*"
-[headers.values]
-Cache-Control = "public, max-age=31536000, immutable"
+`_headers`:
+```
+/source-images/*
+  Cache-Control: public, max-age=604800, must-revalidate
 ```
 
-## User-Uploaded Images
+- Headers set on a source image are applied to the transformed asset served by Image CDN.
+- Custom headers **cannot** be applied to remote (other-domain) source images; Netlify respects whatever cache headers the external domain sends.
+- `Cache-Control` on source images applies only to browsers/CDNs in front of Netlify, **not** the Netlify Cache itself.
 
-Combine **Netlify Functions** (upload handler) + **Netlify Blobs** (storage) + **Image CDN** (serving/transforming) to build a complete user-uploaded image pipeline. See [references/user-uploads.md](references/user-uploads.md) for the full pattern.
+## Framework integrations
+
+Use the framework's native image component/handling; it wires to Image CDN automatically. Configure the remote allowlist per framework:
+
+| Framework | Prerequisite | Remote allowlist |
+|---|---|---|
+| Angular | none — `NgOptimizedImage` auto-uses it | `[images] remote_images` in `netlify.toml` |
+| Astro | none — `<Image />` auto-uses it | `image.domains` / `image.remotePatterns` in `astro.config.mjs` |
+| Nuxt | none — `nuxt/image` auto-uses it | `image.domains` in `nuxt.config.ts` |
+| Next.js | Next 13.5+ and adapter v5 | `remotePatterns` in `next.config.js` |
+| Gatsby | env `NETLIFY_IMAGE_CDN=true` + Contentful/Drupal/WordPress source plugin | `[images] remote_images` in `netlify.toml` |
+
+## Local development
+
+Run `netlify dev` (Netlify CLI) to test transformations locally — it mimics production including Image CDN.
+
+- **A local `404` on `/.netlify/images` almost always means a framework dev server (`vite`, `next dev`, `astro dev`) is running instead of `netlify dev`.** The endpoint, `[images]` allowlisting, and image redirects only exist under `netlify dev`. The URL itself is usually fine.
+
+## Caching & deploys
+
+Transformed results are uniquely cached on Netlify's edge. Atomic deploys are respected: changing a source image in a new deploy re-runs transformations on new requests so stale assets aren't served.
+
+## User-uploaded image pipelines
+
+For user-uploaded image pipelines (Functions + Blobs + Image CDN composed), see `references/user-uploads.md` in this skill.
+
+## Limitations
+
+- **Split Testing is not supported** — you may get inconsistent image results between split test branches.
+- Not currently supported in Netlify's HIPAA-compliant hosting offering. See the Trust Center for the HIPAA-compliant reference architecture.
+
+<!-- system: agent-context/image-cdn/system.md — human-owned, merged by ctx-gen; edit system.md, not this section -->
+# Netlify house rules (image-cdn)
+
+These are org conventions, not docs facts — merged into the rendered skill by
+ctx-gen and never generated. Owned by the skills maintainer.
+
+1. For user-uploaded image pipelines (Functions + Blobs + Image CDN
+   composed), see `references/user-uploads.md` in this skill — an authored
+   guide with no single docs source.
+2. Percent-encode remote source URLs before placing them in the `url`
+   parameter (`encodeURIComponent`) — URLs containing `?` or `&` break
+   otherwise.
+3. `fm=blurhash` returns a BlurHash TEXT string, not image bytes. Pointing an
+   `<img src>` (or CSS background) at it renders nothing — fetch the string
+   ahead of time, decode it client-side with a BlurHash library, and load the
+   real image as a separate request without `fm=blurhash`.
+4. A local 404 on `/.netlify/images` almost always means a framework dev
+   server (`vite`, `next dev`, `astro dev`) is running instead of
+   `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
+   only exist under `netlify dev`. The URL itself is usually fine.
+5. In `remote_images` patterns, the meaningful escape is the dot:
+   `"https://example\.com/.*"`. Forward slashes are not regex
+   metacharacters — do not write `https:\/\/`.


### PR DESCRIPTION
Rolling import of generated skills from `netlify/docs`, updated in place as new context lands.

Latest docs commit: `e33a7260cd1ab02c53b80420d047044454a29833`
Groupings updated: **functions, forms, edge-functions, image-cdn, caching, blobs, database, deploy, ai-gateway, frameworks, identity, access-control, config**

These skills are generated and AXIS-tested upstream, then imported here byte-for-byte — no content changes on this side. `validate-skills` and `build-generated-outputs` (cursor/codex parity) run on this PR. Review the latest diff and merge; rollback = revert.

Note: this sync was run manually — `CTX_PIPELINE_PR_TOKEN` is missing from this repo's Actions secrets (worked 2026-08-11, empty 2026-08-12), so the automatic receiver leg is down until it's re-provisioned.

Per-skill comparison + AXIS scoreboard for this content: see the review briefing artifact linked in the docs thread.

Ref: AX-97.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed guidance across Netlify access control, AI Gateway, Blobs, caching, configuration, database, deployments, Edge Functions, Forms, frameworks, Functions, Identity, and Image CDN.
  * Added current setup instructions, examples, limits, security considerations, migration guidance, local-development details, and framework-specific workflows.
  * Clarified configuration options, supported use cases, plan requirements, operational constraints, and feature limitations.

* **Chores**
  * Updated documentation import tracking for the refreshed content set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->