### PR TITLE
fix(ctx-pipeline): surface guard skips, fail closed on divergence, validate --docs-commit

### DIFF
--- a/.github/workflows/ctx-pipeline-receive.yml
+++ b/.github/workflows/ctx-pipeline-receive.yml
@@ -135,8 +135,11 @@ jobs:
       # newer import must not roll skills back. Ordering comes from the
       # top-level `lastImportedCommit` in state.json (written by
       # ctx-receive.mjs; per-grouping docsCommit entries are provenance and
-      # legitimately disagree). Fail-closed: a position that exists but cannot
-      # be validated fails the run; a state predating the ordering key is
+      # legitimately disagree). A stale delivery skips with a ::warning and a
+      # step-summary entry (AX-159). Fail-closed: a position that exists but
+      # cannot be validated fails the run, as does a DIVERGED history (e.g. a
+      # docs rewrite) that would otherwise skip green forever — recover with
+      # skip_guard; a state predating the ordering key is
       # bootstrap. Logic + decision table live in scripts/ctx-ordering-guard.mjs,
       # tested by scripts/ctx-ordering-guard.test.mjs (runs in validate-skills).
       - name: Monotonicity guard

--- a/scripts/ctx-ordering-guard.mjs
+++ b/scripts/ctx-ordering-guard.mjs
@@ -7,12 +7,20 @@
 //
 //   proceed  incoming descends from the last imported commit (or nothing has
 //            been imported yet — bootstrap)
-//   skip     incoming does not descend from the last imported commit
-//            (stale or unrelated delivery); exit 0 with skip=1
+//   skip     incoming is an ANCESTOR of the last imported commit (a stale
+//            delivery — a newer dispatch already imported past it). Exit 0
+//            with skip=1; self-healing, since the next on-line delivery
+//            proceeds. On Actions the skip is surfaced as a ::warning
+//            annotation and a GITHUB_STEP_SUMMARY entry (AX-159), not just a
+//            green log line.
 //   fail     the recorded position exists but cannot be validated — malformed
 //            JSON, a malformed ordering key, or a recorded commit the docs
-//            checkout cannot resolve. Fail-closed: silence here is how
-//            rollbacks happen. Exit 1.
+//            checkout cannot resolve. ALSO when incoming and the recorded
+//            position have DIVERGED (neither descends from the other, e.g.
+//            after a docs history rewrite where the old commit still
+//            resolves): no future delivery on that line can ever descend from
+//            the recorded position, so skipping green would recur forever.
+//            Fail-closed: silence here is how rollbacks happen. Exit 1.
 //
 // Ordering comes from the top-level `lastImportedCommit` key in state.json —
 // the ordering AUTHORITY written by ctx-receive.mjs on every run. Per-grouping
@@ -69,6 +77,21 @@ function emit(skip, msg) {
   }
 }
 
