### PR TITLE
chore(context): sync skills from netlify/docs

### DIFF
--- a/.ctx-gen/state.json
+++ b/.ctx-gen/state.json
@@ -45,8 +45,8 @@
     ]
   },
   "image-cdn": {
-    "sourceHash": "d610f4e75340434db04b75990b57e1833818f6c3f33b4a2b3ffdea201cc09d23",
-    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "sourceHash": "4dffab1264df9f62a5ec9823657c860f6f7570c0bd8cd3a7f764fb86df669462",
+    "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
     "importerVersion": 1,
     "affects": [
       "api",
@@ -128,8 +128,8 @@
     ]
   },
   "frameworks": {
-    "sourceHash": "aa1942c92161d1d0487d0173ff19302c97d60129796d56456bafc7ca155b9574",
-    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "sourceHash": "17f8bfb84634504f7491f3f715e47adbdeef439c1574b0fadd6ace4174336b1f",
+    "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
     "importerVersion": 1,
     "affects": [
       "authoring",
@@ -142,8 +142,8 @@
     ]
   },
   "identity": {
-    "sourceHash": "735a828e3b87669025ac4e8cc82790defbf88ddc00591ab859d6e04194170c9b",
-    "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
+    "sourceHash": "03af265ab2cf40f3ea3ec2f2460c324d77c895364438a47823dc9bbfe17e7a61",
+    "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
     "importerVersion": 1,
     "affects": [
       "api",

--- a/agent-plugin/skills/netlify-frameworks/SKILL.md
+++ b/agent-plugin/skills/netlify-frameworks/SKILL.md
@@ -33,7 +33,7 @@ SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.htm
 
 ## Local dev with platform emulation (no Netlify CLI)
 
-Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Netlify Database, Cache API, Image CDN, redirects/rewrites, headers, env vars, AI Gateway) in the dev server:
 
 | Framework | Plugin/module | Run |
 |-----------|---------------|-----|
@@ -239,3 +239,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
 6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
    `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
    client-prefixed vars are inlined into the browser bundle.
+7. Next.js skew protection is version-conditional: below Next 14.1.4 the
+   `NETLIFY_NEXT_SKEW_PROTECTION` env var is not sufficient on its own —
+   `experimental.useDeploymentId` (plus `useDeploymentIdServerActions` when
+   server actions are used) must also go in `next.config.js`. Always ask for
+   or state the version condition; never present the env var as the whole
+   setup.

--- a/agent-plugin/skills/netlify-frameworks/references/nextjs.md
+++ b/agent-plugin/skills/netlify-frameworks/references/nextjs.md
@@ -41,6 +41,25 @@ module.exports = nextConfig;
 
 Remote image patterns in `next.config.js` are automatically mapped to Netlify Image CDN's `remote_images` configuration.
 
+### Skew protection
+
+Opt-in. Set `NETLIFY_NEXT_SKEW_PROTECTION` to `true`, then redeploy — env values are injected at build time, so the live deploy is unchanged until a new build runs.
+
+On Next.js **earlier than 14.1.4** the env var is not sufficient on its own; add the deployment-id flags too:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    useDeploymentId: true,
+    // only needed when using Server Actions
+    useDeploymentIdServerActions: true,
+  },
+};
+```
+
+Client `fetch` calls are never covered automatically — Next.js does not attach the deployment identifier to them, so those requests always hit the current deploy. Send it yourself with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`.
+
 ## API Routes
 
 Next.js API routes work automatically — they are deployed as Netlify Functions:

--- a/agent-plugin/skills/netlify-frameworks/references/tanstack.md
+++ b/agent-plugin/skills/netlify-frameworks/references/tanstack.md
@@ -54,7 +54,7 @@ const getItems = createServerFn({ method: "GET" }).handler(async () => {
 npm run dev    # vite dev — full Netlify platform emulation
 ```
 
-The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, the Cache API, Image CDN, redirects, rewrites, headers, and environment variables — without needing `netlify dev`.
+The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, Database, the Cache API, Image CDN, redirects, rewrites, headers, environment variables, and AI Gateway — without needing `netlify dev`.
 
 ## Build and Deploy
 

--- a/agent-plugin/skills/netlify-identity/SKILL.md
+++ b/agent-plugin/skills/netlify-identity/SKILL.md
@@ -112,7 +112,7 @@ export default async (req: Request, context: Context) => {
 ```
 
 - `admin.listUsers()` — array of users.
-- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://www.npmjs.com/package/@netlify/identity
 
 ### Session cookies
 JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.

--- a/agent-plugin/skills/netlify-image-cdn/SKILL.md
+++ b/agent-plugin/skills/netlify-image-cdn/SKILL.md
@@ -67,7 +67,7 @@ const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/ow
 ```
 
 - **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
-- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- In `remote_images` patterns, **escape only the dot**: `'https://example\.com/.*'`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
 - Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
 ## Reusable transformations (redirects)
@@ -152,6 +152,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
    server (`vite`, `next dev`, `astro dev`) is running instead of
    `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
    only exist under `netlify dev`. The URL itself is usually fine.
-5. In `remote_images` patterns, the meaningful escape is the dot:
-   `"https://example\.com/.*"`. Forward slashes are not regex
-   metacharacters — do not write `https:\/\/`.
+5. In `remote_images` patterns, the meaningful regex escape is the dot;
+   forward slashes are not metacharacters — do not write `https:\/\/`.
+   In `netlify.toml`, use a single-quoted literal string
+   (`'https://example\.com/.*'`) or double the backslash in a
+   double-quoted string (`"https://example\\.com/.*"`) — a bare `\.`
+   inside double quotes is invalid TOML.

--- a/codex/skills/netlify-frameworks/SKILL.md
+++ b/codex/skills/netlify-frameworks/SKILL.md
@@ -33,7 +33,7 @@ SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.htm
 
 ## Local dev with platform emulation (no Netlify CLI)
 
-Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Netlify Database, Cache API, Image CDN, redirects/rewrites, headers, env vars, AI Gateway) in the dev server:
 
 | Framework | Plugin/module | Run |
 |-----------|---------------|-----|
@@ -239,3 +239,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
 6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
    `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
    client-prefixed vars are inlined into the browser bundle.
+7. Next.js skew protection is version-conditional: below Next 14.1.4 the
+   `NETLIFY_NEXT_SKEW_PROTECTION` env var is not sufficient on its own —
+   `experimental.useDeploymentId` (plus `useDeploymentIdServerActions` when
+   server actions are used) must also go in `next.config.js`. Always ask for
+   or state the version condition; never present the env var as the whole
+   setup.

--- a/codex/skills/netlify-frameworks/references/nextjs.md
+++ b/codex/skills/netlify-frameworks/references/nextjs.md
@@ -41,6 +41,25 @@ module.exports = nextConfig;
 
 Remote image patterns in `next.config.js` are automatically mapped to Netlify Image CDN's `remote_images` configuration.
 
+### Skew protection
+
+Opt-in. Set `NETLIFY_NEXT_SKEW_PROTECTION` to `true`, then redeploy — env values are injected at build time, so the live deploy is unchanged until a new build runs.
+
+On Next.js **earlier than 14.1.4** the env var is not sufficient on its own; add the deployment-id flags too:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    useDeploymentId: true,
+    // only needed when using Server Actions
+    useDeploymentIdServerActions: true,
+  },
+};
+```
+
+Client `fetch` calls are never covered automatically — Next.js does not attach the deployment identifier to them, so those requests always hit the current deploy. Send it yourself with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`.
+
 ## API Routes
 
 Next.js API routes work automatically — they are deployed as Netlify Functions:

