### PR TITLE
fix: import agent-context skills on byte difference, not manifest hash

### DIFF
--- a/.ctx-gen/README.md
+++ b/.ctx-gen/README.md
@@ -19,11 +19,14 @@ AXIS scenarios.)
   maps to (`functions` → `netlify-functions`).
 - **`state.json`** — a provenance log, never consulted for the skip decision.
   Per grouping we record the `manifest.generation.source_hash` and docs commit
-  last imported, plus `affects`. The delta itself is a byte comparison of
+  last imported, plus `affects` and `intermediateHash` (sha256 of the
+  grouping's `context.md` + `system.md`, the inputs the skill is generated
+  from). The delta itself is a byte comparison of
   `agent-context/<grouping>/skill/**` against `skills/<name>/**` (path set +
   bytes + executable bit; symlinks unsupported), so repeated dispatches of
   identical content are no-ops and upstream hand edits that never touch the
-  manifest still propagate.
+  manifest still propagate. When `intermediateHash` moves while `skill/` is
+  identical, the run warns and imports nothing.
 - **`../scripts/ctx-receive.mjs`** — reads the two files above against a docs
   checkout, imports changed groupings, records provenance in `state.json`.
 - **`../.github/workflows/ctx-pipeline-receive.yml`** — resolves the docs ref,

--- a/.ctx-gen/README.md
+++ b/.ctx-gen/README.md
@@ -16,13 +16,16 @@ AXIS scenarios.)
 ## Pieces
 
 - **`config.json`** — which docs groupings we consume and the local skill each
-  maps to (`functions` → `netlify-functions`), plus `importerVersion` (bump to
-  force a re-import when the import logic itself changes).
-- **`state.json`** — the delta cache. Per grouping we record the
-  `manifest.generation.source_hash` we last imported. Unchanged hash → skip, so
-  repeated notifications for the same docs commit are no-ops.
+  maps to (`functions` → `netlify-functions`).
+- **`state.json`** — a provenance log, never consulted for the skip decision.
+  Per grouping we record the `manifest.generation.source_hash` and docs commit
+  last imported, plus `affects`. The delta itself is a byte comparison of
+  `agent-context/<grouping>/skill/**` against `skills/<name>/**` (path set +
+  bytes + executable bit; symlinks unsupported), so repeated dispatches of
+  identical content are no-ops and upstream hand edits that never touch the
+  manifest still propagate.
 - **`../scripts/ctx-receive.mjs`** — reads the two files above against a docs
-  checkout, imports changed groupings, updates the cache.
+  checkout, imports changed groupings, records provenance in `state.json`.
 - **`../.github/workflows/ctx-pipeline-receive.yml`** — resolves the docs ref,
   checks out docs, runs the importer, and opens or updates a single rolling
   draft PR when something changed. That PR runs the existing `validate-skills`

--- a/.ctx-gen/config.json
+++ b/.ctx-gen/config.json
@@ -3,7 +3,6 @@
     "repo": "netlify/docs",
     "agentContextDir": "agent-context"
   },