+// A skipped delivery must be visible from the run list, not only inside the
+// step log — a stale dispatch is expected noise, but a pattern of skips is
+// how an ordering problem first shows up (AX-159).
+function surfaceSkip(msg) {
+  if (process.env.GITHUB_ACTIONS) {
+    console.log(`::warning title=ctx-ordering-guard::${msg}`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `### ctx-ordering-guard: delivery skipped\n\n${msg}\n`,
+    );
+  }
+}
+
 // git plumbing against the docs checkout; returns the exit status rather than
 // throwing, so "no" (1) is distinguishable from "broken" (anything else).
 function git(docs, args) {
@@ -118,7 +141,22 @@ function main() {
   if (rc === 0) {
     emit(false, `incoming ${opts.incoming} descends from last imported ${last} — proceeding`);
   } else if (rc === 1) {
-    emit(true, `incoming ${opts.incoming} does not descend from last imported ${last} — skipping this delivery`);
+    // Non-descent splits two ways. A stale delivery (incoming is an ancestor
+    // of the position) self-heals: the next on-line dispatch proceeds. A
+    // DIVERGED history (neither is an ancestor of the other — a docs history
+    // rewrite where the recorded commit still resolves, or a foreign branch)
+    // never self-heals: every future delivery on that line would skip green
+    // forever, so it fails closed instead.
+    const reverse = git(opts.docs, ['merge-base', '--is-ancestor', opts.incoming, last]);
+    if (reverse === 0) {
+      const msg = `incoming ${opts.incoming} is an ancestor of last imported ${last} — stale delivery, skipping`;
+      surfaceSkip(msg);
+      emit(true, msg);
+    } else if (reverse === 1) {
+      fail(`incoming ${opts.incoming} and last imported ${last} have diverged — no delivery on this line can ever descend from the recorded position (docs history rewrite?); failing closed. If the divergence is expected, re-run manually with skip_guard to reset the ordering baseline`);
+    } else {
+      fail(`merge-base failed with status ${reverse} — cannot establish ordering; failing closed`);
+    }
   } else {
     fail(`merge-base failed with status ${rc} — cannot establish ordering; failing closed`);
   }

--- a/scripts/ctx-ordering-guard.test.mjs
+++ b/scripts/ctx-ordering-guard.test.mjs
@@ -9,7 +9,9 @@
 //
 // The fixture matrix mirrors the decision table in the guard's header:
 // bootstrap (no file / no key / empty object) proceeds, descent proceeds,
-// non-descent skips, and anything unvalidatable fails closed.
+// a stale delivery (incoming is an ancestor of the position) skips — with a
+// ::warning and step-summary entry on Actions (AX-159) — and anything
+// unvalidatable, including a diverged history, fails closed.
 //
 // Zero dependencies, Node 18+ (node:test, node:assert/strict, node:child_process;
 // requires git on PATH, as in CI).
@@ -61,21 +63,34 @@ function makeDocsRepo() {
 const docs = makeDocsRepo();
 
 // Run the guard against a state fixture. `state` is the JSON value to write,
-// the literal string to write raw, or undefined for "no state file".
-function runGuard({ state, incoming }) {
+// the literal string to write raw, or undefined for "no state file". Actions
+// observability (`::warning`, step summary) is opt-in via `actions` so
+// assertions are deterministic whether or not the suite itself runs in CI;
+// the summary file always exists so "wrote nothing" is assertable too.
+function runGuard({ state, incoming, actions = false }) {
   const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-guard-run-'));
   const statePath = path.join(workDir, 'state.json');
   if (typeof state === 'string') fs.writeFileSync(statePath, state);
   else if (state !== undefined) fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n');
   const outputPath = path.join(workDir, 'github-output');
   fs.writeFileSync(outputPath, '');
+  const summaryPath = path.join(workDir, 'github-step-summary');
+  fs.writeFileSync(summaryPath, '');
+
+  const env = { ...process.env, GITHUB_OUTPUT: outputPath, GITHUB_STEP_SUMMARY: summaryPath };
+  if (actions) env.GITHUB_ACTIONS = 'true';
+  else delete env.GITHUB_ACTIONS;
 
   const res = spawnSync(
     process.execPath,
     [SCRIPT, '--docs', docs.dir, '--incoming', incoming, '--state', statePath],
-    { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outputPath } },
+    { encoding: 'utf8', env },
   );
-  return { ...res, output: fs.readFileSync(outputPath, 'utf8') };
+  return {
+    ...res,
+    output: fs.readFileSync(outputPath, 'utf8'),
+    summary: fs.readFileSync(summaryPath, 'utf8'),
+  };
 }
 
 test('bootstrap: no state file proceeds', () => {
@@ -123,15 +138,48 @@ test('proceed: re-delivery of the last imported commit itself', () => {
 test('skip: incoming is older than last imported', () => {
   const r = runGuard({ state: { lastImportedCommit: docs.b }, incoming: docs.a });
   assert.equal(r.status, 0);
-  assert.match(r.stdout, /does not descend from last imported/);
+  assert.match(r.stdout, /stale delivery, skipping/);
   assert.equal(r.output, 'skip=1\n');
 });
 
-test('skip: incoming is unrelated to last imported', () => {
-  const r = runGuard({ state: { lastImportedCommit: docs.a }, incoming: docs.u });
+test('skip on Actions: stale delivery emits a ::warning and a step-summary entry (AX-159)', () => {
+  const r = runGuard({ state: { lastImportedCommit: docs.b }, incoming: docs.a, actions: true });
   assert.equal(r.status, 0);
-  assert.match(r.stdout, /does not descend from last imported/);
   assert.equal(r.output, 'skip=1\n');
+  assert.match(r.stdout, /::warning title=ctx-ordering-guard::.*stale delivery, skipping/);
+  assert.match(r.summary, /ctx-ordering-guard: delivery skipped/);
+  assert.match(r.summary, new RegExp(`incoming ${docs.a} is an ancestor of last imported ${docs.b}`));
+});
+
+test('skip off Actions: no ::warning annotation, but the step summary still records the skip', () => {
+  // GITHUB_STEP_SUMMARY is only ever set by the runner, so writing to it when
+  // present is safe regardless of GITHUB_ACTIONS; the ::warning line would be
+  // plain noise outside Actions.
+  const r = runGuard({ state: { lastImportedCommit: docs.b }, incoming: docs.a });
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /::warning/);
+  assert.match(r.summary, /delivery skipped/);
+});
+
+test('proceed and fail paths write nothing to the step summary', () => {
+  const ok = runGuard({ state: { lastImportedCommit: docs.a }, incoming: docs.b, actions: true });
+  assert.equal(ok.status, 0);
+  assert.equal(ok.summary, '');
+  const bad = runGuard({ state: { lastImportedCommit: 'f'.repeat(40) }, incoming: docs.b, actions: true });
+  assert.equal(bad.status, 1);
+  assert.equal(bad.summary, '');
+});
+
+test('fail closed: incoming is unrelated to last imported (diverged history never self-heals)', () => {
+  // The non-self-healing shape: after a docs history rewrite the recorded
+  // commit still resolves but nothing on the new line will ever descend from
+  // it — a green skip here would recur on every future delivery.
+  const r = runGuard({ state: { lastImportedCommit: docs.a }, incoming: docs.u, actions: true });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /have diverged/);
+  assert.match(r.stderr, /skip_guard/);
+  assert.equal(r.output, '');
+  assert.equal(r.summary, '');
 });
 
 test('fail closed: ordering key is not a full SHA', () => {

--- a/scripts/ctx-receive-ordering.test.mjs
+++ b/scripts/ctx-receive-ordering.test.mjs
@@ -11,7 +11,8 @@
 // Covers: first import writes the key; a same-commit re-dispatch is a byte-level
 // no-op; a newer-commit re-dispatch advances the key while per-grouping
 // provenance lags; no --docs-commit leaves the key unwritten; --dry-run writes
-// nothing; a grouping named after the key is rejected.
+// nothing; a malformed --docs-commit (short/non-hex/uppercase SHA) is rejected
+// before anything is written; a grouping named after the key is rejected.
 //
 // Zero dependencies, Node 18+ (node:test, node:assert/strict, node:child_process).
 //
@@ -168,6 +169,31 @@ test('--dry-run at a newer commit writes nothing and reports state_changed=false
     assert.equal(r.output, 'changed=\nchanged_count=0\nstate_changed=false\n');
     assert.equal(fx.stateBytes(), before);
     assert.equal(fx.readState().lastImportedCommit, COMMIT_A);
+  });
+});
+
+test('--docs-commit with a short SHA is rejected before anything is written', () => {
+  // A manual local run with an abbreviated SHA used to write a malformed
+  // lastImportedCommit, wedging every subsequent CI run (the guard fails
+  // closed on it). Rejected up front instead.
+  withFixture({}, (fx) => {
+    const r = runReceive(fx, '--docs-commit', COMMIT_A.slice(0, 12));
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /--docs-commit must be a full 40-char lowercase commit SHA/);
+    assert.equal(r.output, '');
+    assert.equal(fx.stateBytes(), '{}\n');
+    assert.equal(fs.existsSync(path.join(fx.skillsDir, 'netlify-widgets')), false);
+  });
+});
+
+test('--docs-commit with non-hex or uppercase characters is rejected', () => {
+  withFixture({}, (fx) => {
+    for (const bad of ['G'.repeat(40), COMMIT_A.toUpperCase(), 'main']) {
+      const r = runReceive(fx, '--docs-commit', bad);
+      assert.equal(r.status, 1, `expected rejection of ${JSON.stringify(bad)}`);
+      assert.match(r.stderr, /full 40-char lowercase commit SHA/);
+    }
+    assert.equal(fx.stateBytes(), '{}\n');
   });
 });
 

--- a/scripts/ctx-receive.mjs
+++ b/scripts/ctx-receive.mjs
@@ -58,7 +58,9 @@
 //
 // Options:
 //   --docs <path>          Path to a netlify/docs checkout (required)
-//   --docs-commit <sha>    Commit the docs checkout resolves to (provenance)
+//   --docs-commit <sha>    Commit the docs checkout resolves to (provenance;
+//                          must be a full 40-hex SHA — it is written verbatim
+//                          as the ordering key the guard validates)
 //   --config <path>        Default: .ctx-gen/config.json
 //   --state <path>         Default: .ctx-gen/state.json
 //   --skills-dir <path>    Default: skills
@@ -98,6 +100,12 @@ function parseArgs(argv) {
     }
   }
   if (!opts.docs) fail('--docs <path> is required');
+  // The value becomes the ordering authority (`lastImportedCommit`) verbatim,
+  // and the guard fails closed on anything that isn't a full SHA — so a manual
+  // run with a short SHA would wedge every subsequent CI run. Reject it here.
+  if (opts.docsCommit !== null && !/^[0-9a-f]{40}$/.test(opts.docsCommit)) {
+    fail(`--docs-commit must be a full 40-char lowercase commit SHA (got ${JSON.stringify(opts.docsCommit)})`);
+  }
   return opts;
 }
 

--- a/scripts/ctx-receive.test.mjs
+++ b/scripts/ctx-receive.test.mjs
@@ -32,9 +32,10 @@ const GROUPING = 'widgets';
 const SKILL_NAME = 'netlify-widgets';
 const DEFAULT_GROUPINGS = [{ grouping: GROUPING, skill: SKILL_NAME }];
 const SOURCE_HASH = 'a'.repeat(64);
-// Kept distinct so a test can tell which one landed in state.json.
-const DOCS_COMMIT = 'docs-commit-1';
-const MANIFEST_COMMIT = 'manifest-commit-1';
+// Kept distinct so a test can tell which one landed in state.json. Full hex
+// SHAs: --docs-commit is validated against /^[0-9a-f]{40}$/.
+const DOCS_COMMIT = 'd0c5'.padEnd(40, '0');
+const MANIFEST_COMMIT = 'a1fe5'.padEnd(40, '0');
 
 function skillMdFor(skillName) {
   return `---


### PR DESCRIPTION
Two small follow-ups from the PR #110 review (monotonicity guard for the Stage 2 receiver).

## AX-159 — observability in the guard skip path

A stale-delivery skip in `scripts/ctx-ordering-guard.mjs` was a plain stdout line inside a green run, while the less-dangerous `skip_guard` bypass already got a `::warning`. Now:

- A skipped delivery emits a `::warning title=ctx-ordering-guard::` annotation and a `GITHUB_STEP_SUMMARY` entry, so a pattern of skips is visible from the run list.
- The non-descent case splits two ways. **Stale** (incoming is an *ancestor* of the recorded position): a newer dispatch already imported past it — skip, self-healing. **Diverged** (neither descends from the other — the shape @seancdavis described, where a netlify/docs history rewrite leaves `lastImportedCommit` resolvable but main never descends from it again): previously this skipped green on every future delivery forever; it now **fails closed** with a message pointing at the `skip_guard` manual-recovery path, which resets the ordering baseline on import.

## Full-SHA validation of `--docs-commit`

`scripts/ctx-receive.mjs` wrote `state[lastImportedCommit] = opts.docsCommit` unvalidated, so a manual local run with a short SHA wrote a malformed ordering key and the next CI run failed closed. `--docs-commit` is now rejected up front unless it matches `/^[0-9a-f]{40}$/` (seancdavis's inline nit on PR #110, deferred to avoid conflicting with #115, now merged).

## Tests

Both zero-dep suites extended (`npm test`, 46 passing):
- guard: stale skip message + `::warning`/step-summary assertions (on and off Actions), proceed/fail paths write no summary, unrelated-history case now asserts fail-closed with `skip_guard` guidance.
- receiver: short SHA, non-hex, uppercase, and branch-name `--docs-commit` values are rejected before anything is written; existing fixtures moved to full hex SHAs.

Ref: AX-97, AX-159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ordering checks so stale deliveries now surface a warning and summary note, while diverged histories fail safely instead of passing silently.
  * Tightened validation for commit references to reject invalid values before any changes are applied.
* **Documentation**
  * Clarified the handling of skipped, diverged, and unrecoverable ordering cases in workflow notes.
* **Tests**
  * Added coverage for warning behavior, fail-closed behavior, and invalid commit reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->