--- a/codex/skills/netlify-frameworks/references/tanstack.md
+++ b/codex/skills/netlify-frameworks/references/tanstack.md
@@ -54,7 +54,7 @@ const getItems = createServerFn({ method: "GET" }).handler(async () => {
 npm run dev    # vite dev — full Netlify platform emulation
 ```
 
-The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, the Cache API, Image CDN, redirects, rewrites, headers, and environment variables — without needing `netlify dev`.
+The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, Database, the Cache API, Image CDN, redirects, rewrites, headers, environment variables, and AI Gateway — without needing `netlify dev`.
 
 ## Build and Deploy
 

--- a/codex/skills/netlify-identity/SKILL.md
+++ b/codex/skills/netlify-identity/SKILL.md
@@ -112,7 +112,7 @@ export default async (req: Request, context: Context) => {
 ```
 
 - `admin.listUsers()` — array of users.
-- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://www.npmjs.com/package/@netlify/identity
 
 ### Session cookies
 JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.

--- a/codex/skills/netlify-image-cdn/SKILL.md
+++ b/codex/skills/netlify-image-cdn/SKILL.md
@@ -67,7 +67,7 @@ const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/ow
 ```
 
 - **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
-- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- In `remote_images` patterns, **escape only the dot**: `'https://example\.com/.*'`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
 - Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
 ## Reusable transformations (redirects)
@@ -152,6 +152,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
    server (`vite`, `next dev`, `astro dev`) is running instead of
    `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
    only exist under `netlify dev`. The URL itself is usually fine.
-5. In `remote_images` patterns, the meaningful escape is the dot:
-   `"https://example\.com/.*"`. Forward slashes are not regex
-   metacharacters — do not write `https:\/\/`.
+5. In `remote_images` patterns, the meaningful regex escape is the dot;
+   forward slashes are not metacharacters — do not write `https:\/\/`.
+   In `netlify.toml`, use a single-quoted literal string
+   (`'https://example\.com/.*'`) or double the backslash in a
+   double-quoted string (`"https://example\\.com/.*"`) — a bare `\.`
+   inside double quotes is invalid TOML.

--- a/cursor/rules/netlify-frameworks-nextjs.mdc
+++ b/cursor/rules/netlify-frameworks-nextjs.mdc
@@ -45,6 +45,25 @@ module.exports = nextConfig;
 
 Remote image patterns in `next.config.js` are automatically mapped to Netlify Image CDN's `remote_images` configuration.
 
+### Skew protection
+
+Opt-in. Set `NETLIFY_NEXT_SKEW_PROTECTION` to `true`, then redeploy — env values are injected at build time, so the live deploy is unchanged until a new build runs.
+
+On Next.js **earlier than 14.1.4** the env var is not sufficient on its own; add the deployment-id flags too:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    useDeploymentId: true,
+    // only needed when using Server Actions
+    useDeploymentIdServerActions: true,
+  },
+};
+```
+
+Client `fetch` calls are never covered automatically — Next.js does not attach the deployment identifier to them, so those requests always hit the current deploy. Send it yourself with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`.
+
 ## API Routes
 
 Next.js API routes work automatically — they are deployed as Netlify Functions:

