### PR TITLE
chore(ctx-pipeline): map remaining 9 groupings to skills

### DIFF
--- a/.ctx-gen/config.json
+++ b/.ctx-gen/config.json
@@ -20,6 +20,42 @@
     {
       "grouping": "image-cdn",
       "skill": "netlify-image-cdn"
+    },
+    {
+      "grouping": "caching",
+      "skill": "netlify-caching"
+    },
+    {
+      "grouping": "blobs",
+      "skill": "netlify-blobs"
+    },
+    {
+      "grouping": "database",
+      "skill": "netlify-database"
+    },
+    {
+      "grouping": "deploy",
+      "skill": "netlify-deploy"
+    },
+    {
+      "grouping": "ai-gateway",
+      "skill": "netlify-ai-gateway"
+    },
+    {
+      "grouping": "frameworks",
+      "skill": "netlify-frameworks"
+    },
+    {
+      "grouping": "identity",
+      "skill": "netlify-identity"
+    },
+    {
+      "grouping": "access-control",
+      "skill": "netlify-access-control"
+    },
+    {
+      "grouping": "config",
+      "skill": "netlify-config"
     }
   ]
 }


### PR DESCRIPTION
Extends the docs import config to all 13 pipeline-fed skills, now that all 19 groupings are generated and merged on netlify/docs main (docs #763, #765).

New mappings: caching, blobs, database, deploy, ai-gateway, frameworks, identity, access-control, config (the unified routing+env-vars+configure-builds grouping rendering netlify-config 1:1).

References-dir safety checked: every CT-side references/ dir (database, deploy, frameworks, identity, access-control) is vendored 1:1 in docs agent-context, so the receiver mirror won't drop anything on first sync.

After merge: re-dispatch the receiver (docs_ref=main) to update rolling draft #104.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added categorized skill groupings for caching, blobs, databases, deployments, AI Gateway, frameworks, identity, access control, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->