-  "importerVersion": 1,
   "groupings": [
     {
       "grouping": "functions",

--- a/.ctx-gen/state.json
+++ b/.ctx-gen/state.json
@@ -2,7 +2,6 @@
   "functions": {
     "sourceHash": "a2c1b272355b04685b89a8b51a7bbfe0747c93d36c982c035ad01d4904c7e5b4",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -17,7 +16,6 @@
   "forms": {
     "sourceHash": "e9238e4279d3cd87a88b715f87e36d4de6afbac3640e3b5ae1cbc9569374f3a9",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -32,7 +30,6 @@
   "edge-functions": {
     "sourceHash": "6aefbe078cf6e2ad07f2825f043393143fd45ce202071399dc1b6e54ca555f53",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -47,7 +44,6 @@
   "image-cdn": {
     "sourceHash": "4dffab1264df9f62a5ec9823657c860f6f7570c0bd8cd3a7f764fb86df669462",
     "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
-    "importerVersion": 1,
     "affects": [
       "api",
       "configuration",
@@ -60,7 +56,6 @@
   "caching": {
     "sourceHash": "d66b80cad3ae85bd3b9c44eedf7b7b51968e8f976880d6ec959e91a4af52a2ee",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "configuration",
@@ -70,7 +65,6 @@
   "blobs": {
     "sourceHash": "78dc00056a00c9f711ca4c8b2fcdf9af2d76070db339594c8d3b243ffecaf4d8",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -85,7 +79,6 @@
   "database": {
     "sourceHash": "21eb58e3c2a11a65af5fc473c08fd724ca130cb4dc4379a692344bcdbcb29c94",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -100,7 +93,6 @@
   "deploy": {
     "sourceHash": "f6973145efb21d3f6c11b37b75171005ec888b8778c57ad0a703218150f62912",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -115,7 +107,6 @@
   "ai-gateway": {
     "sourceHash": "30dce37711d783b0f5d0cd0f2396f159ecc22a5ad716a2e8caa5f8d64d776f57",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -130,7 +121,6 @@
   "frameworks": {
     "sourceHash": "17f8bfb84634504f7491f3f715e47adbdeef439c1574b0fadd6ace4174336b1f",
     "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
-    "importerVersion": 1,
     "affects": [
       "authoring",
       "compat",
@@ -144,7 +134,6 @@
   "identity": {
     "sourceHash": "03af265ab2cf40f3ea3ec2f2460c324d77c895364438a47823dc9bbfe17e7a61",
     "docsCommit": "8bebff3c3bbbbdcf93166c758d630c3379210eeb",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -159,7 +148,6 @@
   "access-control": {
     "sourceHash": "1827f0ee8f9c66beb4d6b53a199d6adbda4852c110609ce2a3b3a49418a2f307",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",
@@ -174,7 +162,6 @@
   "config": {
     "sourceHash": "30e8f6cc0b0482a0f4ea69506b3e7462e3fecaab4f5ef48142a06fbebae52908",
     "docsCommit": "e33a7260cd1ab02c53b80420d047044454a29833",
-    "importerVersion": 1,
     "affects": [
       "api",
       "authoring",

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - "skills/**"
+      - "scripts/ctx-receive.mjs"
+      - "scripts/ctx-receive.test.mjs"
       - ".github/workflows/validate-skills.yml"
 
 jobs:
@@ -56,3 +58,15 @@ jobs:
 
           run_with_retries skill-validator check --strict --emit-annotations skills/
           run_with_retries skill-validator check --strict -o markdown skills/ >> "$GITHUB_STEP_SUMMARY"
+
+  test-receiver:
+    # Zero-dependency script tests for the Stage 2 receiver (scripts/ctx-receive.mjs).
+    # No npm install: the package has no dependencies, so `npm test` runs as-is.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Run receiver tests
+        run: npm test

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,6 +5,7 @@ on:
       - "skills/**"
       - "scripts/ctx-receive.mjs"
       - "scripts/ctx-receive.test.mjs"
+      - "package.json"
       - ".github/workflows/validate-skills.yml"
 
 jobs:
@@ -67,6 +68,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+
+      # 18 is the floor the script header promises; running on it keeps that claim honest.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 18
 
       - name: Run receiver tests
         run: npm test

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -63,6 +63,8 @@ jobs:
   test-receiver:
     # Zero-dependency script tests for the Stage 2 receiver (scripts/ctx-receive.mjs).
     # No npm install: the package has no dependencies, so `npm test` runs as-is.
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
@@ -1,0 +1,53 @@
+# AX-136 autopilot run report — 2026-08-20
+
+Spec: `2026-08-19-ax-136-receiver-byte-diff.md`. Branch built unattended
+(launched 3:02 AM); orchestrator judged, Sonnet developers wrote, Codex
+audited read-only.
+
+## Slices
+
+1. `577e427` — byte-diff delta (`treeDiffers`) replaces the manifest-hash
+   skip; import reasons now name the hand-edit shape. Developer also made the
+   missing-`SKILL.md` check unconditional (previously only on the changed
+   path) — judged in-scope: same failure surface, now deterministic.
+2. `3472da7` — zero-dep test suite (5 tests incl. the docs#801 hand-edit
+   shape), `npm test` wired.
+3. `0fe8cdc` — `test-receiver` job in `validate-skills.yml`; PR paths trigger
+   extended to the receiver scripts so the suite actually fires on
+   receiver-only PRs.
+
+## Spec amendment (orchestrator, mid-run)
+
+The original done-signal grep (`prev.sourceHash === sourceHash` → 0 hits) was
+too blunt: it caught a benign log-only comparison that labels the hand-edit
+case. Amended to target the decision conjunction
+(`… && prev.importerVersion` → 0 hits) plus `treeDiffers` ≥ 2. Rationale
+recorded in the spec's Done-signal section.
+
+## Audit rounds (bound: 3, used: 1)
+
+- **Security (Codex):** clean, round 1.
+- **Simplicity (Codex):** 3 low findings.
+  - Import-reason ternary — accepted narrowed: label made factual
+    (`surface differs, source_hash unchanged`) + legacy-state guard; the
+    labeling itself kept deliberately (visibility is AX-136's point). Codex's
+    claim that it "couples the decision to manifest state" was wrong — the
+    decision is `treeDiffers` only.
+  - Redundant `Set` in `treeDiffers` — accepted; elementwise sorted-array
+    compare.
+  - Fold `test-receiver` into `validate` job — **rejected**: separate job is
+    a named status check, runs parallel to the validator's network download,
+    keeps jobs single-purpose.
+- Fix commit `5bfff01`; tests re-run green by orchestrator; follow-up
+  simplicity pass clean.
+
+## Completeness gate
+
+- `npm test` → 5/5 pass (orchestrator-run).
+- `rg "prev.sourceHash === sourceHash && prev.importerVersion"` → 0 hits.
+- `rg -c "treeDiffers"` → 3 (≥ 2).
+- `rg -c "npm test" .github/workflows/validate-skills.yml` → 2 (≥ 1).
+- human-verify (for Sean): after netlify/docs#801 merges, the next receive
+  run's rolling sync PR must contain the Next.js fetch-skew qualification.
+
+No unmet items; no deferred findings beyond the rejected CI-job fold above.

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
@@ -47,7 +47,37 @@ recorded in the spec's Done-signal section.
 - `rg "prev.sourceHash === sourceHash && prev.importerVersion"` → 0 hits.
 - `rg -c "treeDiffers"` → 3 (≥ 2).
 - `rg -c "npm test" .github/workflows/validate-skills.yml` → 2 (≥ 1).
-- human-verify (for Sean): after netlify/docs#801 merges, the next receive
-  run's rolling sync PR must contain the Next.js fetch-skew qualification.
+- human-verify (for Sean) — **pending, needs a live run**: after
+  netlify/docs#801 merges, the next receive run's rolling sync PR must contain
+  the Next.js fetch-skew qualification.
 
-No unmet items; no deferred findings beyond the rejected CI-job fold above.
+All machine-checkable items met; the human-verify item above is the one
+open item. No deferred findings beyond the rejected CI-job fold above.
+
+## Iteration 1 — 2026-08-25 (PR review)
+
+Input: domitriusclark's review on #115 (6 inline + 2 top-level) plus two
+CodeRabbit findings. All validated against the branch head `f3cae6a`.
+
+Dispositions:
+
+- Fixed — null `docsCommit` crash (test pins the manifest fallback);
+  missing `SKILL.md` warns and continues instead of failing the run; symlinks
+  and other non-regular entries fail loudly, executable bit compared (the
+  only mode bit git tracks); non-directory destination counts as changed and
+  is replaced; `importerVersion` removed from script, config, state, README
+  (with a faithful copy no bump can change output); tests isolated per
+  fixture; CI path filter includes `package.json`, `setup-node` pinned at
+  Node 18; README describes `state.json` as provenance. Commits `ace7e5f`,
+  `a701fb9`, `e22e3b4`, `1d9ae10`, `eb3f515`.
+- Moved — `lastImportedCommit` / `state_changed` had no consumer in this PR;
+  the consumer is #110 (`ctx-receiver-monotonic`). Reverted out of #115
+  (`1a0b93e`); the writer ships in #110 so that PR is self-contained.
+- Spec amended first (Program design): symlink/exec-bit policy,
+  `importerVersion` removal, warn-not-fail on missing `SKILL.md`.
+
+Audit (round 1 of 3): security clean; simplicity 1 low (test-helper state
+and unused returns) — accepted, fixed in `eb3f515`.
+
+Gate re-run: `npm test` 11/11; old skip conjunction 0 hits; `treeDiffers`
+3; `npm test` in CI 2. Human-verify item unchanged (pending).

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
@@ -85,5 +85,34 @@ still copy a symlink — source is now listed (and its root `lstat`ed) first,
 two first-import tests added (`7ed6a67`); `test-receiver` gets an explicit
 `contents: read` token (`ec61f34`). Tests 13/13.
 
+## Iteration 2 — 2026-08-25 (local review)
+
+Input: a local review of the branch (three findings) plus Sean's decision on
+scope.
+
+- Medium, fixed — a previously imported grouping losing `skill/SKILL.md`
+  was skipped like an unonboarded one, leaving a stale skill on a green run.
+  Skip now applies only when never imported (no state entry, no
+  `skills/<name>`); otherwise the run fails. `55cfe8a`.
+- High, scope — AX-136's done-when covers `context.md`/`system.md`, which the
+  receiver never imports. Options put to Sean: narrow the issue + docs-side
+  follow-up (my recommendation), broaden and fail, broaden and warn.
+  **Decision: broaden and warn — this repo must not fail on no-ops.**
+  `hashIntermediates()` (sha256 of the two files) is stored per grouping as
+  `intermediateHash`; when it moves while `skill/` is byte-identical the run
+  prints `[warn]` (+ `::warning::` on Actions) once per upstream change and
+  imports nothing. Legacy entries seed silently. `6643f68`, `11b1738`,
+  `b74cec5` (null — both intermediates deleted — counts as a move).
+- #110's description said the ordering key was introduced here — rewritten.
+
+Audit (round 2 of 3): security clean. Simplicity 2 medium — (1) warn-once
+persistence is discarded by the workflow until #110's `state_changed` gate:
+**rejected**, that gate is #110's by decision and the persistence is correct
+the moment it lands, documented in code; (2) `if (prev && intermediateHash)`
+ignored a hash→null transition: **accepted**, `b74cec5`.
+
+Gate: `npm test` 22/22; old skip conjunction 0; `treeDiffers` 3; `npm test`
+in CI 2. Human-verify item still pending.
+
 Gate re-run: `npm test` 11/11; old skip conjunction 0 hits; `treeDiffers`
 3; `npm test` in CI 2. Human-verify item unchanged (pending).

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md
@@ -79,5 +79,11 @@ Dispositions:
 Audit (round 1 of 3): security clean; simplicity 1 low (test-helper state
 and unused returns) — accepted, fixed in `eb3f515`.
 
+Post-push CodeRabbit (2, both accepted): `treeDiffers` short-circuited on a
+missing destination before listing the source, so a first import could
+still copy a symlink — source is now listed (and its root `lstat`ed) first,
+two first-import tests added (`7ed6a67`); `test-receiver` gets an explicit
+`contents: read` token (`ec61f34`). Tests 13/13.
+
 Gate re-run: `npm test` 11/11; old skip conjunction 0 hits; `treeDiffers`
 3; `npm test` in CI 2. Human-verify item unchanged (pending).

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
@@ -1,0 +1,106 @@
+# 2026-08-19 — AX-136: receiver imports on byte difference
+
+## Intent
+
+A hand edit to a grouping's `skill/**` upstream in netlify/docs propagates to
+context-and-tools on the next dispatch, exactly like a machine regeneration.
+Silent skips of real content changes are eliminated: after this lands,
+"changed" means the imported surface actually differs, byte for byte.
+
+Live victim this must fix: netlify/docs#801 hand-edits
+`agent-context/frameworks/skill/SKILL.md` and
+`skill/references/nextjs.md` without touching `manifest.json` — today the
+receiver logs `[skip] frameworks: unchanged` and delivers nothing.
+
+## Scope
+
+- In: delta logic in `scripts/ctx-receive.mjs`; a zero-dependency test script;
+  a CI step running it in `.github/workflows/validate-skills.yml`; the header
+  "Delta:" comment updated to describe the new rule.
+- Out: docs-side detection or refusal machinery; notifications (AX-138);
+  consumer staleness monitoring (AX-143); the receive workflow's PR mechanics
+  (`ctx-pipeline-receive.yml` is untouched); any content change under `skills/`.
+
+## Plan
+
+1. **Byte-diff delta in `scripts/ctx-receive.mjs`** — replace the
+   `prev.sourceHash === sourceHash && prev.importerVersion === importerVersion`
+   skip (currently line 112) with a tree comparison: a grouping is changed iff
+   `agent-context/<grouping>/skill/**` differs from `skills/<skill>/**`
+   (relative-path set + file bytes; missing destination = changed). Keep the
+   mapping-drift name check, the provenance state write on import, `--dry-run`
+   behavior, and the `GITHUB_OUTPUT` contract (`changed`, `changed_count`)
+   unchanged. Update the header comment.
+   - Check: covered by the slice-2 test (hand-edited fixture reports
+     `[import]`, not `[skip]`).
+2. **Test script** — new `scripts/ctx-receive.test.mjs`, zero-dependency
+   (node:assert, node:fs, temp dirs; Node 18+ built-ins only, matching the
+   script it tests). Cases: first import; identical re-dispatch → no change
+   reported and no import; hand edit to `skill/SKILL.md` +
+   `skill/references/<file>.md` (the docs#801 shape) → import; `changed_count`
+   written correctly to a fake `GITHUB_OUTPUT`. Wire `npm test` in
+   package.json to run it.
+   - Check: `npm test` exits 0.
+3. **CI wiring** — run the test in `.github/workflows/validate-skills.yml`
+   (a step or small job invoking `npm test`).
+   - Check: `rg -c "npm test" .github/workflows/validate-skills.yml` ≥ 1.
+
+## Program design
+
+- New helper `treeDiffers(srcDir, destDir)` → boolean. Recursive
+  relative-path listing (files only) of both trees; differ when the path sets
+  differ or any file's bytes differ. Missing `destDir` → true.
+- `changed` ⟺ `treeDiffers(...)`. The state entry (`sourceHash`,
+  `docsCommit`, `importerVersion`, `affects`) is still written on import —
+  provenance only, never consulted for skipping.
+- Known accepted edge (document in the header comment): a regeneration whose
+  output is byte-identical imports nothing and writes no state, so
+  `state.json` provenance may lag the newest `source_hash`. Harmless — and it
+  fixes a latent failure: today a re-import of identical bytes makes the
+  workflow's `git commit` fail on an empty stage. After this change,
+  `changed_count > 0` always implies a real git diff.
+
+## Exemplars
+
+- `scripts/ctx-receive.mjs` itself — zero-dep style, `fail()` conventions,
+  comment density.
+
+## Done-signal
+
+- `npm test` exits 0 and the suite includes the hand-edit-propagates case and
+  the identical-re-dispatch-no-op case.
+- `rg -n "prev.sourceHash === sourceHash && prev.importerVersion" scripts/ctx-receive.mjs`
+  → 0 hits. (Amended mid-run by the orchestrator: the original blunter grep —
+  any `prev.sourceHash === sourceHash` — caught a benign log-only comparison
+  that labels the hand-edit case in the `[import]` reason string; the skip
+  decision itself must consult only `treeDiffers`, which the next check pins.)
+- `rg -c "treeDiffers" scripts/ctx-receive.mjs` ≥ 2 (definition + the skip
+  decision).
+- `rg -c "npm test" .github/workflows/validate-skills.yml` ≥ 1.
+- human-verify: after netlify/docs#801 merges, the next receive run's rolling
+  sync PR contains the Next.js fetch-skew qualification.
+
+## Audit lenses
+
+- simplicity
+- security
+
+## Issue
+
+AX-136 — https://linear.app/netlify/issue/AX-136/stage-2-receiver-silently-skips-hand-edited-upstream-skills
+
+## Branch
+
+seandavis/ax-136-stage-2-receiver-silently-skips-hand-edited-upstream-skills
+
+## Guardrails
+
+- Loop bound: 3 audit/fix rounds.
+- End by opening a PR — ready if the completeness gate passes clean, draft
+  otherwise; never merge or deploy.
+- PR title must be semantic (`fix: …`) — this repo's CI lints PR titles.
+- No Claude attribution on commits or the PR body.
+
+## External dependencies
+
+none

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
@@ -49,10 +49,23 @@ receiver logs `[skip] frameworks: unchanged` and delivers nothing.
 
 - New helper `treeDiffers(srcDir, destDir)` → boolean. Recursive
   relative-path listing (files only) of both trees; differ when the path sets
-  differ or any file's bytes differ. Missing `destDir` → true.
+  differ, any file's bytes differ, or any file's executable bit differs (the
+  only mode bit git tracks — `cpSync` copies modes, so the gate must see
+  them). Missing `destDir`, or a `destDir` that exists but is not a directory
+  → true (the import's `rmSync` + `cpSync` repairs it). Symlinks and other
+  non-regular entries in either tree fail the run loudly — `cpSync` would
+  copy them but the gate can't compare them, so they are declared
+  unsupported rather than silently skipped.
 - `changed` ⟺ `treeDiffers(...)`. The state entry (`sourceHash`,
-  `docsCommit`, `importerVersion`, `affects`) is still written on import —
-  provenance only, never consulted for skipping.
+  `docsCommit`, `affects`) is still written on import — provenance only,
+  never consulted for skipping. `importerVersion` is removed (config, state,
+  README): with a faithful byte copy there is no import logic whose change
+  could alter output, and a forced re-import of identical bytes would only
+  recreate the empty-commit failure.
+- A grouping whose `skill/SKILL.md` is missing is skipped with a warning
+  (same as a missing manifest) rather than failing the run — one unfinished
+  grouping must not block the other twelve. (Review amendment, 2026-08-25:
+  the first run made this check a hard `fail()`.)
 - Known accepted edge (document in the header comment): a regeneration whose
   output is byte-identical imports nothing and writes no state, so
   `state.json` provenance may lag the newest `source_hash`. Harmless — and it

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
@@ -17,9 +17,11 @@ receiver logs `[skip] frameworks: unchanged` and delivers nothing.
 - In: delta logic in `scripts/ctx-receive.mjs`; a zero-dependency test script;
   a CI step running it in `.github/workflows/validate-skills.yml`; the header
   "Delta:" comment updated to describe the new rule.
-- Out: docs-side detection or refusal machinery; notifications (AX-138);
-  consumer staleness monitoring (AX-143); the receive workflow's PR mechanics
-  (`ctx-pipeline-receive.yml` is untouched); any content change under `skills/`.
+- Out: docs-side refusal machinery (the receiver warns on intermediate drift —
+  see Program design — but a hard check that `skill/` is regenerated belongs
+  in docs CI); notifications (AX-138); consumer staleness monitoring (AX-143);
+  the receive workflow's PR mechanics (`ctx-pipeline-receive.yml` is
+  untouched); any content change under `skills/`.
 
 ## Plan
 
@@ -69,6 +71,16 @@ receiver logs `[skip] frameworks: unchanged` and delivers nothing.
   upstream deletion must not leave a stale skill in place silently. (Review
   amendment, 2026-08-25: the first run made this check a hard `fail()`;
   narrowed the same day on local review.)
+- `hashIntermediates(groupingDir)` → sha256 over `context.md` + `system.md`
+  (the docs-side inputs the skill is generated from; `null` when neither
+  exists), remembered per grouping as `intermediateHash` in `state.json`. When
+  it moves while `skill/**` is byte-identical, the run prints `[warn]` (plus a
+  `::warning` annotation under GitHub Actions), stores the new hash so the
+  warning fires once per upstream change rather than every run, and imports
+  nothing. A legacy entry with no `intermediateHash` is seeded silently —
+  there is no baseline to compare against. Decision (2026-08-25, Sean): warn,
+  never fail — this repo must not fail on no-ops, and the receiver can't tell
+  "forgot to regenerate" from "regeneration was a no-op".
 - Known accepted edge (document in the header comment): a regeneration whose
   output is byte-identical imports nothing and writes no state, so
   `state.json` provenance may lag the newest `source_hash`. Harmless — and it
@@ -83,8 +95,8 @@ receiver logs `[skip] frameworks: unchanged` and delivers nothing.
 
 ## Done-signal
 
-- `npm test` exits 0 and the suite includes the hand-edit-propagates case and
-  the identical-re-dispatch-no-op case.
+- `npm test` exits 0 and the suite includes the hand-edit-propagates case,
+  the identical-re-dispatch-no-op case, and the intermediate-drift-warns case.
 - `rg -n "prev.sourceHash === sourceHash && prev.importerVersion" scripts/ctx-receive.mjs`
   → 0 hits. (Amended mid-run by the orchestrator: the original blunter grep —
   any `prev.sourceHash === sourceHash` — caught a benign log-only comparison

--- a/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
+++ b/docs/autopilot/2026-08-19-ax-136-receiver-byte-diff.md
@@ -63,9 +63,12 @@ receiver logs `[skip] frameworks: unchanged` and delivers nothing.
   could alter output, and a forced re-import of identical bytes would only
   recreate the empty-commit failure.
 - A grouping whose `skill/SKILL.md` is missing is skipped with a warning
-  (same as a missing manifest) rather than failing the run — one unfinished
-  grouping must not block the other twelve. (Review amendment, 2026-08-25:
-  the first run made this check a hard `fail()`.)
+  (same as a missing manifest) only when it has never been imported — no
+  state entry and no `skills/<name>` on disk — so one not-yet-onboarded
+  grouping does not block the other twelve. Otherwise the run fails: an
+  upstream deletion must not leave a stale skill in place silently. (Review
+  amendment, 2026-08-25: the first run made this check a hard `fail()`;
+  narrowed the same day on local review.)
 - Known accepted edge (document in the header comment): a regeneration whose
   output is byte-identical imports nothing and writes no state, so
   `state.json` provenance may lag the newest `source_hash`. Harmless — and it

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Public Netlify skills for AI coding agents. Each skill is a focused, factual reference for a Netlify platform primitive — designed to help agents build correctly on Netlify without needing to search docs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node scripts/ctx-receive.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -8,9 +8,20 @@
 // so a faithful copy is enough (test-where-the-mutation-happens). If we ever
 // start transforming content here, that is when this repo earns its own AXIS.
 //
-// Delta: each grouping is keyed on `manifest.generation.source_hash` plus the
-// importer version. Unchanged source_hash → skip. So repeated dispatches of the
-// same docs commit are no-ops, and only real content changes open a PR.
+// Delta: a grouping is "changed" iff `agent-context/<grouping>/skill/**` (in
+// the docs checkout) differs from `skills/<skill>/**` in this repo — the
+// relative-path set plus file bytes, computed by treeDiffers() below. A
+// missing destination directory counts as changed. manifest.generation
+// .source_hash, docsCommit, and importerVersion are still written to
+// state.json on import, but purely as provenance — they are never consulted
+// to decide skip vs. import.
+//
+// Accepted edge: a regeneration whose output is byte-identical to what's
+// already imported imports nothing and writes no state entry, so state.json
+// provenance can lag the newest source_hash. Harmless, and it guarantees
+// changed_count > 0 always implies a real git diff — previously, re-importing
+// byte-identical content could make the workflow's `git commit` fail on an
+// empty stage.
 //
 // Zero dependencies, Node 18+ (uses fs.cpSync / fs.rmSync).
 //
@@ -86,6 +97,45 @@ function unionAffects(changes) {
   return [...set].sort();
 }
 
+// Relative POSIX-style paths of every regular file under `dir`, recursive,
+// sorted. Symlinks and empty directories are not represented — only files
+// matter for the delta.
+function listFiles(dir) {
+  const out = [];
+  (function walk(current, prefix) {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const abs = path.join(current, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else if (entry.isFile()) {
+        out.push(rel);
+      }
+    }
+  })(dir, '');
+  return out.sort();
+}
+
+// True iff `srcDir` and `destDir` differ: a different relative-path set of
+// files, or any shared-path file with different bytes. A missing `destDir`
+// counts as different (e.g. first import).
+function treeDiffers(srcDir, destDir) {
+  if (!fs.existsSync(destDir)) return true;
+
+  const srcFiles = listFiles(srcDir);
+  const destFiles = listFiles(destDir);
+  if (srcFiles.length !== destFiles.length) return true;
+
+  const destSet = new Set(destFiles);
+  for (const rel of srcFiles) {
+    if (!destSet.has(rel)) return true;
+    const a = fs.readFileSync(path.join(srcDir, rel));
+    const b = fs.readFileSync(path.join(destDir, rel));
+    if (!a.equals(b)) return true;
+  }
+  return false;
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   const config = readJson(opts.config);
@@ -108,15 +158,17 @@ function main() {
     const sourceHash = manifest.generation?.source_hash;
     if (!sourceHash) fail(`${manifestPath}: missing generation.source_hash`);
 
-    const prev = state[grouping];
-    if (prev && prev.sourceHash === sourceHash && prev.importerVersion === importerVersion) {
-      console.log(`[skip] ${grouping}: unchanged (source_hash ${sourceHash.slice(0, 12)})`);
-      continue;
-    }
-
     const skillSrc = path.join(groupingDir, 'skill');
     if (!fs.existsSync(path.join(skillSrc, 'SKILL.md'))) {
-      fail(`${grouping}: changed but ${skillSrc}/SKILL.md is missing`);
+      fail(`${grouping}: ${skillSrc}/SKILL.md is missing`);
+    }
+
+    const prev = state[grouping];
+    const dest = path.join(opts.skillsDir, skill);
+
+    if (!treeDiffers(skillSrc, dest)) {
+      console.log(`[skip] ${grouping}: surface identical (source_hash ${sourceHash.slice(0, 12)})`);
+      continue;
     }
 
     // Defend against mapping drift: the generated skill must own the name we map to.
@@ -125,9 +177,12 @@ function main() {
       fail(`${grouping}: mapping says skill "${skill}" but generated SKILL.md declares name "${declaredName}"`);
     }
 
-    const dest = path.join(opts.skillsDir, skill);
     const affects = unionAffects(manifest.changes);
-    const reason = prev ? `source_hash ${prev.sourceHash.slice(0, 12)} → ${sourceHash.slice(0, 12)}` : 'first import';
+    const reason = !prev
+      ? 'first import'
+      : prev.sourceHash === sourceHash
+        ? `hand edit (source_hash unchanged at ${sourceHash.slice(0, 12)})`
+        : `source_hash ${prev.sourceHash.slice(0, 12)} → ${sourceHash.slice(0, 12)}`;
     console.log(`[import] ${grouping} → ${dest} (${reason}; affects: ${affects.join(', ') || 'n/a'})`);
 
     if (!opts.dryRun) {

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -17,11 +17,20 @@
 // to decide skip vs. import.
 //
 // Accepted edge: a regeneration whose output is byte-identical to what's
-// already imported imports nothing and writes no state entry, so state.json
-// provenance can lag the newest source_hash. Harmless, and it guarantees
-// changed_count > 0 always implies a real git diff — previously, re-importing
-// byte-identical content could make the workflow's `git commit` fail on an
-// empty stage.
+// already imported imports nothing and writes no per-grouping state entry, so
+// per-grouping provenance can lag the newest source_hash. Harmless, and it
+// guarantees changed_count > 0 always implies a real git diff — previously,
+// re-importing byte-identical content could make the workflow's `git commit`
+// fail on an empty stage.
+//
+// Ordering vs. provenance: the per-grouping entries above are a provenance
+// LOG and are allowed to lag. The top-level `lastImportedCommit` is the
+// ordering AUTHORITY and is written on EVERY non-dry run, no-op included, so
+// a consumer can always answer "what did we last import?" without aggregating
+// per-grouping entries. Deriving position from provenance is what breaks when
+// entries legitimately disagree — see the monotonicity guard in
+// .github/workflows/ctx-pipeline-receive.yml, which must read this key rather
+// than reconciling docsCommit across entries.
 //
 // Zero dependencies, Node 18+ (uses fs.cpSync / fs.rmSync).
 //
@@ -40,6 +49,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+
+// Reserved top-level key in state.json: the ordering authority. Never a
+// grouping name — see the collision check in main().
+const ORDERING_KEY = 'lastImportedCommit';
 
 function parseArgs(argv) {
   const opts = {
@@ -144,6 +157,13 @@ function main() {
   const state = fs.existsSync(opts.state) ? readJson(opts.state) : {};
   const changed = [];
 
+  // `lastImportedCommit` is a reserved top-level key, not a grouping entry.
+  // Fail loudly rather than let a grouping of that name shadow the ordering
+  // authority.
+  if (config.groupings.some(({ grouping }) => grouping === ORDERING_KEY)) {
+    fail(`"${ORDERING_KEY}" is reserved for the ordering key and can't be a grouping name`);
+  }
+
   for (const { grouping, skill } of config.groupings) {
     const groupingDir = path.join(opts.docs, agentContextDir, grouping);
     const manifestPath = path.join(groupingDir, 'manifest.json');
@@ -203,16 +223,29 @@ function main() {
     changed.push(grouping);
   }
 
-  if (!opts.dryRun && changed.length) {
-    fs.writeFileSync(opts.state, JSON.stringify(state, null, 2) + '\n');
-  }
+  // The ordering key advances on every run, imports or not — that's what makes
+  // it usable for ordering. Only write when we were actually told which commit
+  // we're importing; inventing one from a manifest would record a position we
+  // can't defend.
+  if (!opts.dryRun && opts.docsCommit) state[ORDERING_KEY] = opts.docsCommit;
+
+  const nextState = JSON.stringify(state, null, 2) + '\n';
+  const stateChanged =
+    !opts.dryRun && (!fs.existsSync(opts.state) || fs.readFileSync(opts.state, 'utf8') !== nextState);
+  if (stateChanged) fs.writeFileSync(opts.state, nextState);
 
   console.log(changed.length ? `\nChanged: ${changed.join(', ')}` : '\nNo changes.');
+  if (stateChanged && !changed.length) {
+    console.log(`State advanced to ${opts.docsCommit.slice(0, 12)} with no skill changes.`);
+  }
 
   if (process.env.GITHUB_OUTPUT) {
+    // `state_changed` exists so the workflow can commit an ordering-only
+    // advance. Gating the commit on changed_count alone would write the key
+    // and then discard it, leaving the guard reading a stale position.
     fs.appendFileSync(
       process.env.GITHUB_OUTPUT,
-      `changed=${changed.join(',')}\nchanged_count=${changed.length}\n`,
+      `changed=${changed.join(',')}\nchanged_count=${changed.length}\nstate_changed=${stateChanged}\n`,
     );
   }
 }

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -126,11 +126,10 @@ function treeDiffers(srcDir, destDir) {
   const destFiles = listFiles(destDir);
   if (srcFiles.length !== destFiles.length) return true;
 
-  const destSet = new Set(destFiles);
-  for (const rel of srcFiles) {
-    if (!destSet.has(rel)) return true;
-    const a = fs.readFileSync(path.join(srcDir, rel));
-    const b = fs.readFileSync(path.join(destDir, rel));
+  for (let i = 0; i < srcFiles.length; i++) {
+    if (srcFiles[i] !== destFiles[i]) return true;
+    const a = fs.readFileSync(path.join(srcDir, srcFiles[i]));
+    const b = fs.readFileSync(path.join(destDir, destFiles[i]));
     if (!a.equals(b)) return true;
   }
   return false;
@@ -178,11 +177,16 @@ function main() {
     }
 
     const affects = unionAffects(manifest.changes);
+    // Factual, not inferential: this only states what changed and what
+    // didn't. An unchanged source_hash with a differing surface can mean an
+    // upstream hand edit (docs#801 shape) or local drift in skills/ — either
+    // way, the import below restores parity with the source.
+    const prevSourceHash = typeof prev?.sourceHash === 'string' ? prev.sourceHash : null;
     const reason = !prev
       ? 'first import'
-      : prev.sourceHash === sourceHash
-        ? `hand edit (source_hash unchanged at ${sourceHash.slice(0, 12)})`
-        : `source_hash ${prev.sourceHash.slice(0, 12)} → ${sourceHash.slice(0, 12)}`;
+      : prevSourceHash === sourceHash
+        ? `surface differs, source_hash unchanged at ${sourceHash.slice(0, 12)}`
+        : `source_hash ${prevSourceHash ? prevSourceHash.slice(0, 12) : '<unknown>'} → ${sourceHash.slice(0, 12)}`;
     console.log(`[import] ${grouping} → ${dest} (${reason}; affects: ${affects.join(', ') || 'n/a'})`);
 
     if (!opts.dryRun) {

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -17,20 +17,11 @@
 // to decide skip vs. import.
 //
 // Accepted edge: a regeneration whose output is byte-identical to what's
-// already imported imports nothing and writes no per-grouping state entry, so
-// per-grouping provenance can lag the newest source_hash. Harmless, and it
-// guarantees changed_count > 0 always implies a real git diff — previously,
-// re-importing byte-identical content could make the workflow's `git commit`
-// fail on an empty stage.
-//
-// Ordering vs. provenance: the per-grouping entries above are a provenance
-// LOG and are allowed to lag. The top-level `lastImportedCommit` is the
-// ordering AUTHORITY and is written on EVERY non-dry run, no-op included, so
-// a consumer can always answer "what did we last import?" without aggregating
-// per-grouping entries. Deriving position from provenance is what breaks when
-// entries legitimately disagree — see the monotonicity guard in
-// .github/workflows/ctx-pipeline-receive.yml, which must read this key rather
-// than reconciling docsCommit across entries.
+// already imported imports nothing and writes no state entry, so state.json
+// provenance can lag the newest source_hash. Harmless, and it guarantees
+// changed_count > 0 always implies a real git diff — previously, re-importing
+// byte-identical content could make the workflow's `git commit` fail on an
+// empty stage.
 //
 // Zero dependencies, Node 18+ (uses fs.cpSync / fs.rmSync).
 //
@@ -49,10 +40,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-
-// Reserved top-level key in state.json: the ordering authority. Never a
-// grouping name — see the collision check in main().
-const ORDERING_KEY = 'lastImportedCommit';
 
 function parseArgs(argv) {
   const opts = {
@@ -157,13 +144,6 @@ function main() {
   const state = fs.existsSync(opts.state) ? readJson(opts.state) : {};
   const changed = [];
 
-  // `lastImportedCommit` is a reserved top-level key, not a grouping entry.
-  // Fail loudly rather than let a grouping of that name shadow the ordering
-  // authority.
-  if (config.groupings.some(({ grouping }) => grouping === ORDERING_KEY)) {
-    fail(`"${ORDERING_KEY}" is reserved for the ordering key and can't be a grouping name`);
-  }
-
   for (const { grouping, skill } of config.groupings) {
     const groupingDir = path.join(opts.docs, agentContextDir, grouping);
     const manifestPath = path.join(groupingDir, 'manifest.json');
@@ -223,29 +203,16 @@ function main() {
     changed.push(grouping);
   }
 
-  // The ordering key advances on every run, imports or not — that's what makes
-  // it usable for ordering. Only write when we were actually told which commit
-  // we're importing; inventing one from a manifest would record a position we
-  // can't defend.
-  if (!opts.dryRun && opts.docsCommit) state[ORDERING_KEY] = opts.docsCommit;
-
-  const nextState = JSON.stringify(state, null, 2) + '\n';
-  const stateChanged =
-    !opts.dryRun && (!fs.existsSync(opts.state) || fs.readFileSync(opts.state, 'utf8') !== nextState);
-  if (stateChanged) fs.writeFileSync(opts.state, nextState);
-
-  console.log(changed.length ? `\nChanged: ${changed.join(', ')}` : '\nNo changes.');
-  if (stateChanged && !changed.length) {
-    console.log(`State advanced to ${opts.docsCommit.slice(0, 12)} with no skill changes.`);
+  if (!opts.dryRun && changed.length) {
+    fs.writeFileSync(opts.state, JSON.stringify(state, null, 2) + '\n');
   }
 
+  console.log(changed.length ? `\nChanged: ${changed.join(', ')}` : '\nNo changes.');
+
   if (process.env.GITHUB_OUTPUT) {
-    // `state_changed` exists so the workflow can commit an ordering-only
-    // advance. Gating the commit on changed_count alone would write the key
-    // and then discard it, leaving the guard reading a stale position.
     fs.appendFileSync(
       process.env.GITHUB_OUTPUT,
-      `changed=${changed.join(',')}\nchanged_count=${changed.length}\nstate_changed=${stateChanged}\n`,
+      `changed=${changed.join(',')}\nchanged_count=${changed.length}\n`,
     );
   }
 }

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -10,9 +10,13 @@
 //
 // Delta: a grouping is "changed" iff `agent-context/<grouping>/skill/**` (in
 // the docs checkout) differs from `skills/<skill>/**` in this repo — the
-// relative-path set plus file bytes, computed by treeDiffers() below. A
-// missing destination directory counts as changed. manifest.generation
-// .source_hash, docsCommit, and importerVersion are still written to
+// relative-path set, file bytes, and the executable bit (the only mode bit
+// git tracks; cpSync copies modes, so the gate must see them), computed by
+// treeDiffers() below. A missing destination, or one that exists but is not
+// a directory, counts as changed and is replaced. Symlinks and other
+// non-regular entries in either tree are unsupported and fail the run loudly:
+// cpSync would copy them, but the gate can't compare them. manifest
+// .generation.source_hash, docsCommit, and affects are still written to
 // state.json on import, but purely as provenance — they are never consulted
 // to decide skip vs. import.
 //
@@ -98,8 +102,11 @@ function unionAffects(changes) {
 }
 
 // Relative POSIX-style paths of every regular file under `dir`, recursive,
-// sorted. Symlinks and empty directories are not represented — only files
-// matter for the delta.
+// sorted. Empty directories are not represented — only files matter for the
+// delta. Anything that is neither a regular file nor a directory fails
+// loudly: cpSync would copy it, but the delta can't compare it, so ignoring
+// it here would skip a new or retargeted symlink forever. (readdirSync with
+// withFileTypes reports a symlink as a symlink, never as its target.)
 function listFiles(dir) {
   const out = [];
   (function walk(current, prefix) {
@@ -110,17 +117,27 @@ function listFiles(dir) {
         walk(abs, rel);
       } else if (entry.isFile()) {
         out.push(rel);
+      } else {
+        fail(`${abs}: symlinks and other non-regular entries are not supported in skill trees`);
       }
     }
   })(dir, '');
   return out.sort();
 }
 
+// The only mode bit git tracks (100644 vs 100755).
+function isExecutable(file) {
+  return Boolean(fs.statSync(file).mode & 0o111);
+}
+
 // True iff `srcDir` and `destDir` differ: a different relative-path set of
-// files, or any shared-path file with different bytes. A missing `destDir`
-// counts as different (e.g. first import).
+// files, or any shared-path file with different bytes or a different
+// executable bit. A missing `destDir` (e.g. first import), or one that is
+// not a directory (a stray file or symlink at `skills/<name>`), counts as
+// different — the caller's rmSync + cpSync then replaces it.
 function treeDiffers(srcDir, destDir) {
-  if (!fs.existsSync(destDir)) return true;
+  const destStat = fs.lstatSync(destDir, { throwIfNoEntry: false });
+  if (!destStat?.isDirectory()) return true;
 
   const srcFiles = listFiles(srcDir);
   const destFiles = listFiles(destDir);
@@ -128,9 +145,10 @@ function treeDiffers(srcDir, destDir) {
 
   for (let i = 0; i < srcFiles.length; i++) {
     if (srcFiles[i] !== destFiles[i]) return true;
-    const a = fs.readFileSync(path.join(srcDir, srcFiles[i]));
-    const b = fs.readFileSync(path.join(destDir, destFiles[i]));
-    if (!a.equals(b)) return true;
+    const src = path.join(srcDir, srcFiles[i]);
+    const dest = path.join(destDir, destFiles[i]);
+    if (!fs.readFileSync(src).equals(fs.readFileSync(dest))) return true;
+    if (isExecutable(src) !== isExecutable(dest)) return true;
   }
   return false;
 }
@@ -139,7 +157,6 @@ function main() {
   const opts = parseArgs(process.argv.slice(2));
   const config = readJson(opts.config);
   const agentContextDir = config.source?.agentContextDir || 'agent-context';
-  const importerVersion = config.importerVersion ?? 1;
 
   const state = fs.existsSync(opts.state) ? readJson(opts.state) : {};
   const changed = [];
@@ -159,7 +176,10 @@ function main() {
 
     const skillSrc = path.join(groupingDir, 'skill');
     if (!fs.existsSync(path.join(skillSrc, 'SKILL.md'))) {
-      fail(`${grouping}: ${skillSrc}/SKILL.md is missing`);
+      // Same forward-compatibility as the manifest check: one unfinished
+      // grouping must not block the others.
+      console.log(`[skip] ${grouping}: ${skillSrc}/SKILL.md is missing`);
+      continue;
     }
 
     const prev = state[grouping];
@@ -196,7 +216,6 @@ function main() {
       state[grouping] = {
         sourceHash,
         docsCommit: opts.docsCommit || manifest.generated_from?.commit || null,
-        importerVersion,
         affects,
       };
     }

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -22,9 +22,17 @@
 // only if it was never imported; once imported, its disappearance fails the
 // run rather than leaving a stale skill behind.
 //
+// Intermediates: `agent-context/<grouping>/context.md` and `system.md` are
+// the docs-side inputs the skill is generated from. They are never imported;
+// their sha256 is remembered in state.json (intermediateHash) as provenance.
+// If it moves while `skill/**` stays byte-identical, the run warns once and
+// imports nothing — it never fails. The receiver can't tell "forgot to
+// regenerate" from "regeneration was a no-op", which is why this is a
+// warning; the real check belongs in docs CI.
+//
 // Accepted edge: a regeneration whose output is byte-identical to what's
-// already imported imports nothing and writes no state entry, so state.json
-// provenance can lag the newest source_hash. Harmless, and it guarantees
+// already imported imports nothing and leaves the entry's source_hash alone,
+// so state.json provenance can lag the newest source_hash. Harmless, and it guarantees
 // changed_count > 0 always implies a real git diff — previously, re-importing
 // byte-identical content could make the workflow's `git commit` fail on an
 // empty stage.
@@ -44,6 +52,7 @@
 //
 // When GITHUB_OUTPUT is set, writes `changed=<csv>` and `changed_count=<n>`.
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -101,6 +110,26 @@ function unionAffects(changes) {
   const set = new Set();
   for (const c of changes || []) for (const a of c.affects || []) set.add(a);
   return [...set].sort();
+}
+
+// sha256 over the grouping's intermediates — context.md then system.md, the
+// docs-side inputs the skill is generated from. The receiver never imports
+// them; it only remembers their hash so "intermediate edited, skill not
+// regenerated" is visible instead of silent. Each file contributes
+// `${name}\0` + bytes + `\0` only if it exists as a regular file; null when
+// neither does.
+function hashIntermediates(groupingDir) {
+  const hash = crypto.createHash('sha256');
+  let found = false;
+  for (const name of ['context.md', 'system.md']) {
+    const file = path.join(groupingDir, name);
+    if (!fs.lstatSync(file, { throwIfNoEntry: false })?.isFile()) continue;
+    hash.update(`${name}\0`);
+    hash.update(fs.readFileSync(file));
+    hash.update('\0');
+    found = true;
+  }
+  return found ? hash.digest('hex') : null;
 }
 
 // Relative POSIX-style paths of every regular file under `dir`, recursive,
@@ -200,7 +229,21 @@ function main() {
       continue;
     }
 
+    const intermediateHash = hashIntermediates(groupingDir);
+
     if (!treeDiffers(skillSrc, dest)) {
+      if (prev && intermediateHash) {
+        if (typeof prev.intermediateHash !== 'string') {
+          // Legacy entry, predates the field: seed silently — no baseline to compare.
+          prev.intermediateHash = intermediateHash;
+        } else if (prev.intermediateHash !== intermediateHash) {
+          const msg = `${grouping}: context.md/system.md changed upstream (${prev.intermediateHash.slice(0, 12)} → ${intermediateHash.slice(0, 12)}) but skill/ is byte-identical — skill may not have been regenerated; nothing imported`;
+          console.log(`[warn] ${msg}`);
+          if (process.env.GITHUB_ACTIONS) console.log(`::warning title=ctx-receive::${msg}`);
+          // Remember the new hash so this fires once per upstream change, not every run.
+          prev.intermediateHash = intermediateHash;
+        }
+      }
       console.log(`[skip] ${grouping}: surface identical (source_hash ${sourceHash.slice(0, 12)})`);
       continue;
     }
@@ -232,13 +275,22 @@ function main() {
         sourceHash,
         docsCommit: opts.docsCommit || manifest.generated_from?.commit || null,
         affects,
+        intermediateHash,
       };
     }
     changed.push(grouping);
   }
 
-  if (!opts.dryRun && changed.length) {
-    fs.writeFileSync(opts.state, JSON.stringify(state, null, 2) + '\n');
+  // Written whenever the serialized state moved — an import, or a seeded /
+  // updated intermediateHash with zero imports. The receive workflow still
+  // commits only when changed_count != 0, so a hash-only update is discarded
+  // on the runner until #110's state_changed gate lands; until then the
+  // warning repeats each run until an import or #110. Acceptable.
+  if (!opts.dryRun) {
+    const nextState = JSON.stringify(state, null, 2) + '\n';
+    const current = fs.existsSync(opts.state) ? fs.readFileSync(opts.state, 'utf8') : null;
+    const stateChanged = current !== nextState;
+    if (stateChanged) fs.writeFileSync(opts.state, nextState);
   }
 
   console.log(changed.length ? `\nChanged: ${changed.join(', ')}` : '\nNo changes.');

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -132,6 +132,11 @@ function hashIntermediates(groupingDir) {
   return found ? hash.digest('hex') : null;
 }
 
+// For log lines: a hash → its first 12 chars, null → "none".
+function shortHash(hash) {
+  return typeof hash === 'string' ? hash.slice(0, 12) : 'none';
+}
+
 // Relative POSIX-style paths of every regular file under `dir`, recursive,
 // sorted. Empty directories are not represented — only files matter for the
 // delta. Anything that is neither a regular file nor a directory fails
@@ -232,12 +237,15 @@ function main() {
     const intermediateHash = hashIntermediates(groupingDir);
 
     if (!treeDiffers(skillSrc, dest)) {
-      if (prev && intermediateHash) {
-        if (typeof prev.intermediateHash !== 'string') {
-          // Legacy entry, predates the field: seed silently — no baseline to compare.
+      if (prev) {
+        if (!('intermediateHash' in prev)) {
+          // Legacy entry, predates the field: seed silently (possibly with
+          // null) — no baseline to compare.
           prev.intermediateHash = intermediateHash;
         } else if (prev.intermediateHash !== intermediateHash) {
-          const msg = `${grouping}: context.md/system.md changed upstream (${prev.intermediateHash.slice(0, 12)} → ${intermediateHash.slice(0, 12)}) but skill/ is byte-identical — skill may not have been regenerated; nothing imported`;
+          // null is a real value here: both intermediates deleted upstream
+          // with the skill untouched is drift too.
+          const msg = `${grouping}: context.md/system.md changed upstream (${shortHash(prev.intermediateHash)} → ${shortHash(intermediateHash)}) but skill/ is byte-identical — skill may not have been regenerated; nothing imported`;
           console.log(`[warn] ${msg}`);
           if (process.env.GITHUB_ACTIONS) console.log(`::warning title=ctx-receive::${msg}`);
           // Remember the new hash so this fires once per upstream change, not every run.

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -18,7 +18,9 @@
 // cpSync would copy them, but the gate can't compare them. manifest
 // .generation.source_hash, docsCommit, and affects are still written to
 // state.json on import, but purely as provenance — they are never consulted
-// to decide skip vs. import.
+// to decide skip vs. import. A grouping with no `skill/SKILL.md` is skipped
+// only if it was never imported; once imported, its disappearance fails the
+// run rather than leaving a stale skill behind.
 //
 // Accepted edge: a regeneration whose output is byte-identical to what's
 // already imported imports nothing and writes no state entry, so state.json
@@ -185,15 +187,18 @@ function main() {
     if (!sourceHash) fail(`${manifestPath}: missing generation.source_hash`);
 
     const skillSrc = path.join(groupingDir, 'skill');
+    const prev = state[grouping];
+    const dest = path.join(opts.skillsDir, skill);
+
     if (!fs.existsSync(path.join(skillSrc, 'SKILL.md'))) {
-      // Same forward-compatibility as the manifest check: one unfinished
-      // grouping must not block the others.
+      if (prev || fs.lstatSync(dest, { throwIfNoEntry: false })) {
+        fail(`${grouping}: ${skillSrc}/SKILL.md is missing but this grouping was imported before (state entry or ${dest} exists) — refusing to leave a stale skill in place`);
+      }
+      // Never imported: same forward-compatibility as the manifest check —
+      // one not-yet-onboarded grouping must not block the others.
       console.log(`[skip] ${grouping}: ${skillSrc}/SKILL.md is missing`);
       continue;
     }
-
-    const prev = state[grouping];
-    const dest = path.join(opts.skillsDir, skill);
 
     if (!treeDiffers(skillSrc, dest)) {
       console.log(`[skip] ${grouping}: surface identical (source_hash ${sourceHash.slice(0, 12)})`);

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -106,8 +106,15 @@ function unionAffects(changes) {
 // delta. Anything that is neither a regular file nor a directory fails
 // loudly: cpSync would copy it, but the delta can't compare it, so ignoring
 // it here would skip a new or retargeted symlink forever. (readdirSync with
-// withFileTypes reports a symlink as a symlink, never as its target.)
+// withFileTypes reports a symlink as a symlink, never as its target.) The
+// root gets the same treatment: existsSync on `skill/SKILL.md` happily
+// follows a symlinked `skill/`, so the check has to happen here.
 function listFiles(dir) {
+  const rootStat = fs.lstatSync(dir, { throwIfNoEntry: false });
+  if (!rootStat?.isDirectory()) {
+    fail(`${dir}: not a directory (symlinked or missing skill trees are not supported)`);
+  }
+
   const out = [];
   (function walk(current, prefix) {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
@@ -134,12 +141,15 @@ function isExecutable(file) {
 // files, or any shared-path file with different bytes or a different
 // executable bit. A missing `destDir` (e.g. first import), or one that is
 // not a directory (a stray file or symlink at `skills/<name>`), counts as
-// different — the caller's rmSync + cpSync then replaces it.
+// different — the caller's rmSync + cpSync then replaces it. The source tree
+// is listed (and so validated) before that short-circuit: otherwise a first
+// import would never see an unsupported entry, and cpSync would copy it.
 function treeDiffers(srcDir, destDir) {
+  const srcFiles = listFiles(srcDir);
+
   const destStat = fs.lstatSync(destDir, { throwIfNoEntry: false });
   if (!destStat?.isDirectory()) return true;
 
-  const srcFiles = listFiles(srcDir);
   const destFiles = listFiles(destDir);
   if (srcFiles.length !== destFiles.length) return true;
 

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// ctx-receive.test.mjs — zero-dependency test suite for scripts/ctx-receive.mjs (AX-136).
+//
+// Builds a throwaway fixture: a fake docs checkout (agent-context/<grouping>/manifest.json
+// + skill/**) and a fake consumer repo (.ctx-gen/config.json, state.json, skills/), then
+// runs ctx-receive.mjs against it as a child process and asserts on stdout, the resulting
+// skills/ tree, state.json, and the GITHUB_OUTPUT contract.
+//
+// Covers the docs#801 shape this fixes: a hand edit to skill/SKILL.md and
+// skill/references/*.md that does NOT touch manifest.json must still import — the delta is
+// treeDiffers(), never source_hash.
+//
+// Zero dependencies, Node 18+ (node:test, node:assert/strict, node:child_process).
+//
+// Usage: node scripts/ctx-receive.test.mjs   (also wired as `npm test`)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(__dirname, 'ctx-receive.mjs');
+
+const GROUPING = 'widgets';
+const SKILL_NAME = 'netlify-widgets';
+const SOURCE_HASH = 'a'.repeat(64);
+
+const SKILL_MD = `---
+name: ${SKILL_NAME}
+description: A test skill for the widgets grouping.
+---
+
+# Widgets
+
+Body content for the widgets skill.
+`;
+
+const REFERENCE_MD = `# Widgets reference
+
+Some reference detail.
+`;
+
+function writeSkillTree(skillDir, { skillMd = SKILL_MD, referenceMd = REFERENCE_MD } = {}) {
+  fs.mkdirSync(path.join(skillDir, 'references'), { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillMd);
+  fs.writeFileSync(path.join(skillDir, 'references', 'widgets.md'), referenceMd);
+}
+
+function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = 'docs-commit-1' } = {}) {
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        generation: { source_hash: sourceHash },
+        generated_from: { commit },
+        changes: [{ affects: ['examples'] }],
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+}
+
+// Builds a fresh fixture: a fake docs checkout (docsDir) + a fake consumer repo (repoDir),
+// wired together via config.json, matching the shape ctx-receive.mjs expects.
+function buildFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-receive-test-'));
+  const docsDir = path.join(root, 'docs');
+  const repoDir = path.join(root, 'repo');
+
+  const groupingDir = path.join(docsDir, 'agent-context', GROUPING);
+  const skillSrc = path.join(groupingDir, 'skill');
+  writeSkillTree(skillSrc);
+  writeManifest(path.join(groupingDir, 'manifest.json'));
+
+  const configPath = path.join(repoDir, '.ctx-gen', 'config.json');
+  const statePath = path.join(repoDir, '.ctx-gen', 'state.json');
+  const skillsDir = path.join(repoDir, 'skills');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.mkdirSync(skillsDir, { recursive: true });
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        source: { agentContextDir: 'agent-context' },
+        importerVersion: 1,
+        groupings: [{ grouping: GROUPING, skill: SKILL_NAME }],
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  fs.writeFileSync(statePath, '{}\n');
+
+  return { root, docsDir, repoDir, configPath, statePath, skillsDir, groupingDir, skillSrc };
+}
+
+let runCount = 0;
+
+// Runs ctx-receive.mjs against a fixture as a child process. Returns stdout plus the parsed
+// GITHUB_OUTPUT contract (`changed` as an array, `changed_count` as a number).
+function run(fixture, extraArgs = []) {
+  runCount += 1;
+  const outputPath = path.join(fixture.root, `github-output-${runCount}`);
+  fs.writeFileSync(outputPath, '');
+
+  const args = [
+    SCRIPT,
+    '--docs', fixture.docsDir,
+    '--docs-commit', 'docs-commit-1',
+    '--config', fixture.configPath,
+    '--state', fixture.statePath,
+    '--skills-dir', fixture.skillsDir,
+    ...extraArgs,
+  ];
+  const stdout = execFileSync('node', args, {
+    env: { ...process.env, GITHUB_OUTPUT: outputPath },
+    encoding: 'utf8',
+  });
+
+  const raw = fs.readFileSync(outputPath, 'utf8');
+  const lines = raw.split('\n').filter(Boolean);
+  const changedLine = lines.find((l) => l.startsWith('changed='));
+  const countLine = lines.find((l) => l.startsWith('changed_count='));
+  assert.ok(changedLine, `GITHUB_OUTPUT missing changed= line:\n${raw}`);
+  assert.ok(countLine, `GITHUB_OUTPUT missing changed_count= line:\n${raw}`);
+  const changed = changedLine.slice('changed='.length).split(',').filter(Boolean);
+  const changedCount = Number(countLine.slice('changed_count='.length));
+
+  return { stdout, raw, changed, changedCount };
+}
+
+function readState(fixture) {
+  return JSON.parse(fs.readFileSync(fixture.statePath, 'utf8'));
+}
+
+function readSkillBytes(fixture, ...segments) {
+  return fs.readFileSync(path.join(fixture.skillsDir, SKILL_NAME, ...segments));
+}
+
+test('ctx-receive: byte-diff import delta', async (t) => {
+  const fixture = buildFixture();
+
+  await t.test('first import: grouping imported, bytes match source, state written', () => {
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[import\] widgets .*first import/);
+    assert.deepEqual(result.changed, [GROUPING]);
+    assert.equal(result.changedCount, 1);
+
+    assert.deepEqual(
+      readSkillBytes(fixture, 'SKILL.md'),
+      fs.readFileSync(path.join(fixture.skillSrc, 'SKILL.md')),
+    );
+    assert.deepEqual(
+      readSkillBytes(fixture, 'references', 'widgets.md'),
+      fs.readFileSync(path.join(fixture.skillSrc, 'references', 'widgets.md')),
+    );
+
+    const state = readState(fixture);
+    assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
+    assert.equal(state[GROUPING].docsCommit, 'docs-commit-1');
+    assert.equal(state[GROUPING].importerVersion, 1);
+    assert.deepEqual(state[GROUPING].affects, ['examples']);
+  });
+
+  const stateAfterFirstImport = readState(fixture);
+
+  await t.test('identical re-dispatch: no changes reported, no import', () => {
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[skip\] widgets: surface identical/);
+    assert.deepEqual(result.changed, []);
+    assert.equal(result.changedCount, 0);
+    assert.deepEqual(readState(fixture), stateAfterFirstImport);
+  });
+
+  // The docs#801 shape: SKILL.md and a references/*.md file are hand-edited upstream, but
+  // manifest.json (and its generation.source_hash) is never touched.
+  const editedSkillMd = SKILL_MD + '\n<!-- hand edit: docs#801 shape -->\n';
+  const editedReferenceMd = `${REFERENCE_MD}\nHand-edited detail that never touched manifest.json.\n`;
+
+  await t.test('hand edit, --dry-run: reports import, writes nothing', () => {
+    writeSkillTree(fixture.skillSrc, { skillMd: editedSkillMd, referenceMd: editedReferenceMd });
+
+    const result = run(fixture, ['--dry-run']);
+
+    assert.match(result.stdout, /\[import\] widgets .*hand edit \(source_hash unchanged/);
+    assert.deepEqual(result.changed, [GROUPING]);
+    assert.equal(result.changedCount, 1);
+
+    // Dry-run reports the delta but must not touch skills/ or state.json.
+    assert.notDeepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(editedSkillMd));
+    assert.deepEqual(readState(fixture), stateAfterFirstImport);
+  });
+
+  await t.test('hand edit propagates: grouping changed, edit lands in skills/, state updated', () => {
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[import\] widgets .*hand edit \(source_hash unchanged/);
+    assert.deepEqual(result.changed, [GROUPING]);
+    assert.equal(result.changedCount, 1);
+
+    assert.deepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(editedSkillMd));
+    assert.deepEqual(
+      readSkillBytes(fixture, 'references', 'widgets.md'),
+      Buffer.from(editedReferenceMd),
+    );
+
+    // Provenance is rewritten even though source_hash didn't move — it's informational only.
+    const state = readState(fixture);
+    assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
+  });
+
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+});

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -189,7 +189,7 @@ test('ctx-receive: byte-diff import delta', async (t) => {
 
     const result = run(fixture, ['--dry-run']);
 
-    assert.match(result.stdout, /\[import\] widgets .*hand edit \(source_hash unchanged/);
+    assert.match(result.stdout, /\[import\] widgets .*surface differs, source_hash unchanged/);
     assert.deepEqual(result.changed, [GROUPING]);
     assert.equal(result.changedCount, 1);
 
@@ -201,7 +201,7 @@ test('ctx-receive: byte-diff import delta', async (t) => {
   await t.test('hand edit propagates: grouping changed, edit lands in skills/, state updated', () => {
     const result = run(fixture);
 
-    assert.match(result.stdout, /\[import\] widgets .*hand edit \(source_hash unchanged/);
+    assert.match(result.stdout, /\[import\] widgets .*surface differs, source_hash unchanged/);
     assert.deepEqual(result.changed, [GROUPING]);
     assert.equal(result.changedCount, 1);
 

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -103,7 +103,7 @@ let runCount = 0;
 
 // Runs ctx-receive.mjs against a fixture as a child process. Returns stdout plus the parsed
 // GITHUB_OUTPUT contract (`changed` as an array, `changed_count` as a number).
-function run(fixture, extraArgs = []) {
+function run(fixture, extraArgs = [], { docsCommit = 'docs-commit-1' } = {}) {
   runCount += 1;
   const outputPath = path.join(fixture.root, `github-output-${runCount}`);
   fs.writeFileSync(outputPath, '');
@@ -111,7 +111,7 @@ function run(fixture, extraArgs = []) {
   const args = [
     SCRIPT,
     '--docs', fixture.docsDir,
-    '--docs-commit', 'docs-commit-1',
+    '--docs-commit', docsCommit,
     '--config', fixture.configPath,
     '--state', fixture.statePath,
     '--skills-dir', fixture.skillsDir,
@@ -130,8 +130,11 @@ function run(fixture, extraArgs = []) {
   assert.ok(countLine, `GITHUB_OUTPUT missing changed_count= line:\n${raw}`);
   const changed = changedLine.slice('changed='.length).split(',').filter(Boolean);
   const changedCount = Number(countLine.slice('changed_count='.length));
+  const stateLine = lines.find((l) => l.startsWith('state_changed='));
+  assert.ok(stateLine, `GITHUB_OUTPUT missing state_changed= line:\n${raw}`);
+  const stateChanged = stateLine.slice('state_changed='.length) === 'true';
 
-  return { stdout, raw, changed, changedCount };
+  return { stdout, raw, changed, changedCount, stateChanged };
 }
 
 function readState(fixture) {
@@ -166,18 +169,44 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.equal(state[GROUPING].docsCommit, 'docs-commit-1');
     assert.equal(state[GROUPING].importerVersion, 1);
     assert.deepEqual(state[GROUPING].affects, ['examples']);
+    assert.equal(state.lastImportedCommit, 'docs-commit-1');
   });
 
   const stateAfterFirstImport = readState(fixture);
 
-  await t.test('identical re-dispatch: no changes reported, no import', () => {
+  await t.test('identical re-dispatch, same commit: nothing moves', () => {
     const result = run(fixture);
 
     assert.match(result.stdout, /\[skip\] widgets: surface identical/);
     assert.deepEqual(result.changed, []);
     assert.equal(result.changedCount, 0);
+    assert.equal(result.stateChanged, false);
     assert.deepEqual(readState(fixture), stateAfterFirstImport);
   });
+
+  // The ordering key is the whole point of the split: per-grouping entries are
+  // provenance and may lag, but position advances on every run. Without this,
+  // the monotonicity guard reads a stale commit and can't order a later
+  // dispatch against it.
+  await t.test('identical re-dispatch, newer commit: position advances, provenance does not', () => {
+    const result = run(fixture, [], { docsCommit: 'docs-commit-2' });
+
+    assert.deepEqual(result.changed, []);
+    assert.equal(result.changedCount, 0);
+    assert.equal(result.stateChanged, true, 'ordering-only advance must be reported so the workflow commits it');
+    assert.match(result.stdout, /State advanced to docs-commit/);
+
+    const state = readState(fixture);
+    assert.equal(state.lastImportedCommit, 'docs-commit-2');
+    assert.equal(
+      state[GROUPING].docsCommit,
+      'docs-commit-1',
+      'per-grouping provenance stays at the commit that actually imported it',
+    );
+  });
+
+  // Restore the ordering key so later assertions compare against a known state.
+  run(fixture);
 
   // The docs#801 shape: SKILL.md and a references/*.md file are hand-edited upstream, but
   // manifest.json (and its generation.source_hash) is never touched.

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -327,6 +327,33 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.equal(fs.existsSync(path.join(fixture.skillsDir, other.skill)), false);
   });
 
+  // The skip above is only for a grouping that was never imported. Once one has been, an
+  // upstream deletion of SKILL.md must fail the run, not go green with a stale skills/<name>.
+  await t.test('missing skill/SKILL.md after a prior import: fails, stale skill left untouched', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    fs.rmSync(path.join(fixture.skillSrc, 'SKILL.md'));
+
+    const result = runExpectFailure(fixture);
+
+    assert.match(result.stderr, /imported before/);
+    assert.deepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(SKILL_MD));
+  });
+
+  await t.test('missing skill/SKILL.md with skills/<name> on disk but no state entry: fails', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    writeSkillTree(path.join(fixture.skillsDir, SKILL_NAME));
+    fs.rmSync(path.join(fixture.skillSrc, 'SKILL.md'));
+
+    const result = runExpectFailure(fixture);
+
+    assert.match(result.stderr, /imported before/);
+  });
+
   await t.test('symlink in the source tree: run fails loudly', (t) => {
     const fixture = buildFixture();
     t.after(() => removeFixture(fixture));

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -103,7 +103,6 @@ function buildFixture(groupings = DEFAULT_GROUPINGS) {
     JSON.stringify(
       {
         source: { agentContextDir: 'agent-context' },
-        importerVersion: 1,
         groupings,
       },
       null,
@@ -217,12 +216,23 @@ test('ctx-receive: byte-diff import delta', async (t) => {
       fs.readFileSync(path.join(fixture.skillSrc, 'references', 'widgets.md')),
     );
 
-    // --docs-commit wins over the manifest's generated_from.commit.
-    const state = readState(fixture);
-    assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
-    assert.equal(state[GROUPING].docsCommit, DOCS_COMMIT);
-    assert.equal(state[GROUPING].importerVersion, 1);
-    assert.deepEqual(state[GROUPING].affects, ['examples']);
+    // Exact shape: provenance only, and --docs-commit wins over the manifest's
+    // generated_from.commit.
+    assert.deepEqual(readState(fixture), {
+      [GROUPING]: { sourceHash: SOURCE_HASH, docsCommit: DOCS_COMMIT, affects: ['examples'] },
+    });
+  });
+
+  await t.test('--docs-commit omitted: docsCommit falls back to the manifest commit', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    // An earlier version crashed on `.slice()` of null here; pin that it stays fixed.
+    const result = run(fixture, { docsCommit: null });
+
+    assert.match(result.stdout, /\[import\] widgets .*first import/);
+    assert.equal(result.changedCount, 1);
+    assert.equal(readState(fixture)[GROUPING].docsCommit, MANIFEST_COMMIT);
   });
 
   await t.test('identical re-dispatch: no changes reported, no import', (t) => {
@@ -281,5 +291,83 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     // Provenance is rewritten even though source_hash didn't move — it's informational only.
     const state = readState(fixture);
     assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
+  });
+
+  await t.test('path-set change: an added upstream file imports, and its removal propagates', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+
+    const extraSrc = path.join(fixture.skillSrc, 'references', 'extra.md');
+    fs.writeFileSync(extraSrc, '# Extra\n');
+    const added = run(fixture);
+    assert.match(added.stdout, /\[import\] widgets /);
+    assert.equal(added.changedCount, 1);
+    assert.deepEqual(readSkillBytes(fixture, 'references', 'extra.md'), Buffer.from('# Extra\n'));
+
+    fs.rmSync(extraSrc);
+    const removed = run(fixture);
+    assert.match(removed.stdout, /\[import\] widgets /);
+    assert.equal(removed.changedCount, 1);
+    assert.equal(fs.existsSync(skillFile(fixture, 'references', 'extra.md')), false);
+  });
+
+  await t.test('missing skill/SKILL.md skips only that grouping', (t) => {
+    const other = { grouping: 'gadgets', skill: 'netlify-gadgets' };
+    const fixture = buildFixture([...DEFAULT_GROUPINGS, other]);
+    t.after(() => removeFixture(fixture));
+
+    fs.rmSync(path.join(fixture.docsDir, 'agent-context', other.grouping, 'skill', 'SKILL.md'));
+
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[skip\] gadgets: .*SKILL\.md is missing/);
+    assert.match(result.stdout, /\[import\] widgets .*first import/);
+    assert.deepEqual(result.changed, [GROUPING]);
+    assert.equal(result.changedCount, 1);
+    assert.equal(fs.existsSync(skillFile(fixture, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(fixture.skillsDir, other.skill)), false);
+  });
+
+  await t.test('symlink in the source tree: run fails loudly', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    fs.symlinkSync('widgets.md', path.join(fixture.skillSrc, 'references', 'link.md'));
+
+    const result = runExpectFailure(fixture);
+
+    assert.match(result.stderr, /link\.md: symlinks and other non-regular entries are not supported/);
+  });
+
+  await t.test('executable bit: a chmod upstream imports and the mode is copied', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    assert.equal(fs.statSync(skillFile(fixture, 'SKILL.md')).mode & 0o111, 0);
+
+    fs.chmodSync(path.join(fixture.skillSrc, 'SKILL.md'), 0o755);
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[import\] widgets /);
+    assert.equal(result.changedCount, 1);
+    assert.notEqual(fs.statSync(skillFile(fixture, 'SKILL.md')).mode & 0o111, 0);
+  });
+
+  await t.test('destination is a regular file: replaced by the imported tree', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    fs.writeFileSync(path.join(fixture.skillsDir, SKILL_NAME), 'not a directory\n');
+
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[import\] widgets /);
+    assert.equal(result.changedCount, 1);
+    assert.equal(fs.statSync(path.join(fixture.skillsDir, SKILL_NAME)).isDirectory(), true);
+    assert.deepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(SKILL_MD));
   });
 });

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -339,6 +339,34 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.match(result.stderr, /link\.md: symlinks and other non-regular entries are not supported/);
   });
 
+  // The first-import path short-circuits on a missing destination; the source tree must
+  // still be validated before that, or cpSync would copy the symlink into skills/.
+  await t.test('symlink in the source tree on first import: fails, nothing copied', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    fs.symlinkSync('widgets.md', path.join(fixture.skillSrc, 'references', 'link.md'));
+
+    const result = runExpectFailure(fixture);
+
+    assert.match(result.stderr, /link\.md: .*not supported/);
+    assert.equal(fs.existsSync(path.join(fixture.skillsDir, SKILL_NAME)), false);
+  });
+
+  await t.test('skill/ itself is a symlink: fails even though SKILL.md resolves', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    const realDir = path.join(fixture.root, 'real-skill');
+    fs.renameSync(fixture.skillSrc, realDir);
+    fs.symlinkSync(realDir, fixture.skillSrc, 'dir');
+
+    const result = runExpectFailure(fixture);
+
+    assert.match(result.stderr, /skill: not a directory .*not supported/);
+    assert.equal(fs.existsSync(path.join(fixture.skillsDir, SKILL_NAME)), false);
+  });
+
   await t.test('executable bit: a chmod upstream imports and the mode is copied', (t) => {
     const fixture = buildFixture();
     t.after(() => removeFixture(fixture));

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -71,6 +71,11 @@ function writeIntermediates(groupingDir, { contextMd = CONTEXT_MD, systemMd = SY
   fs.writeFileSync(path.join(groupingDir, 'system.md'), systemMd);
 }
 
+function removeIntermediates(groupingDir) {
+  fs.rmSync(path.join(groupingDir, 'context.md'));
+  fs.rmSync(path.join(groupingDir, 'system.md'));
+}
+
 // Mirrors hashIntermediates() in the script — the state.json field is a contract, so the
 // scheme is pinned here rather than imported.
 function expectedIntermediateHash({ contextMd = CONTEXT_MD, systemMd = SYSTEM_MD } = {}) {
@@ -551,5 +556,43 @@ test('ctx-receive: byte-diff import delta', async (t) => {
 
     assert.match(result.stdout, /\[warn\] widgets: /);
     assert.match(result.stdout, /::warning title=ctx-receive::widgets: context\.md\/system\.md changed upstream/);
+  });
+
+  // hashIntermediates() returns null when neither file exists; a stored hash moving to null
+  // is drift too, and null → null is not a move.
+  await t.test('both intermediates deleted upstream, identical skill: warns once, hash null', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    removeIntermediates(fixture.groupingDir);
+
+    const drift = run(fixture);
+    assert.match(
+      drift.stdout,
+      /\[warn\] widgets: context\.md\/system\.md changed upstream \([0-9a-f]{12} → none\)/,
+    );
+    assert.equal(drift.changedCount, 0);
+    assert.equal(readState(fixture)[GROUPING].intermediateHash, null);
+
+    const again = run(fixture);
+    assert.doesNotMatch(again.stdout, /\[warn\]/);
+    assert.equal(again.changedCount, 0);
+  });
+
+  await t.test('no intermediates from the start: imports with a null hash, never warns', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    removeIntermediates(fixture.groupingDir);
+
+    const first = run(fixture);
+    assert.match(first.stdout, /\[import\] widgets .*first import/);
+    assert.equal(first.changedCount, 1);
+    assert.equal(readState(fixture)[GROUPING].intermediateHash, null);
+
+    const again = run(fixture);
+    assert.doesNotMatch(again.stdout, /\[warn\]/);
+    assert.equal(again.changedCount, 0);
   });
 });

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -80,7 +80,7 @@ function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = MANIFE
 // Builds a fresh fixture: a fake docs checkout (docsDir) + a fake consumer repo (repoDir),
 // wired together via config.json, matching the shape ctx-receive.mjs expects. `groupings`
 // is the config.json mapping list; every entry gets a manifest and a skill tree whose
-// SKILL.md declares the mapped name. `groupingDir`/`skillSrc` point at the first entry —
+// SKILL.md declares the mapped name. `skillSrc` points at the first entry's skill tree —
 // the one every single-grouping case edits.
 function buildFixture(groupings = DEFAULT_GROUPINGS) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-receive-test-'));
@@ -111,23 +111,20 @@ function buildFixture(groupings = DEFAULT_GROUPINGS) {
   );
   fs.writeFileSync(statePath, '{}\n');
 
-  const groupingDir = path.join(docsDir, 'agent-context', groupings[0].grouping);
-  const skillSrc = path.join(groupingDir, 'skill');
-  return { root, docsDir, repoDir, configPath, statePath, skillsDir, groupingDir, skillSrc };
+  const skillSrc = path.join(docsDir, 'agent-context', groupings[0].grouping, 'skill');
+  return { root, docsDir, configPath, statePath, skillsDir, skillSrc };
 }
 
 function removeFixture(fixture) {
   fs.rmSync(fixture.root, { recursive: true, force: true });
 }
 
-let runCount = 0;
-
-// Spawns ctx-receive.mjs against a fixture with a fresh GITHUB_OUTPUT file. Never throws on
-// a non-zero exit — run() and runExpectFailure() decide what status they expect.
-// `docsCommit: null` omits the --docs-commit flag entirely.
+// Spawns ctx-receive.mjs against a fixture with a fresh GITHUB_OUTPUT file (one per fixture
+// root; truncated on every invocation). Never throws on a non-zero exit — run() and
+// runExpectFailure() decide what status they expect. `docsCommit: null` omits the
+// --docs-commit flag entirely.
 function invoke(fixture, { docsCommit = DOCS_COMMIT, args = [] } = {}) {
-  runCount += 1;
-  const outputPath = path.join(fixture.root, `github-output-${runCount}`);
+  const outputPath = path.join(fixture.root, 'github-output');
   fs.writeFileSync(outputPath, '');
 
   const argv = [
@@ -165,14 +162,14 @@ function run(fixture, opts) {
   const changed = changedLine.slice('changed='.length).split(',').filter(Boolean);
   const changedCount = Number(countLine.slice('changed_count='.length));
 
-  return { stdout: result.stdout, raw, changed, changedCount };
+  return { stdout: result.stdout, changed, changedCount };
 }
 
-// Runs ctx-receive.mjs expecting the fail() exit code. Returns { status, stdout, stderr }.
+// Runs ctx-receive.mjs expecting the fail() exit code. Returns { stdout, stderr }.
 function runExpectFailure(fixture, opts) {
   const { status, stdout, stderr } = invoke(fixture, opts);
   assert.equal(status, 1, `expected ctx-receive to exit 1: ${describeRun({ status, stdout, stderr })}`);
-  return { status, stdout, stderr };
+  return { stdout, stderr };
 }
 
 function readState(fixture) {

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -9,14 +9,16 @@
 //
 // Covers the docs#801 shape this fixes: a hand edit to skill/SKILL.md and
 // skill/references/*.md that does NOT touch manifest.json must still import — the delta is
-// treeDiffers(), never source_hash.
+// treeDiffers(), never source_hash. Also covers the inverse: context.md/system.md move
+// upstream while skill/** is byte-identical → a [warn], fired once, never a failure.
 //
-// Zero dependencies, Node 18+ (node:test, node:assert/strict, node:child_process).
+// Zero dependencies, Node 18+ (node:test, node:assert/strict, node:child_process, node:crypto).
 //
 // Usage: node scripts/ctx-receive.test.mjs   (also wired as `npm test`)
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -53,6 +55,35 @@ const REFERENCE_MD = `# Widgets reference
 Some reference detail.
 `;
 
+// The docs-side intermediates the skill is generated from. Never imported; only hashed.
+const CONTEXT_MD = `# Widgets context
+
+Distilled docs the skill is generated from.
+`;
+
+const SYSTEM_MD = `# Widgets system
+
+Generation instructions for the widgets skill.
+`;
+
+function writeIntermediates(groupingDir, { contextMd = CONTEXT_MD, systemMd = SYSTEM_MD } = {}) {
+  fs.writeFileSync(path.join(groupingDir, 'context.md'), contextMd);
+  fs.writeFileSync(path.join(groupingDir, 'system.md'), systemMd);
+}
+
+// Mirrors hashIntermediates() in the script — the state.json field is a contract, so the
+// scheme is pinned here rather than imported.
+function expectedIntermediateHash({ contextMd = CONTEXT_MD, systemMd = SYSTEM_MD } = {}) {
+  const hash = crypto.createHash('sha256');
+  hash.update('context.md\0');
+  hash.update(contextMd);
+  hash.update('\0');
+  hash.update('system.md\0');
+  hash.update(systemMd);
+  hash.update('\0');
+  return hash.digest('hex');
+}
+
 function writeSkillTree(
   skillDir,
   { skillName = SKILL_NAME, skillMd = skillMdFor(skillName), referenceMd = REFERENCE_MD } = {},
@@ -80,8 +111,8 @@ function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = MANIFE
 // Builds a fresh fixture: a fake docs checkout (docsDir) + a fake consumer repo (repoDir),
 // wired together via config.json, matching the shape ctx-receive.mjs expects. `groupings`
 // is the config.json mapping list; every entry gets a manifest and a skill tree whose
-// SKILL.md declares the mapped name. `skillSrc` points at the first entry's skill tree —
-// the one every single-grouping case edits.
+// SKILL.md declares the mapped name, plus context.md/system.md intermediates. `groupingDir`
+// and `skillSrc` point at the first entry — the one every single-grouping case edits.
 function buildFixture(groupings = DEFAULT_GROUPINGS) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-receive-test-'));
   const docsDir = path.join(root, 'docs');
@@ -90,6 +121,7 @@ function buildFixture(groupings = DEFAULT_GROUPINGS) {
   for (const { grouping, skill } of groupings) {
     const dir = path.join(docsDir, 'agent-context', grouping);
     writeSkillTree(path.join(dir, 'skill'), { skillName: skill });
+    writeIntermediates(dir);
     writeManifest(path.join(dir, 'manifest.json'));
   }
 
@@ -111,8 +143,9 @@ function buildFixture(groupings = DEFAULT_GROUPINGS) {
   );
   fs.writeFileSync(statePath, '{}\n');
 
-  const skillSrc = path.join(docsDir, 'agent-context', groupings[0].grouping, 'skill');
-  return { root, docsDir, configPath, statePath, skillsDir, skillSrc };
+  const groupingDir = path.join(docsDir, 'agent-context', groupings[0].grouping);
+  const skillSrc = path.join(groupingDir, 'skill');
+  return { root, docsDir, configPath, statePath, skillsDir, groupingDir, skillSrc };
 }
 
 function removeFixture(fixture) {
@@ -122,8 +155,8 @@ function removeFixture(fixture) {
 // Spawns ctx-receive.mjs against a fixture with a fresh GITHUB_OUTPUT file (one per fixture
 // root; truncated on every invocation). Never throws on a non-zero exit — run() and
 // runExpectFailure() decide what status they expect. `docsCommit: null` omits the
-// --docs-commit flag entirely.
-function invoke(fixture, { docsCommit = DOCS_COMMIT, args = [] } = {}) {
+// --docs-commit flag entirely; `env` is merged over process.env.
+function invoke(fixture, { docsCommit = DOCS_COMMIT, args = [], env = {} } = {}) {
   const outputPath = path.join(fixture.root, 'github-output');
   fs.writeFileSync(outputPath, '');
 
@@ -137,7 +170,7 @@ function invoke(fixture, { docsCommit = DOCS_COMMIT, args = [] } = {}) {
     ...args,
   ];
   const { status, stdout, stderr } = spawnSync('node', argv, {
-    env: { ...process.env, GITHUB_OUTPUT: outputPath },
+    env: { ...process.env, ...env, GITHUB_OUTPUT: outputPath },
     encoding: 'utf8',
   });
   return { status, stdout, stderr, outputPath };
@@ -215,8 +248,15 @@ test('ctx-receive: byte-diff import delta', async (t) => {
 
     // Exact shape: provenance only, and --docs-commit wins over the manifest's
     // generated_from.commit.
-    assert.deepEqual(readState(fixture), {
-      [GROUPING]: { sourceHash: SOURCE_HASH, docsCommit: DOCS_COMMIT, affects: ['examples'] },
+    const state = readState(fixture);
+    assert.match(state[GROUPING].intermediateHash, /^[0-9a-f]{64}$/);
+    assert.deepEqual(state, {
+      [GROUPING]: {
+        sourceHash: SOURCE_HASH,
+        docsCommit: DOCS_COMMIT,
+        affects: ['examples'],
+        intermediateHash: expectedIntermediateHash(),
+      },
     });
   });
 
@@ -421,5 +461,95 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.equal(result.changedCount, 1);
     assert.equal(fs.statSync(path.join(fixture.skillsDir, SKILL_NAME)).isDirectory(), true);
     assert.deepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(SKILL_MD));
+  });
+
+  // Intermediates moved upstream but skill/ did not: the skill may not have been
+  // regenerated. Warn once, import nothing, never fail.
+  const editedContextMd = `${CONTEXT_MD}\nEdited upstream without regenerating the skill.\n`;
+
+  await t.test('intermediate drift, identical skill: warns once, imports nothing, hash updated', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    writeIntermediates(fixture.groupingDir, { contextMd: editedContextMd });
+
+    const drift = run(fixture);
+    assert.match(drift.stdout, /\[warn\] widgets: context\.md\/system\.md changed upstream/);
+    assert.match(drift.stdout, /\[skip\] widgets: surface identical/);
+    assert.deepEqual(drift.changed, []);
+    assert.equal(drift.changedCount, 0);
+    assert.equal(
+      readState(fixture)[GROUPING].intermediateHash,
+      expectedIntermediateHash({ contextMd: editedContextMd }),
+    );
+
+    // Nothing moved since: the warning must not repeat.
+    const again = run(fixture);
+    assert.doesNotMatch(again.stdout, /\[warn\]/);
+    assert.equal(again.changedCount, 0);
+  });
+
+  await t.test('intermediate drift with a skill edit: imports, no warning, hash updated', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    writeIntermediates(fixture.groupingDir, { contextMd: editedContextMd });
+    handEditUpstream(fixture);
+
+    const result = run(fixture);
+
+    assert.match(result.stdout, /\[import\] widgets /);
+    assert.doesNotMatch(result.stdout, /\[warn\]/);
+    assert.equal(result.changedCount, 1);
+    assert.equal(
+      readState(fixture)[GROUPING].intermediateHash,
+      expectedIntermediateHash({ contextMd: editedContextMd }),
+    );
+  });
+
+  await t.test('legacy state entry without intermediateHash: seeded silently, no warning', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    const legacy = readState(fixture);
+    delete legacy[GROUPING].intermediateHash;
+    fs.writeFileSync(fixture.statePath, JSON.stringify(legacy, null, 2) + '\n');
+
+    const result = run(fixture);
+
+    assert.doesNotMatch(result.stdout, /\[warn\]/);
+    assert.equal(result.changedCount, 0);
+    assert.equal(readState(fixture)[GROUPING].intermediateHash, expectedIntermediateHash());
+  });
+
+  await t.test('intermediate drift, --dry-run: warns, state file untouched', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    const stateBytes = fs.readFileSync(fixture.statePath);
+    writeIntermediates(fixture.groupingDir, { systemMd: `${SYSTEM_MD}\nEdited.\n` });
+
+    const result = run(fixture, { args: ['--dry-run'] });
+
+    assert.match(result.stdout, /\[warn\] widgets: context\.md\/system\.md changed upstream/);
+    assert.equal(result.changedCount, 0);
+    assert.deepEqual(fs.readFileSync(fixture.statePath), stateBytes);
+  });
+
+  await t.test('intermediate drift under GITHUB_ACTIONS: also emits a run annotation', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    writeIntermediates(fixture.groupingDir, { contextMd: editedContextMd });
+
+    const result = run(fixture, { env: { GITHUB_ACTIONS: 'true' } });
+
+    assert.match(result.stdout, /\[warn\] widgets: /);
+    assert.match(result.stdout, /::warning title=ctx-receive::widgets: context\.md\/system\.md changed upstream/);
   });
 });

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 // ctx-receive.test.mjs — zero-dependency test suite for scripts/ctx-receive.mjs (AX-136).
 //
-// Builds a throwaway fixture: a fake docs checkout (agent-context/<grouping>/manifest.json
-// + skill/**) and a fake consumer repo (.ctx-gen/config.json, state.json, skills/), then
-// runs ctx-receive.mjs against it as a child process and asserts on stdout, the resulting
-// skills/ tree, state.json, and the GITHUB_OUTPUT contract.
+// Every subtest builds its own throwaway fixture: a fake docs checkout
+// (agent-context/<grouping>/manifest.json + skill/**) and a fake consumer repo
+// (.ctx-gen/config.json, state.json, skills/), runs ctx-receive.mjs against it as a child
+// process, and asserts on stdout/stderr, exit status, the resulting skills/ tree, state.json,
+// and the GITHUB_OUTPUT contract. Fixtures are never shared, so cases pass in any order.
 //
 // Covers the docs#801 shape this fixes: a hand edit to skill/SKILL.md and
 // skill/references/*.md that does NOT touch manifest.json must still import — the delta is
@@ -20,37 +21,48 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(__dirname, 'ctx-receive.mjs');
 
 const GROUPING = 'widgets';
 const SKILL_NAME = 'netlify-widgets';
+const DEFAULT_GROUPINGS = [{ grouping: GROUPING, skill: SKILL_NAME }];
 const SOURCE_HASH = 'a'.repeat(64);
+// Kept distinct so a test can tell which one landed in state.json.
+const DOCS_COMMIT = 'docs-commit-1';
+const MANIFEST_COMMIT = 'manifest-commit-1';
 
-const SKILL_MD = `---
-name: ${SKILL_NAME}
-description: A test skill for the widgets grouping.
+function skillMdFor(skillName) {
+  return `---
+name: ${skillName}
+description: A test skill for the ${skillName} grouping.
 ---
 
-# Widgets
+# ${skillName}
 
-Body content for the widgets skill.
+Body content for the ${skillName} skill.
 `;
+}
+
+const SKILL_MD = skillMdFor(SKILL_NAME);
 
 const REFERENCE_MD = `# Widgets reference
 
 Some reference detail.
 `;
 
-function writeSkillTree(skillDir, { skillMd = SKILL_MD, referenceMd = REFERENCE_MD } = {}) {
+function writeSkillTree(
+  skillDir,
+  { skillName = SKILL_NAME, skillMd = skillMdFor(skillName), referenceMd = REFERENCE_MD } = {},
+) {
   fs.mkdirSync(path.join(skillDir, 'references'), { recursive: true });
   fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillMd);
   fs.writeFileSync(path.join(skillDir, 'references', 'widgets.md'), referenceMd);
 }
 
-function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = 'docs-commit-1' } = {}) {
+function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = MANIFEST_COMMIT } = {}) {
   fs.writeFileSync(
     manifestPath,
     JSON.stringify(
@@ -66,16 +78,20 @@ function writeManifest(manifestPath, { sourceHash = SOURCE_HASH, commit = 'docs-
 }
 
 // Builds a fresh fixture: a fake docs checkout (docsDir) + a fake consumer repo (repoDir),
-// wired together via config.json, matching the shape ctx-receive.mjs expects.
-function buildFixture() {
+// wired together via config.json, matching the shape ctx-receive.mjs expects. `groupings`
+// is the config.json mapping list; every entry gets a manifest and a skill tree whose
+// SKILL.md declares the mapped name. `groupingDir`/`skillSrc` point at the first entry —
+// the one every single-grouping case edits.
+function buildFixture(groupings = DEFAULT_GROUPINGS) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-receive-test-'));
   const docsDir = path.join(root, 'docs');
   const repoDir = path.join(root, 'repo');
 
-  const groupingDir = path.join(docsDir, 'agent-context', GROUPING);
-  const skillSrc = path.join(groupingDir, 'skill');
-  writeSkillTree(skillSrc);
-  writeManifest(path.join(groupingDir, 'manifest.json'));
+  for (const { grouping, skill } of groupings) {
+    const dir = path.join(docsDir, 'agent-context', grouping);
+    writeSkillTree(path.join(dir, 'skill'), { skillName: skill });
+    writeManifest(path.join(dir, 'manifest.json'));
+  }
 
   const configPath = path.join(repoDir, '.ctx-gen', 'config.json');
   const statePath = path.join(repoDir, '.ctx-gen', 'state.json');
@@ -88,7 +104,7 @@ function buildFixture() {
       {
         source: { agentContextDir: 'agent-context' },
         importerVersion: 1,
-        groupings: [{ grouping: GROUPING, skill: SKILL_NAME }],
+        groupings,
       },
       null,
       2,
@@ -96,33 +112,52 @@ function buildFixture() {
   );
   fs.writeFileSync(statePath, '{}\n');
 
+  const groupingDir = path.join(docsDir, 'agent-context', groupings[0].grouping);
+  const skillSrc = path.join(groupingDir, 'skill');
   return { root, docsDir, repoDir, configPath, statePath, skillsDir, groupingDir, skillSrc };
+}
+
+function removeFixture(fixture) {
+  fs.rmSync(fixture.root, { recursive: true, force: true });
 }
 
 let runCount = 0;
 
-// Runs ctx-receive.mjs against a fixture as a child process. Returns stdout plus the parsed
-// GITHUB_OUTPUT contract (`changed` as an array, `changed_count` as a number).
-function run(fixture, extraArgs = []) {
+// Spawns ctx-receive.mjs against a fixture with a fresh GITHUB_OUTPUT file. Never throws on
+// a non-zero exit — run() and runExpectFailure() decide what status they expect.
+// `docsCommit: null` omits the --docs-commit flag entirely.
+function invoke(fixture, { docsCommit = DOCS_COMMIT, args = [] } = {}) {
   runCount += 1;
   const outputPath = path.join(fixture.root, `github-output-${runCount}`);
   fs.writeFileSync(outputPath, '');
 
-  const args = [
+  const argv = [
     SCRIPT,
     '--docs', fixture.docsDir,
-    '--docs-commit', 'docs-commit-1',
+    ...(docsCommit ? ['--docs-commit', docsCommit] : []),
     '--config', fixture.configPath,
     '--state', fixture.statePath,
     '--skills-dir', fixture.skillsDir,
-    ...extraArgs,
+    ...args,
   ];
-  const stdout = execFileSync('node', args, {
+  const { status, stdout, stderr } = spawnSync('node', argv, {
     env: { ...process.env, GITHUB_OUTPUT: outputPath },
     encoding: 'utf8',
   });
+  return { status, stdout, stderr, outputPath };
+}
 
-  const raw = fs.readFileSync(outputPath, 'utf8');
+function describeRun({ status, stdout, stderr }) {
+  return `exit ${status}\nstdout:\n${stdout}\nstderr:\n${stderr}`;
+}
+
+// Runs ctx-receive.mjs expecting exit 0. Returns stdout plus the parsed GITHUB_OUTPUT
+// contract (`changed` as an array, `changed_count` as a number).
+function run(fixture, opts) {
+  const result = invoke(fixture, opts);
+  assert.equal(result.status, 0, `ctx-receive failed: ${describeRun(result)}`);
+
+  const raw = fs.readFileSync(result.outputPath, 'utf8');
   const lines = raw.split('\n').filter(Boolean);
   const changedLine = lines.find((l) => l.startsWith('changed='));
   const countLine = lines.find((l) => l.startsWith('changed_count='));
@@ -131,21 +166,42 @@ function run(fixture, extraArgs = []) {
   const changed = changedLine.slice('changed='.length).split(',').filter(Boolean);
   const changedCount = Number(countLine.slice('changed_count='.length));
 
-  return { stdout, raw, changed, changedCount };
+  return { stdout: result.stdout, raw, changed, changedCount };
+}
+
+// Runs ctx-receive.mjs expecting the fail() exit code. Returns { status, stdout, stderr }.
+function runExpectFailure(fixture, opts) {
+  const { status, stdout, stderr } = invoke(fixture, opts);
+  assert.equal(status, 1, `expected ctx-receive to exit 1: ${describeRun({ status, stdout, stderr })}`);
+  return { status, stdout, stderr };
 }
 
 function readState(fixture) {
   return JSON.parse(fs.readFileSync(fixture.statePath, 'utf8'));
 }
 
+function skillFile(fixture, ...segments) {
+  return path.join(fixture.skillsDir, SKILL_NAME, ...segments);
+}
+
 function readSkillBytes(fixture, ...segments) {
-  return fs.readFileSync(path.join(fixture.skillsDir, SKILL_NAME, ...segments));
+  return fs.readFileSync(skillFile(fixture, ...segments));
+}
+
+// The docs#801 shape: SKILL.md and a references/*.md file are hand-edited upstream, but
+// manifest.json (and its generation.source_hash) is never touched.
+const editedSkillMd = SKILL_MD + '\n<!-- hand edit: docs#801 shape -->\n';
+const editedReferenceMd = `${REFERENCE_MD}\nHand-edited detail that never touched manifest.json.\n`;
+
+function handEditUpstream(fixture) {
+  writeSkillTree(fixture.skillSrc, { skillMd: editedSkillMd, referenceMd: editedReferenceMd });
 }
 
 test('ctx-receive: byte-diff import delta', async (t) => {
-  const fixture = buildFixture();
+  await t.test('first import: grouping imported, bytes match source, state written', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
 
-  await t.test('first import: grouping imported, bytes match source, state written', () => {
     const result = run(fixture);
 
     assert.match(result.stdout, /\[import\] widgets .*first import/);
@@ -161,16 +217,21 @@ test('ctx-receive: byte-diff import delta', async (t) => {
       fs.readFileSync(path.join(fixture.skillSrc, 'references', 'widgets.md')),
     );
 
+    // --docs-commit wins over the manifest's generated_from.commit.
     const state = readState(fixture);
     assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
-    assert.equal(state[GROUPING].docsCommit, 'docs-commit-1');
+    assert.equal(state[GROUPING].docsCommit, DOCS_COMMIT);
     assert.equal(state[GROUPING].importerVersion, 1);
     assert.deepEqual(state[GROUPING].affects, ['examples']);
   });
 
-  const stateAfterFirstImport = readState(fixture);
+  await t.test('identical re-dispatch: no changes reported, no import', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
 
-  await t.test('identical re-dispatch: no changes reported, no import', () => {
+    run(fixture);
+    const stateAfterFirstImport = readState(fixture);
+
     const result = run(fixture);
 
     assert.match(result.stdout, /\[skip\] widgets: surface identical/);
@@ -179,26 +240,32 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.deepEqual(readState(fixture), stateAfterFirstImport);
   });
 
-  // The docs#801 shape: SKILL.md and a references/*.md file are hand-edited upstream, but
-  // manifest.json (and its generation.source_hash) is never touched.
-  const editedSkillMd = SKILL_MD + '\n<!-- hand edit: docs#801 shape -->\n';
-  const editedReferenceMd = `${REFERENCE_MD}\nHand-edited detail that never touched manifest.json.\n`;
+  await t.test('hand edit, --dry-run: reports import, writes nothing', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
 
-  await t.test('hand edit, --dry-run: reports import, writes nothing', () => {
-    writeSkillTree(fixture.skillSrc, { skillMd: editedSkillMd, referenceMd: editedReferenceMd });
+    run(fixture);
+    const stateAfterFirstImport = readState(fixture);
+    handEditUpstream(fixture);
 
-    const result = run(fixture, ['--dry-run']);
+    const result = run(fixture, { args: ['--dry-run'] });
 
     assert.match(result.stdout, /\[import\] widgets .*surface differs, source_hash unchanged/);
     assert.deepEqual(result.changed, [GROUPING]);
     assert.equal(result.changedCount, 1);
 
     // Dry-run reports the delta but must not touch skills/ or state.json.
-    assert.notDeepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(editedSkillMd));
+    assert.deepEqual(readSkillBytes(fixture, 'SKILL.md'), Buffer.from(SKILL_MD));
     assert.deepEqual(readState(fixture), stateAfterFirstImport);
   });
 
-  await t.test('hand edit propagates: grouping changed, edit lands in skills/, state updated', () => {
+  await t.test('hand edit propagates: grouping changed, edit lands in skills/, state updated', (t) => {
+    const fixture = buildFixture();
+    t.after(() => removeFixture(fixture));
+
+    run(fixture);
+    handEditUpstream(fixture);
+
     const result = run(fixture);
 
     assert.match(result.stdout, /\[import\] widgets .*surface differs, source_hash unchanged/);
@@ -215,6 +282,4 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     const state = readState(fixture);
     assert.equal(state[GROUPING].sourceHash, SOURCE_HASH);
   });
-
-  fs.rmSync(fixture.root, { recursive: true, force: true });
 });

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -103,7 +103,7 @@ let runCount = 0;
 
 // Runs ctx-receive.mjs against a fixture as a child process. Returns stdout plus the parsed
 // GITHUB_OUTPUT contract (`changed` as an array, `changed_count` as a number).
-function run(fixture, extraArgs = [], { docsCommit = 'docs-commit-1' } = {}) {
+function run(fixture, extraArgs = []) {
   runCount += 1;
   const outputPath = path.join(fixture.root, `github-output-${runCount}`);
   fs.writeFileSync(outputPath, '');
@@ -111,7 +111,7 @@ function run(fixture, extraArgs = [], { docsCommit = 'docs-commit-1' } = {}) {
   const args = [
     SCRIPT,
     '--docs', fixture.docsDir,
-    '--docs-commit', docsCommit,
+    '--docs-commit', 'docs-commit-1',
     '--config', fixture.configPath,
     '--state', fixture.statePath,
     '--skills-dir', fixture.skillsDir,
@@ -130,11 +130,8 @@ function run(fixture, extraArgs = [], { docsCommit = 'docs-commit-1' } = {}) {
   assert.ok(countLine, `GITHUB_OUTPUT missing changed_count= line:\n${raw}`);
   const changed = changedLine.slice('changed='.length).split(',').filter(Boolean);
   const changedCount = Number(countLine.slice('changed_count='.length));
-  const stateLine = lines.find((l) => l.startsWith('state_changed='));
-  assert.ok(stateLine, `GITHUB_OUTPUT missing state_changed= line:\n${raw}`);
-  const stateChanged = stateLine.slice('state_changed='.length) === 'true';
 
-  return { stdout, raw, changed, changedCount, stateChanged };
+  return { stdout, raw, changed, changedCount };
 }
 
 function readState(fixture) {
@@ -169,44 +166,18 @@ test('ctx-receive: byte-diff import delta', async (t) => {
     assert.equal(state[GROUPING].docsCommit, 'docs-commit-1');
     assert.equal(state[GROUPING].importerVersion, 1);
     assert.deepEqual(state[GROUPING].affects, ['examples']);
-    assert.equal(state.lastImportedCommit, 'docs-commit-1');
   });
 
   const stateAfterFirstImport = readState(fixture);
 
-  await t.test('identical re-dispatch, same commit: nothing moves', () => {
+  await t.test('identical re-dispatch: no changes reported, no import', () => {
     const result = run(fixture);
 
     assert.match(result.stdout, /\[skip\] widgets: surface identical/);
     assert.deepEqual(result.changed, []);
     assert.equal(result.changedCount, 0);
-    assert.equal(result.stateChanged, false);
     assert.deepEqual(readState(fixture), stateAfterFirstImport);
   });
-
-  // The ordering key is the whole point of the split: per-grouping entries are
-  // provenance and may lag, but position advances on every run. Without this,
-  // the monotonicity guard reads a stale commit and can't order a later
-  // dispatch against it.
-  await t.test('identical re-dispatch, newer commit: position advances, provenance does not', () => {
-    const result = run(fixture, [], { docsCommit: 'docs-commit-2' });
-
-    assert.deepEqual(result.changed, []);
-    assert.equal(result.changedCount, 0);
-    assert.equal(result.stateChanged, true, 'ordering-only advance must be reported so the workflow commits it');
-    assert.match(result.stdout, /State advanced to docs-commit/);
-
-    const state = readState(fixture);
-    assert.equal(state.lastImportedCommit, 'docs-commit-2');
-    assert.equal(
-      state[GROUPING].docsCommit,
-      'docs-commit-1',
-      'per-grouping provenance stays at the commit that actually imported it',
-    );
-  });
-
-  // Restore the ordering key so later assertions compare against a known state.
-  run(fixture);
 
   // The docs#801 shape: SKILL.md and a references/*.md file are hand-edited upstream, but
   // manifest.json (and its generation.source_hash) is never touched.


### PR DESCRIPTION
## Summary

The Stage-2 receiver now decides import vs skip by byte-comparing `agent-context/<grouping>/skill/**` against `skills/<name>/**`, so upstream hand edits (like netlify/docs#801) propagate instead of being silently skipped when the manifest's `source_hash` hasn't moved. `changed_count > 0` now always implies a real git diff, which also removes the empty-commit failure mode in the receive workflow.

## What changed

- `scripts/ctx-receive.mjs`: `treeDiffers()` (path set + file bytes + executable bit) is the sole import/skip decision; manifest state is provenance-only
- Symlinks and other non-regular entries in either tree fail the run loudly (`cpSync` would copy them, the gate can't compare them); the source tree is validated before the first-import short-circuit
- A destination that exists but isn't a directory counts as changed and is replaced
- A grouping with no `skill/SKILL.md` is skipped only if never imported; once imported, its disappearance fails the run rather than leaving a stale skill
- `context.md` + `system.md` are hashed per grouping into `state.json` (`intermediateHash`); when that moves while `skill/` is byte-identical the run **warns** (`[warn]` + `::warning::` on Actions), once per upstream change, and imports nothing — never fails. Warn-once persistence becomes effective when #110's `state_changed` commit gate lands
- `importerVersion` removed (script, `config.json`, `state.json`, README): with a faithful byte copy no version bump can change output
- `scripts/ctx-receive.test.mjs` (new): 22-case zero-dep suite, one fixture per case; wired as `npm test`
- `.github/workflows/validate-skills.yml`: `test-receiver` job (Node 18 via SHA-pinned `setup-node`, `contents: read`); PR path filter covers the receiver scripts and `package.json`
- `.ctx-gen/README.md`: `state.json` described as a provenance log; the delta is the byte comparison
- `docs/autopilot/`: run spec + report with both iteration rounds ([full audit detail](docs/autopilot/2026-08-19-ax-136-receiver-byte-diff-report.md))

Ordering (`lastImportedCommit`, `state_changed`, the monotonicity guard) lives in #110, which should merge after this and needs a rebase.

## Verify

- After netlify/docs#801 merges, the next receive run's rolling sync PR should contain the Next.js fetch-skew qualification — that's the live proof of this fix.

Linear: [AX-136](https://linear.app/netlify/issue/AX-136/stage-2-receiver-silently-skips-hand-edited-upstream-skills)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imports now detect file-path, content, and executable-permission changes.
  * Invalid destination files are replaced, and missing directories are repaired.
  * Intermediate file changes are tracked, with warnings when generated skills remain unchanged.
  * Incomplete groupings without a `SKILL.md` are skipped only when never previously imported.
* **Bug Fixes**
  * Unsupported symlinks and other non-regular entries now fail clearly.
  * Import state remains accurate after source or intermediate changes.
* **Tests**
  * Expanded coverage for edge cases, dry runs, and failure handling.
* **Documentation**
  * Added receiver design and implementation reports.
* **Chores**
  * CI runs receiver tests when relevant scripts or package configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