--- a/cursor/rules/netlify-frameworks-tanstack.mdc
+++ b/cursor/rules/netlify-frameworks-tanstack.mdc
@@ -58,7 +58,7 @@ const getItems = createServerFn({ method: "GET" }).handler(async () => {
 npm run dev    # vite dev — full Netlify platform emulation
 ```
 
-The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, the Cache API, Image CDN, redirects, rewrites, headers, and environment variables — without needing `netlify dev`.
+The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, Database, the Cache API, Image CDN, redirects, rewrites, headers, environment variables, and AI Gateway — without needing `netlify dev`.
 
 ## Build and Deploy
 

--- a/cursor/rules/netlify-frameworks.mdc
+++ b/cursor/rules/netlify-frameworks.mdc
@@ -33,7 +33,7 @@ SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.htm
 
 ## Local dev with platform emulation (no Netlify CLI)
 
-Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Netlify Database, Cache API, Image CDN, redirects/rewrites, headers, env vars, AI Gateway) in the dev server:
 
 | Framework | Plugin/module | Run |
 |-----------|---------------|-----|
@@ -239,3 +239,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
 6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
    `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
    client-prefixed vars are inlined into the browser bundle.
+7. Next.js skew protection is version-conditional: below Next 14.1.4 the
+   `NETLIFY_NEXT_SKEW_PROTECTION` env var is not sufficient on its own —
+   `experimental.useDeploymentId` (plus `useDeploymentIdServerActions` when
+   server actions are used) must also go in `next.config.js`. Always ask for
+   or state the version condition; never present the env var as the whole
+   setup.

--- a/cursor/rules/netlify-identity.mdc
+++ b/cursor/rules/netlify-identity.mdc
@@ -112,7 +112,7 @@ export default async (req: Request, context: Context) => {
 ```
 
 - `admin.listUsers()` — array of users.
-- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://www.npmjs.com/package/@netlify/identity
 
 ### Session cookies
 JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.

--- a/cursor/rules/netlify-image-cdn.mdc
+++ b/cursor/rules/netlify-image-cdn.mdc
@@ -67,7 +67,7 @@ const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/ow
 ```
 
 - **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
-- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- In `remote_images` patterns, **escape only the dot**: `'https://example\.com/.*'`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
 - Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
 ## Reusable transformations (redirects)
@@ -152,6 +152,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
    server (`vite`, `next dev`, `astro dev`) is running instead of
    `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
    only exist under `netlify dev`. The URL itself is usually fine.
-5. In `remote_images` patterns, the meaningful escape is the dot:
-   `"https://example\.com/.*"`. Forward slashes are not regex
-   metacharacters — do not write `https:\/\/`.
+5. In `remote_images` patterns, the meaningful regex escape is the dot;
+   forward slashes are not metacharacters — do not write `https:\/\/`.
+   In `netlify.toml`, use a single-quoted literal string
+   (`'https://example\.com/.*'`) or double the backslash in a
+   double-quoted string (`"https://example\\.com/.*"`) — a bare `\.`
+   inside double quotes is invalid TOML.

--- a/skills/netlify-frameworks/SKILL.md
+++ b/skills/netlify-frameworks/SKILL.md
@@ -33,7 +33,7 @@ SPAs (React, Vue CLI, Vite, Nuxt in SPA mode) need a rewrite to serve `index.htm
 
 ## Local dev with platform emulation (no Netlify CLI)
 
-Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Cache API, Image CDN, redirects/rewrites, headers, env vars) in the dev server:
+Vite-based frameworks emulate Netlify primitives (functions, edge functions, blobs, Netlify Database, Cache API, Image CDN, redirects/rewrites, headers, env vars, AI Gateway) in the dev server:
 
 | Framework | Plugin/module | Run |
 |-----------|---------------|-----|
@@ -239,3 +239,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
 6. Never use a client prefix (`VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`,
    `NUXT_PUBLIC_`, `REACT_APP_`, `GATSBY_`, `VUE_APP_`) for secrets —
    client-prefixed vars are inlined into the browser bundle.
+7. Next.js skew protection is version-conditional: below Next 14.1.4 the
+   `NETLIFY_NEXT_SKEW_PROTECTION` env var is not sufficient on its own —
+   `experimental.useDeploymentId` (plus `useDeploymentIdServerActions` when
+   server actions are used) must also go in `next.config.js`. Always ask for
+   or state the version condition; never present the env var as the whole
+   setup.

--- a/skills/netlify-frameworks/references/nextjs.md
+++ b/skills/netlify-frameworks/references/nextjs.md
@@ -41,6 +41,25 @@ module.exports = nextConfig;
 
 Remote image patterns in `next.config.js` are automatically mapped to Netlify Image CDN's `remote_images` configuration.
 
+### Skew protection
+
+Opt-in. Set `NETLIFY_NEXT_SKEW_PROTECTION` to `true`, then redeploy — env values are injected at build time, so the live deploy is unchanged until a new build runs.
+
+On Next.js **earlier than 14.1.4** the env var is not sufficient on its own; add the deployment-id flags too:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    useDeploymentId: true,
+    // only needed when using Server Actions
+    useDeploymentIdServerActions: true,
+  },
+};
+```
+
+Client `fetch` calls are never covered automatically — Next.js does not attach the deployment identifier to them, so those requests always hit the current deploy. Send it yourself with `x-deployment-id: process.env.NEXT_DEPLOYMENT_ID`.
+
 ## API Routes
 
 Next.js API routes work automatically — they are deployed as Netlify Functions:

--- a/skills/netlify-frameworks/references/tanstack.md
+++ b/skills/netlify-frameworks/references/tanstack.md
@@ -54,7 +54,7 @@ const getItems = createServerFn({ method: "GET" }).handler(async () => {
 npm run dev    # vite dev — full Netlify platform emulation
 ```
 
-The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, the Cache API, Image CDN, redirects, rewrites, headers, and environment variables — without needing `netlify dev`.
+The plugin emulates the production Netlify platform locally, exposing Functions, Edge Functions, Blobs, Database, the Cache API, Image CDN, redirects, rewrites, headers, environment variables, and AI Gateway — without needing `netlify dev`.
 
 ## Build and Deploy
 

--- a/skills/netlify-identity/SKILL.md
+++ b/skills/netlify-identity/SKILL.md
@@ -112,7 +112,7 @@ export default async (req: Request, context: Context) => {
 ```
 
 - `admin.listUsers()` — array of users.
-- `admin.updateUser()` — update a user (e.g. roles). Full API: https://github.com/netlify/identity#admin-operations
+- `admin.updateUser()` — update a user (e.g. roles). Full API: https://www.npmjs.com/package/@netlify/identity
 
 ### Session cookies
 JWT stored in cookie `nf_jwt`, sent automatically. Server-side `login`/`signup`/`logout` read/write `nf_jwt` and `nf_refresh` via the runtime, so the browser gets the session in the response.

--- a/skills/netlify-image-cdn/SKILL.md
+++ b/skills/netlify-image-cdn/SKILL.md
@@ -67,7 +67,7 @@ const src = `/.netlify/images?url=${encodeURIComponent("https://my-images.com/ow
 ```
 
 - **Always `encodeURIComponent` the remote URL** before placing it in `url` — URLs containing `?` or `&` break otherwise.
-- In `remote_images` patterns, **escape only the dot**: `"https://example\.com/.*"`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
+- In `remote_images` patterns, **escape only the dot**: `'https://example\.com/.*'`. Forward slashes are NOT regex metacharacters — do not write `https:\/\/`.
 - Remote sources must be **publicly accessible**. Netlify does NOT forward `Authorization` or `Cookie` headers to remote sources. For auth-required images use self-authorizing URLs (e.g. S3 presigned URLs) and make sure your `remote_images` pattern matches them.
 
 ## Reusable transformations (redirects)
@@ -152,6 +152,9 @@ ctx-gen and never generated. Owned by the skills maintainer.
    server (`vite`, `next dev`, `astro dev`) is running instead of
    `netlify dev` — the endpoint, `[images]` allowlisting, and image redirects
    only exist under `netlify dev`. The URL itself is usually fine.
-5. In `remote_images` patterns, the meaningful escape is the dot:
-   `"https://example\.com/.*"`. Forward slashes are not regex
-   metacharacters — do not write `https:\/\/`.
+5. In `remote_images` patterns, the meaningful regex escape is the dot;
+   forward slashes are not metacharacters — do not write `https:\/\/`.
+   In `netlify.toml`, use a single-quoted literal string
+   (`'https://example\.com/.*'`) or double the backslash in a
+   double-quoted string (`"https://example\\.com/.*"`) — a bare `\.`
+   inside double quotes is invalid TOML.


### PR DESCRIPTION
Rolling import of generated skills from `netlify/docs`, updated in place as new context lands.

Latest docs commit: `8bebff3c3bbbbdcf93166c758d630c3379210eeb`
Groupings updated: **image-cdn,frameworks,identity**

These skills are generated and AXIS-tested upstream, then imported here byte-for-byte — no content changes on this side. `validate-skills` and `build-generated-outputs` (cursor/codex parity) run on this PR. Review the latest diff and merge; rollback = revert.

Ref: AX-97.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded local development guidance to include Netlify Database, Cache API, and AI Gateway emulation.
  - Added Next.js deployment skew-protection setup, including environment variables, version-specific configuration, redeployment requirements, and client request handling.
  - Clarified valid TOML syntax and escaping for remote image patterns.
  - Updated the `admin.updateUser()` documentation link to the npm package page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->