### PR TITLE
feat(ctx-pipeline): post receive outcomes to Slack (EX-3057)

### DIFF
--- a/.ctx-gen/README.md
+++ b/.ctx-gen/README.md
@@ -34,6 +34,13 @@ AXIS scenarios.)
   draft PR when something changed. That PR runs the existing `validate-skills`
   and `build-generated-outputs` (cursor/codex parity) gates; a human reviews
   and merges. Rollback = revert.
+- **`../.github/workflows/ctx-pipeline-notify.yml`** — a `workflow_run`
+  watcher that posts every receiver outcome (imported / no-op / stale skip /
+  failed) to `#notify-context-pipeline`, the same channel the docs side
+  reports to. docs' dispatch is fire-and-forget, so without this a failed
+  import was invisible while Slack kept saying "delivered" (EX-3057). Logic in
+  `../scripts/ctx-notify.mjs`; inert until `SLACK_WEBHOOK_URL` exists in the
+  `ctx-pipeline` environment.
 
 ## Triggers
 

--- a/.ctx-gen/README.md
+++ b/.ctx-gen/README.md
@@ -36,7 +36,7 @@ AXIS scenarios.)
   and merges. Rollback = revert.
 - **`../.github/workflows/ctx-pipeline-notify.yml`** — a `workflow_run`
   watcher that posts every receiver outcome (imported / no-op / stale skip /
-  failed) to `#notify-context-pipeline`, the same channel the docs side
+  failed / unclassified) to `#notify-context-pipeline`, the same channel the docs side
   reports to. docs' dispatch is fire-and-forget, so without this a failed
   import was invisible while Slack kept saying "delivered" (EX-3057). Logic in
   `../scripts/ctx-notify.mjs`; inert until `SLACK_WEBHOOK_URL` exists in the

--- a/.github/workflows/ctx-pipeline-notify.yml
+++ b/.github/workflows/ctx-pipeline-notify.yml
@@ -45,10 +45,22 @@ permissions:
 
 jobs:
   notify:
-    # A dispatch that arrived with CTX_PIPELINE off skips the receive job and
-    # the run concludes "skipped" — nothing to report, so don't spin up a
-    # runner to decide silence. Every other outcome is a message shape.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'skipped'
+    # Trust boundary first: workflow_run matches by workflow NAME, so a fork PR
+    # that adds a pull_request trigger to the receive workflow (or ships a
+    # same-named file) would complete a run this watcher fires on — with the
+    # webhook secret, reading the fork's step names and artifact. Only runs
+    # from this repository on the receive workflow's two legitimate triggers
+    # get a runner; ctx-notify.mjs re-checks the same rule before posting.
+    # Then: a dispatch that arrived with CTX_PIPELINE off skips the receive job
+    # and the run concludes "skipped" — nothing to report, so no runner for
+    # that either. Every other outcome is a message shape.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        contains(fromJSON('["repository_dispatch","workflow_dispatch"]'), github.event.workflow_run.event) &&
+        github.event.workflow_run.conclusion != 'skipped'
+      )
     runs-on: ubuntu-latest
     environment: ctx-pipeline
     steps:

--- a/.github/workflows/ctx-pipeline-notify.yml
+++ b/.github/workflows/ctx-pipeline-notify.yml
@@ -1,10 +1,8 @@
 name: ctx-pipeline notify
 
-# EX-3057: docs dispatches to us fire-and-forget, so the docs-side notifier
-# (AX-138) posts "delivered" the moment the dispatch is accepted — a receive
-# failure here was invisible while Slack kept reporting success. This watcher
-# posts every receive outcome to the same channel, #notify-context-pipeline,
-# so both halves of the pipeline report in one place.
+# EX-3057: post every "Receive agent-context" outcome to
+# #notify-context-pipeline, the channel the docs-side notifier (AX-138)
+# already reports to. Why it exists: see the header of scripts/ctx-notify.mjs.
 #
 # A separate workflow_run watcher, not notify steps inside the receiver: it
 # fires on every terminal state — including runs that die at checkout,

--- a/.github/workflows/ctx-pipeline-notify.yml
+++ b/.github/workflows/ctx-pipeline-notify.yml
@@ -1,0 +1,69 @@
+name: ctx-pipeline notify
+
+# EX-3057: docs dispatches to us fire-and-forget, so the docs-side notifier
+# (AX-138) posts "delivered" the moment the dispatch is accepted — a receive
+# failure here was invisible while Slack kept reporting success. This watcher
+# posts every receive outcome to the same channel, #notify-context-pipeline,
+# so both halves of the pipeline report in one place.
+#
+# A separate workflow_run watcher, not notify steps inside the receiver: it
+# fires on every terminal state — including runs that die at checkout,
+# cancels, and timeouts — and a bug here can never redden the receiver
+# itself. All logic lives in scripts/ctx-notify.mjs (thin-caller rule); the
+# five message shapes are documented there and tested by
+# scripts/ctx-notify.test.mjs (runs in validate-skills).
+#
+# workflow_run and workflow_dispatch both run this file's copy on the default
+# branch, so neither trigger works before merge. To test pre-merge, replay a
+# historical run locally:
+#   node scripts/ctx-notify.mjs --run-id <id> --repo netlify/context-and-tools --dry-run
+# After merge, workflow_dispatch replays any run ID — dry_run prints the exact
+# message instead of posting.
+#
+# Inert until SLACK_WEBHOOK_URL exists in the ctx-pipeline environment. It is
+# the same Slack webhook the docs side posts through (docs keeps its copy in
+# its ctx-gen environment); environment scoping means the secret only injects
+# into jobs that declare the environment, which matters in a public repo.
+# Without the secret, ctx-notify.mjs prints the message as a dry run and
+# exits 0.
+
+on:
+  workflow_run:
+    workflows: ["Receive agent-context"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of a Receive agent-context run to classify (replay)"
+        required: true
+      dry_run:
+        description: "Print the message instead of posting to Slack"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: read # run metadata + the ctx-receive-outcome artifact
+
+jobs:
+  notify:
+    # A dispatch that arrived with CTX_PIPELINE off skips the receive job and
+    # the run concludes "skipped" — nothing to report, so don't spin up a
+    # runner to decide silence. Every other outcome is a message shape.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    environment: ctx-pipeline
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Classify run and post to Slack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+          # env indirection: dispatch inputs are attacker-shaped and must reach
+          # the shell as data, never interpolated into command text.
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+        run: node scripts/ctx-notify.mjs --run-id "$RUN_ID"

--- a/.github/workflows/ctx-pipeline-receive.yml
+++ b/.github/workflows/ctx-pipeline-receive.yml
@@ -23,6 +23,12 @@ name: Receive agent-context
 #                          GITHUB_TOKEN would not trigger them)
 # One token with both scopes may back both secrets. The dispatch trigger also
 # requires the CTX_PIPELINE repo variable = 'true'; manual runs never do.
+#
+# Outcomes are posted to #notify-context-pipeline by ctx-pipeline-notify.yml,
+# a workflow_run watcher (EX-3057). It classifies from this job's step
+# conclusions and enriches from the small `ctx-receive-outcome` artifact the
+# last two steps upload on every terminal state (docs sha, groupings, PR URL).
+# Keep step names stable: scripts/ctx-notify.mjs matches them by prefix.
 
 on:
   repository_dispatch:
@@ -167,6 +173,7 @@ jobs:
         run: node scripts/ctx-receive.mjs --docs .docs-src --docs-commit "${{ steps.docs.outputs.sha }}"
 
       - name: Open or update the rolling sync PR
+        id: pr
         # Gated on the guard too: when the import is skipped, changed_count is
         # empty ('' != '0' is true) and success() still holds, so without the
         # skip clause a stale delivery would reach `git commit` with nothing
@@ -217,3 +224,46 @@ jobs:
               --title "chore(context): sync skills from netlify/docs" \
               --body-file "$RUNNER_TEMP/pr-body.md"
           fi
+          echo "url=$(gh pr view "$branch" --json url --jq '.url')" >> "$GITHUB_OUTPUT"
+
+      # What happened, for the Slack notifier (EX-3057). Step outputs are not
+      # visible through the Actions API, so the docs sha, groupings and PR URL
+      # travel as a tiny artifact; the notifier reads the outcome itself
+      # (success / skip / which step failed) from job step conclusions and only
+      # decorates with this. always(): a run that dies mid-way still records
+      # what it resolved (e.g. the docs ref it could not check out). Fields are
+      # strings, possibly empty, exactly as Actions outputs are.
+      - name: Record receive outcome
+        if: always()
+        # Notifier plumbing must never redden the receiver: a failure here
+        # only costs the Slack line its docs sha / groupings / PR link.
+        continue-on-error: true
+        env:
+          DOCS_REF: ${{ steps.ref.outputs.ref }}
+          DOCS_SHA: ${{ steps.docs.outputs.sha }}
+          GUARD_SKIP: ${{ steps.guard.outputs.skip }}
+          GUARD_BYPASSED: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_guard }}
+          CHANGED: ${{ steps.import.outputs.changed }}
+          CHANGED_COUNT: ${{ steps.import.outputs.changed_count }}
+          STATE_CHANGED: ${{ steps.import.outputs.state_changed }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/receive-outcome"
+          node -e '
+            const keys = ["DOCS_REF","DOCS_SHA","GUARD_SKIP","GUARD_BYPASSED","CHANGED","CHANGED_COUNT","STATE_CHANGED","PR_URL"];
+            const out = Object.fromEntries(keys.map((k) => [k.toLowerCase(), process.env[k] ?? ""]));
+            require("fs").writeFileSync(process.argv[1], JSON.stringify(out, null, 2) + "\n");
+          ' "$RUNNER_TEMP/receive-outcome/outcome.json"
+          cat "$RUNNER_TEMP/receive-outcome/outcome.json"
+
+      - name: Upload receive outcome
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ctx-receive-outcome
+          path: ${{ runner.temp }}/receive-outcome/
+          retention-days: 30
+          # workflow_run fires per attempt and the notifier reads the latest;
+          # a re-run must be able to replace attempt 1's artifact.
+          overwrite: true

--- a/.github/workflows/ctx-pipeline-receive.yml
+++ b/.github/workflows/ctx-pipeline-receive.yml
@@ -241,10 +241,14 @@ jobs:
           CHANGED_COUNT: ${{ steps.import.outputs.changed_count }}
           STATE_CHANGED: ${{ steps.import.outputs.state_changed }}
           PR_URL: ${{ steps.pr.outputs.url }}
+          # Binds the file to this attempt: a re-run that dies before the
+          # upload leaves the previous attempt's artifact, which the notifier
+          # must ignore rather than attach to the new message.
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           mkdir -p "$RUNNER_TEMP/receive-outcome"
           node -e '
-            const keys = ["DOCS_REF","DOCS_SHA","GUARD_SKIP","GUARD_BYPASSED","CHANGED","CHANGED_COUNT","STATE_CHANGED","PR_URL"];
+            const keys = ["DOCS_REF","DOCS_SHA","GUARD_SKIP","GUARD_BYPASSED","CHANGED","CHANGED_COUNT","STATE_CHANGED","PR_URL","RUN_ATTEMPT"];
             const out = Object.fromEntries(keys.map((k) => [k.toLowerCase(), process.env[k] ?? ""]));
             require("fs").writeFileSync(process.argv[1], JSON.stringify(out, null, 2) + "\n");
           ' "$RUNNER_TEMP/receive-outcome/outcome.json"

--- a/.github/workflows/ctx-pipeline-receive.yml
+++ b/.github/workflows/ctx-pipeline-receive.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Record receive outcome
         if: always()
         # Notifier plumbing must never redden the receiver: a failure here
-        # only costs the Slack line its docs sha / groupings / PR link.
+        # only costs the Slack message its docs sha / groupings / PR link.
         continue-on-error: true
         env:
           DOCS_REF: ${{ steps.ref.outputs.ref }}

--- a/.github/workflows/ctx-pipeline-receive.yml
+++ b/.github/workflows/ctx-pipeline-receive.yml
@@ -24,11 +24,9 @@ name: Receive agent-context
 # One token with both scopes may back both secrets. The dispatch trigger also
 # requires the CTX_PIPELINE repo variable = 'true'; manual runs never do.
 #
-# Outcomes are posted to #notify-context-pipeline by ctx-pipeline-notify.yml,
-# a workflow_run watcher (EX-3057). It classifies from this job's step
-# conclusions and enriches from the small `ctx-receive-outcome` artifact the
-# last two steps upload on every terminal state (docs sha, groupings, PR URL).
-# Keep step names stable: scripts/ctx-notify.mjs matches them by prefix.
+# Outcomes are posted to Slack by ctx-pipeline-notify.yml (EX-3057), which
+# classifies from this job's step conclusions. Keep the job name and the step
+# names stable: scripts/ctx-notify.mjs matches them by prefix.
 
 on:
   repository_dispatch:
@@ -226,13 +224,9 @@ jobs:
           fi
           echo "url=$(gh pr view "$branch" --json url --jq '.url')" >> "$GITHUB_OUTPUT"
 
-      # What happened, for the Slack notifier (EX-3057). Step outputs are not
-      # visible through the Actions API, so the docs sha, groupings and PR URL
-      # travel as a tiny artifact; the notifier reads the outcome itself
-      # (success / skip / which step failed) from job step conclusions and only
-      # decorates with this. always(): a run that dies mid-way still records
-      # what it resolved (e.g. the docs ref it could not check out). Fields are
-      # strings, possibly empty, exactly as Actions outputs are.
+      # Step outputs are not visible through the Actions API, so the docs sha,
+      # groupings and PR URL travel to the Slack notifier as a tiny artifact.
+      # always(): a run that dies mid-way still records the ref it resolved.
       - name: Record receive outcome
         if: always()
         # Notifier plumbing must never redden the receiver: a failure here

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -10,6 +10,9 @@ on:
       - "scripts/ctx-ordering-guard.test.mjs"
       - "scripts/ctx-notify.mjs"
       - "scripts/ctx-notify.test.mjs"
+      # ctx-notify.test.mjs parses these: a step rename must run the suite.
+      - ".github/workflows/ctx-pipeline-receive.yml"
+      - ".github/workflows/ctx-pipeline-notify.yml"
       - "package.json"
       - ".github/workflows/validate-skills.yml"
 

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -8,6 +8,8 @@ on:
       - "scripts/ctx-receive-ordering.test.mjs"
       - "scripts/ctx-ordering-guard.mjs"
       - "scripts/ctx-ordering-guard.test.mjs"
+      - "scripts/ctx-notify.mjs"
+      - "scripts/ctx-notify.test.mjs"
       - "package.json"
       - ".github/workflows/validate-skills.yml"
 
@@ -65,7 +67,8 @@ jobs:
 
   test-receiver:
     # Zero-dependency script tests for the Stage 2 receiver pipeline
-    # (scripts/ctx-receive.mjs, scripts/ctx-ordering-guard.mjs); `npm test`
+    # (scripts/ctx-receive.mjs, scripts/ctx-ordering-guard.mjs,
+    # scripts/ctx-notify.mjs); `npm test`
     # runs every scripts/*.test.mjs. No npm install: the package has no
     # dependencies, so `npm test` runs as-is.
     permissions:

--- a/scripts/ctx-notify.mjs
+++ b/scripts/ctx-notify.mjs
@@ -19,10 +19,23 @@
 //   ⚠️ UNCLASSIFIED  cancelled / timed out / unrecognized job layout
 // Runs with conclusion "skipped" (CTX_PIPELINE off) post nothing.
 //
-// Field order is a contract shared with the docs-side notifier (the channel
-// is scraped as well as read): shape · run link · docs sha · trigger · detail.
+// Message layout, one field per line (the channel is scraped as well as
+// read, so the order is a contract):
+//   <emoji> ctx-pipeline receive <SHAPE>
+//   docs <sha9|n/a> · <trigger>[ (attempt N)]
+//   <detail>
+//   run: <url>
+//   PR: <url>            (only when the rolling PR was opened or updated)
 // The docs sha is the correlation key: it matches the sha in the docs-side
 // 📦 DELIVERED line for the same delivery.
+//
+// The channel's webhook is a Slack Workflow Builder trigger (EX-3065), which
+// drops `text` into a template as PLAIN text: mrkdwn is not interpreted, so
+// <url|label> links render as literal brackets and &amp; shows as-is. Bare
+// URLs auto-link and newlines break lines, so the message uses only those.
+// The one payload-derived field (docs_ref) has angle brackets stripped: moot
+// in plain-text mode, and the right guard if the trigger ever becomes a
+// classic incoming webhook that does parse mrkdwn.
 //
 // Classification reads GitHub's own job/step conclusions, so it works even
 // for runs that die before checkout. The receive workflow additionally
@@ -67,8 +80,8 @@ const STEP = {
   pr: 'Open or update the rolling sync PR',
 };
 
-export function slackEscape(s) {
-  return String(s).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+export function stripMarkup(s) {
+  return String(s).replaceAll('<', '').replaceAll('>', '');
 }
 
 function truncate(s, max) {
@@ -94,13 +107,6 @@ function groupings(outcome) {
   return 'groupings unknown (no outcome artifact)';
 }
 
-function prLink(outcome) {
-  const url = outcome?.pr_url;
-  if (!url) return 'PR n/a';
-  const m = /\/pull\/(\d+)$/.exec(url);
-  return m ? `PR <${url}|#${m[1]}>` : `PR <${url}>`;
-}
-
 function failureDetail(step, outcome) {
   const name = step?.name ?? '';
   if (name.startsWith(STEP.preflight))
@@ -108,7 +114,7 @@ function failureDetail(step, outcome) {
   if (name.startsWith(STEP.checkoutDocs)) {
     // docs_ref echoes the dispatch payload — untrusted, so it must not carry
     // Slack markup (<!channel>) into the message.
-    const ref = outcome?.docs_ref ? slackEscape(truncate(outcome.docs_ref, 60)) : 'the requested ref';
+    const ref = outcome?.docs_ref ? stripMarkup(truncate(outcome.docs_ref, 60)) : 'the requested ref';
     return `could not check out netlify/docs at ${ref} — DOCS_READ_TOKEN expired, or the ref no longer exists (docs history rewrite?)`;
   }
   if (name.startsWith(STEP.guard))
@@ -144,8 +150,7 @@ export function classifyRun(run, jobs, outcome = null) {
     const guard = step(STEP.guard);
     const imp = step(STEP.import);
     const pr = step(STEP.pr);
-    if (pr?.conclusion === 'success')
-      return { shape: 'imported', detail: `${groupings(outcome)} · ${prLink(outcome)}` };
+    if (pr?.conclusion === 'success') return { shape: 'imported', detail: groupings(outcome) };
     // The import step is gated only on the guard's skip output, so "guard
     // green, import skipped" is a stale delivery and nothing else.
     if (guard?.conclusion === 'success' && imp?.conclusion === 'skipped')
@@ -176,16 +181,20 @@ export function formatMessage(cls, run, outcome = null) {
   if (!cls) return null;
   const { emoji, label } = SHAPES[cls.shape];
   const docsSha = (outcome?.docs_sha || '').slice(0, 9);
-  return [
+  // workflow_run fires per attempt: a re-run posts a second message for the
+  // same run ID, deliberately (a re-run that goes green must post 📥) — the
+  // attempt number keeps the duplicate legible.
+  const attempt = run.run_attempt > 1 ? ` (attempt ${run.run_attempt})` : '';
+  const lines = [
     `${emoji} ctx-pipeline receive ${label}`,
-    // workflow_run fires per attempt: a re-run posts a second line for the
-    // same run ID, deliberately (a re-run that goes green must post 📥) —
-    // the attempt number keeps the duplicate legible.
-    `<${run.html_url}|run ${run.id}>${run.run_attempt > 1 ? ` (attempt ${run.run_attempt})` : ''}`,
-    docsSha ? `docs ${docsSha}` : 'docs n/a',
-    slackEscape(trigger(run, outcome)),
+    `${docsSha ? `docs ${docsSha}` : 'docs n/a'} · ${trigger(run, outcome)}${attempt}`,
     truncate(cls.detail, 300),
-  ].join(' · ');
+    `run: ${run.html_url}`,
+  ];
+  // pr_url is only written when the PR step succeeded, so its presence is
+  // the signal — no shape check needed.
+  if (outcome?.pr_url) lines.push(`PR: ${outcome.pr_url}`);
+  return lines.join('\n');
 }
 
 // ── I/O below: nothing above this line shells out or reads the network ──

--- a/scripts/ctx-notify.mjs
+++ b/scripts/ctx-notify.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// ctx-notify — classify a finished "Receive agent-context" run and post a
+// one-line status to #notify-context-pipeline (EX-3057).
+//
+// Called by .github/workflows/ctx-pipeline-notify.yml (a workflow_run
+// watcher). The docs-side merge pipeline already reports to this channel, but
+// its dispatch to us is fire-and-forget: docs goes green the moment the
+// dispatch is accepted, so a receive failure here was invisible while Slack
+// kept saying "delivered". This closes the loop so "the docs run succeeded"
+// stops being mistaken for "the skills landed".
+//
+// One message per receive run, five shapes:
+//   📥 IMPORTED      skills (or the ordering position) changed; the rolling
+//                    sync PR was opened or updated
+//   💤 NO-OP         docs commit imported cleanly, nothing changed
+//   ⏭️ SKIPPED       stale delivery — the monotonicity guard refused an older
+//                    docs commit (AX-159); self-heals on the next dispatch
+//   🔴 FAILED        with the failing step and, where the step is known, what
+//                    to do about it (the guard's fail-closed branch calls out
+//                    the skip_guard recovery, because that state recurs on
+//                    every later dispatch until a human resets it)
+//   ⚠️ UNCLASSIFIED  cancelled / timed out / unrecognized job layout
+// Runs with conclusion "skipped" (CTX_PIPELINE off) post nothing.
+//
+// Field order is a contract shared with the docs-side notifier (the channel
+// is scraped as well as read): shape · run link · docs sha · trigger · detail.
+// The docs sha is the correlation key: it matches the sha in the docs-side
+// 📦 DELIVERED line for the same delivery.
+//
+// Classification reads GitHub's own job/step conclusions, so it works even
+// for runs that die before checkout. The receive workflow additionally
+// uploads a small `ctx-receive-outcome` artifact (docs sha, groupings, PR
+// URL) that only enriches the message — its absence degrades to "docs n/a",
+// never to a wrong shape. Anything unrecognized posts ⚠️ loudly rather than
+// a confident guess.
+//
+// Inert until SLACK_WEBHOOK_URL exists (ctx-pipeline environment): without it
+// the message prints as a dry run and the step exits 0. A failed Slack POST
+// exits 1 — the notify run goes red in Actions; the receive run itself is
+// never touched.
+//
+// Zero dependencies, Node 18+.
+//
+// Usage:
+//   node scripts/ctx-notify.mjs --run-id <id> [--repo owner/name] [--dry-run]
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const RECEIVE_WORKFLOW = 'Receive agent-context';
+export const OUTCOME_ARTIFACT = 'ctx-receive-outcome';
+
+const SHAPES = {
+  imported: { emoji: '📥', label: 'IMPORTED' },
+  noop: { emoji: '💤', label: 'NO-OP' },
+  stale: { emoji: '⏭️', label: 'SKIPPED' },
+  red: { emoji: '🔴', label: 'FAILED' },
+  unclassified: { emoji: '⚠️', label: 'UNCLASSIFIED' },
+};
+
+// Step names as the receive workflow declares them; matched by prefix so a
+// trailing clarification in the workflow doesn't silently break a match.
+const STEP = {
+  preflight: 'Preflight',
+  checkoutDocs: 'Checkout netlify/docs',
+  guard: 'Monotonicity guard',
+  import: 'Import changed skills',
+  pr: 'Open or update the rolling sync PR',
+};
+
+export function slackEscape(s) {
+  return String(s).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function truncate(s, max) {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+// The outcome artifact is written by the receive workflow from step outputs;
+// every field is a string (Actions outputs are), possibly empty. Anything
+// that is not a JSON object is treated as absent.
+export function parseOutcome(text) {
+  try {
+    const parsed = JSON.parse(text);
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function groupings(outcome) {
+  const changed = (outcome?.changed || '').split(',').filter(Boolean);
+  if (changed.length) return `groupings: ${changed.join(' ')}`;
+  if (outcome?.state_changed === 'true') return 'ordering advanced only (no skill bytes changed)';
+  return 'groupings unknown (no outcome artifact)';
+}
+
+function prLink(outcome) {
+  const url = outcome?.pr_url;
+  if (!url) return 'PR n/a';
+  const m = /\/pull\/(\d+)$/.exec(url);
+  return m ? `PR <${url}|#${m[1]}>` : `PR <${url}>`;
+}
+
+function failureDetail(step, outcome) {
+  const name = step?.name ?? '';
+  if (name.startsWith(STEP.preflight))
+    return 'receiver not configured — DOCS_READ_TOKEN and/or CTX_PIPELINE_PR_TOKEN missing (see run)';
+  if (name.startsWith(STEP.checkoutDocs))
+    return `could not check out netlify/docs at ${outcome?.docs_ref || 'the requested ref'} — DOCS_READ_TOKEN expired, or the ref no longer exists (docs history rewrite?)`;
+  if (name.startsWith(STEP.guard))
+    return 'monotonicity guard failed closed — docs history diverged from lastImportedCommit, or state.json is unreadable. Every later dispatch fails the same way until a manual run with skip_guard resets the baseline';
+  if (name.startsWith(STEP.import))
+    return 'import failed — a previously imported grouping vanished upstream, or an unsupported entry (symlink) in the skill tree; see run';
+  if (name.startsWith(STEP.pr))
+    // The worst red: skills imported, PR never surfaced. Say so.
+    return `skills imported but the rolling sync PR was NOT pushed/opened (check CTX_PIPELINE_PR_TOKEN) — ${groupings(outcome)}`;
+  return `receive failed at "${name || 'unknown step'}"`;
+}
+
+// run: {name, conclusion, id, html_url, event, run_attempt}
+// jobs: [{name, conclusion, steps: [{name, conclusion}]}]
+// outcome: parseOutcome() result, or null (artifact unavailable)
+// Returns {shape, detail} or null (post nothing).
+export function classifyRun(run, jobs, outcome = null) {
+  if (run.name !== RECEIVE_WORKFLOW)
+    return { shape: 'unclassified', detail: `unknown workflow "${run.name}"` };
+  if (run.conclusion === 'skipped') return null;
+
+  if (run.conclusion === 'cancelled' || run.conclusion === 'timed_out')
+    return { shape: 'unclassified', detail: `run ${run.conclusion} before completion` };
+  // Dies-before-checkout is unambiguous red, not confusion — it's the exact
+  // case this watcher exists to catch.
+  if (run.conclusion === 'startup_failure')
+    return { shape: 'red', detail: 'workflow failed to start (startup_failure) — see the run page' };
+
+  const job = jobs.find((j) => j.name === 'receive');
+  const step = (prefix) => job?.steps?.find((s) => s.name.startsWith(prefix));
+
+  if (run.conclusion === 'success') {
+    if (!job) return { shape: 'unclassified', detail: 'green run but no "receive" job found' };
+    const guard = step(STEP.guard);
+    const imp = step(STEP.import);
+    const pr = step(STEP.pr);
+    if (pr?.conclusion === 'success')
+      return { shape: 'imported', detail: `${groupings(outcome)} · ${prLink(outcome)}` };
+    // The import step is gated only on the guard's skip output, so "guard
+    // green, import skipped" is a stale delivery and nothing else.
+    if (guard?.conclusion === 'success' && imp?.conclusion === 'skipped')
+      return { shape: 'stale', detail: 'stale delivery — an older docs commit arrived after a newer import (AX-159); no action, self-heals on the next dispatch' };
+    if (imp?.conclusion === 'success' && pr?.conclusion === 'skipped')
+      return { shape: 'noop', detail: 'docs commit matches what is already imported — nothing to do' };
+    return { shape: 'unclassified', detail: 'green run with unrecognized step layout' };
+  }
+
+  if (run.conclusion === 'failure') {
+    if (!job) return { shape: 'red', detail: 'run failed but no "receive" job reported' };
+    const failed = job.steps?.find((s) => s.conclusion === 'failure');
+    if (!failed) return { shape: 'red', detail: 'run failed but no failed step reported' };
+    return { shape: 'red', detail: failureDetail(failed, outcome) };
+  }
+
+  return { shape: 'unclassified', detail: `unhandled run conclusion "${run.conclusion}"` };
+}
+
+function trigger(run, outcome) {
+  if (run.event === 'repository_dispatch') return 'dispatch';
+  if (run.event === 'workflow_dispatch')
+    return outcome?.guard_bypassed === 'true' ? 'manual (skip_guard)' : 'manual';
+  return run.event || 'trigger n/a';
+}
+
+export function formatMessage(cls, run, outcome = null) {
+  if (!cls) return null;
+  const { emoji, label } = SHAPES[cls.shape];
+  const docsSha = (outcome?.docs_sha || '').slice(0, 9);
+  return [
+    `${emoji} ctx-pipeline receive ${label}`,
+    // workflow_run fires per attempt: a re-run posts a second line for the
+    // same run ID, deliberately (a re-run that goes green must post 📥) —
+    // the attempt number keeps the duplicate legible.
+    `<${run.html_url}|run ${run.id}>${run.run_attempt > 1 ? ` (attempt ${run.run_attempt})` : ''}`,
+    docsSha ? `docs ${docsSha}` : 'docs n/a',
+    slackEscape(trigger(run, outcome)),
+    truncate(cls.detail, 300),
+  ].join(' · ');
+}
+
+// ── I/O below: nothing above this line shells out or reads the network ──
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+function loadOutcome(repo, runId) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-notify-'));
+  try {
+    gh(['run', 'download', String(runId), '-R', repo, '-n', OUTCOME_ARTIFACT, '-D', dir]);
+    return parseOutcome(fs.readFileSync(path.join(dir, 'outcome.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--dry-run') args.dryRun = true;
+    else if (argv[i] === '--run-id') args.runId = argv[++i];
+    else if (argv[i] === '--repo') args.repo = argv[++i];
+    else throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = args.repo || process.env.GITHUB_REPOSITORY;
+  if (!args.runId || !repo) {
+    console.error('usage: ctx-notify.mjs --run-id <id> [--repo owner/name] [--dry-run]');
+    process.exit(2);
+  }
+  const run = ghJson(['api', `repos/${repo}/actions/runs/${args.runId}`]);
+  const { jobs } = ghJson(['api', `repos/${repo}/actions/runs/${args.runId}/jobs?per_page=100`]);
+  const outcome = run.conclusion === 'skipped' ? null : loadOutcome(repo, args.runId);
+
+  const message = formatMessage(classifyRun(run, jobs, outcome), run, outcome);
+  if (!message) {
+    console.log(`no message for this run (${run.conclusion} ${run.name})`);
+    return;
+  }
+
+  const webhook = process.env.SLACK_WEBHOOK_URL;
+  if (args.dryRun || process.env.DRY_RUN === 'true' || !webhook) {
+    if (!webhook) console.log('SLACK_WEBHOOK_URL unset — inert until the secret exists in the ctx-pipeline environment');
+    console.log(`notify (dry-run): ${message}`);
+    return;
+  }
+  const res = await fetch(webhook, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text: message }),
+  });
+  if (!res.ok) {
+    console.error(`Slack webhook returned ${res.status}: ${await res.text()}`);
+    process.exit(1);
+  }
+  console.log(`posted: ${message}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err.stack || err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/ctx-notify.mjs
+++ b/scripts/ctx-notify.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // ctx-notify — classify a finished "Receive agent-context" run and post a
-// one-line status to #notify-context-pipeline (EX-3057).
+// short status to #notify-context-pipeline (EX-3057).
 //
 // Called by .github/workflows/ctx-pipeline-notify.yml (a workflow_run
 // watcher). The docs-side notifier reports delivery when its dispatch is
@@ -79,6 +79,8 @@ const STEP = {
   import: 'Import changed skills',
   pr: 'Open or update the rolling sync PR',
 };
+
+const PULL_URL = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+$/;
 
 export function stripMarkup(s) {
   return String(s).replaceAll('<', '').replaceAll('>', '');
@@ -191,9 +193,10 @@ export function formatMessage(cls, run, outcome = null) {
     truncate(cls.detail, 300),
     `run: ${run.html_url}`,
   ];
-  // pr_url is only written when the PR step succeeded, so its presence is
-  // the signal — no shape check needed.
-  if (outcome?.pr_url) lines.push(`PR: ${outcome.pr_url}`);
+  // The receive workflow only writes pr_url when the PR step succeeded, but
+  // the header promises this line appears on IMPORTED alone, so the shape
+  // and the URL's form are checked here rather than trusted from the artifact.
+  if (cls.shape === 'imported' && PULL_URL.test(outcome?.pr_url || '')) lines.push(`PR: ${outcome.pr_url}`);
   return lines.join('\n');
 }
 

--- a/scripts/ctx-notify.mjs
+++ b/scripts/ctx-notify.mjs
@@ -19,8 +19,8 @@
 //   ⚠️ UNCLASSIFIED  cancelled / timed out / unrecognized job layout
 // Runs with conclusion "skipped" (CTX_PIPELINE off) post nothing.
 //
-// Message layout, one field per line (the channel is scraped as well as
-// read, so the order is a contract):
+// Message layout, one field per line, in a fixed order so a reader can pair
+// it with the docs-side line at a glance:
 //   <emoji> ctx-pipeline receive <SHAPE>
 //   docs <sha9|n/a> · <trigger>[ (attempt N)]
 //   <detail>
@@ -37,12 +37,28 @@
 // in plain-text mode, and the right guard if the trigger ever becomes a
 // classic incoming webhook that does parse mrkdwn.
 //
+// Trust boundary: workflow_run matches the watched workflow by NAME and fires
+// for any completed run of that name, including one a fork PR produced by
+// adding a pull_request trigger (or a same-named file) — and this watcher
+// runs on main with the webhook secret. So only runs from this repository
+// triggered by repository_dispatch or workflow_dispatch (the receive
+// workflow's only legitimate triggers) are classified; anything else is
+// refused before its steps or artifact are read. The notify workflow's job
+// `if:` enforces the same rule so a foreign run never starts a runner.
+//
 // Classification reads GitHub's own job/step conclusions, so it works even
 // for runs that die before checkout. The receive workflow additionally
 // uploads a small `ctx-receive-outcome` artifact (docs sha, groupings, PR
 // URL) that only enriches the message — its absence degrades to "docs n/a",
-// never to a wrong shape. Anything unrecognized posts ⚠️ loudly rather than
-// a confident guess.
+// never to a wrong shape. The artifact carries the run_attempt that wrote
+// it; a re-run that dies before uploading leaves the previous attempt's file
+// behind, and that one is ignored rather than attached to the new message.
+// Anything unrecognized posts ⚠️ loudly rather than a confident guess.
+//
+// GitHub API reads and the Slack POST retry three times with backoff and a
+// 10s timeout each. If Slack is still down after that the notify run goes
+// red; a persistent Slack outage cannot be reported through Slack, and the
+// red run is the floor (same as the docs side).
 //
 // Inert until SLACK_WEBHOOK_URL exists (ctx-pipeline environment): without it
 // the message prints as a dry run and the step exits 0. A failed Slack POST
@@ -71,8 +87,9 @@ const SHAPES = {
 };
 
 // Step names as the receive workflow declares them; matched by prefix so a
-// trailing clarification in the workflow doesn't silently break a match.
-const STEP = {
+// trailing clarification in the workflow doesn't silently break a match. The
+// test suite parses the workflow and fails if any prefix stops matching.
+export const STEP = {
   preflight: 'Preflight',
   checkoutDocs: 'Checkout netlify/docs',
   guard: 'Monotonicity guard',
@@ -81,6 +98,24 @@ const STEP = {
 };
 
 const PULL_URL = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+$/;
+
+export const TRUSTED_EVENTS = ['repository_dispatch', 'workflow_dispatch'];
+
+// Returns null when the run may be classified, else the reason it may not.
+// run: {event, head_repository: {full_name}}
+export function untrustedReason(run, repo) {
+  const head = run.head_repository?.full_name;
+  if (head !== repo) return `run belongs to ${head ?? 'an unknown repository'}, not ${repo} (fork?)`;
+  if (!TRUSTED_EVENTS.includes(run.event))
+    return `run was triggered by ${run.event ?? 'an unknown event'}; the receive workflow only runs on ${TRUSTED_EVENTS.join(' / ')}`;
+  return null;
+}
+
+// The artifact is only trusted for the attempt that wrote it (see header).
+export function outcomeForAttempt(outcome, run) {
+  if (!outcome) return null;
+  return outcome.run_attempt === String(run.run_attempt) ? outcome : null;
+}
 
 export function stripMarkup(s) {
   return String(s).replaceAll('<', '').replaceAll('>', '');
@@ -122,7 +157,7 @@ function failureDetail(step, outcome) {
   if (name.startsWith(STEP.guard))
     return 'monotonicity guard failed closed — docs history diverged from lastImportedCommit, or state.json is unreadable. Every later dispatch fails the same way until a manual run with skip_guard resets the baseline';
   if (name.startsWith(STEP.import))
-    return 'import failed — a previously imported grouping vanished upstream, or an unsupported entry (symlink) in the skill tree; see run';
+    return 'import failed — ctx-receive exited non-zero; the run log names the cause';
   if (name.startsWith(STEP.pr))
     return `skills imported but the rolling sync PR was NOT pushed/opened (check CTX_PIPELINE_PR_TOKEN) — ${groupings(outcome)}`;
   return `receive failed at "${name || 'unknown step'}"`;
@@ -202,18 +237,33 @@ export function formatMessage(cls, run, outcome = null) {
 
 // ── I/O below: nothing above this line shells out or reads the network ──
 
-function gh(args) {
-  return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-}
-function ghJson(args) {
-  return JSON.parse(gh(args));
+const RETRY_DELAYS_MS = [2000, 5000];
+const HTTP_TIMEOUT_MS = 10_000;
+
+async function withRetry(label, fn) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= RETRY_DELAYS_MS.length) throw err;
+      console.error(`${label} failed (${err.message.split('\n')[0]}); retrying in ${RETRY_DELAYS_MS[attempt] / 1000}s`);
+      await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+    }
+  }
 }
 
-function loadOutcome(repo, runId) {
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: HTTP_TIMEOUT_MS });
+}
+function ghJson(args) {
+  return withRetry(`gh ${args[0]} ${args[1]}`, async () => JSON.parse(gh(args)));
+}
+
+function loadOutcome(repo, run) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-notify-'));
   try {
-    gh(['run', 'download', String(runId), '-R', repo, '-n', OUTCOME_ARTIFACT, '-D', dir]);
-    return parseOutcome(fs.readFileSync(path.join(dir, 'outcome.json'), 'utf8'));
+    gh(['run', 'download', String(run.id), '-R', repo, '-n', OUTCOME_ARTIFACT, '-D', dir]);
+    return outcomeForAttempt(parseOutcome(fs.readFileSync(path.join(dir, 'outcome.json'), 'utf8')), run);
   } catch {
     return null;
   }
@@ -241,9 +291,14 @@ async function main() {
     console.error(`--run-id must be numeric, got ${JSON.stringify(args.runId)}`);
     process.exit(2);
   }
-  const run = ghJson(['api', `repos/${repo}/actions/runs/${args.runId}`]);
-  const { jobs } = ghJson(['api', `repos/${repo}/actions/runs/${args.runId}/jobs?per_page=100`]);
-  const outcome = run.conclusion === 'skipped' ? null : loadOutcome(repo, args.runId);
+  const run = await ghJson(['api', `repos/${repo}/actions/runs/${args.runId}`]);
+  const refused = untrustedReason(run, repo);
+  if (refused) {
+    console.log(`refusing to classify run ${run.id}: ${refused}`);
+    return;
+  }
+  const { jobs } = await ghJson(['api', `repos/${repo}/actions/runs/${args.runId}/jobs?per_page=100`]);
+  const outcome = run.conclusion === 'skipped' ? null : loadOutcome(repo, run);
 
   const message = formatMessage(classifyRun(run, jobs, outcome), run, outcome);
   if (!message) {
@@ -257,15 +312,15 @@ async function main() {
     console.log(`notify (dry-run): ${message}`);
     return;
   }
-  const res = await fetch(webhook, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ text: message }),
+  await withRetry('Slack POST', async () => {
+    const res = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: message }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`Slack webhook returned ${res.status}: ${await res.text()}`);
   });
-  if (!res.ok) {
-    console.error(`Slack webhook returned ${res.status}: ${await res.text()}`);
-    process.exit(1);
-  }
   console.log(`posted: ${message}`);
 }
 

--- a/scripts/ctx-notify.mjs
+++ b/scripts/ctx-notify.mjs
@@ -3,11 +3,8 @@
 // one-line status to #notify-context-pipeline (EX-3057).
 //
 // Called by .github/workflows/ctx-pipeline-notify.yml (a workflow_run
-// watcher). The docs-side merge pipeline already reports to this channel, but
-// its dispatch to us is fire-and-forget: docs goes green the moment the
-// dispatch is accepted, so a receive failure here was invisible while Slack
-// kept saying "delivered". This closes the loop so "the docs run succeeded"
-// stops being mistaken for "the skills landed".
+// watcher). The docs-side notifier reports delivery when its dispatch is
+// accepted; this one reports whether the import actually landed.
 //
 // One message per receive run, five shapes:
 //   📥 IMPORTED      skills (or the ordering position) changed; the rolling
@@ -108,14 +105,17 @@ function failureDetail(step, outcome) {
   const name = step?.name ?? '';
   if (name.startsWith(STEP.preflight))
     return 'receiver not configured — DOCS_READ_TOKEN and/or CTX_PIPELINE_PR_TOKEN missing (see run)';
-  if (name.startsWith(STEP.checkoutDocs))
-    return `could not check out netlify/docs at ${outcome?.docs_ref || 'the requested ref'} — DOCS_READ_TOKEN expired, or the ref no longer exists (docs history rewrite?)`;
+  if (name.startsWith(STEP.checkoutDocs)) {
+    // docs_ref echoes the dispatch payload — untrusted, so it must not carry
+    // Slack markup (<!channel>) into the message.
+    const ref = outcome?.docs_ref ? slackEscape(truncate(outcome.docs_ref, 60)) : 'the requested ref';
+    return `could not check out netlify/docs at ${ref} — DOCS_READ_TOKEN expired, or the ref no longer exists (docs history rewrite?)`;
+  }
   if (name.startsWith(STEP.guard))
     return 'monotonicity guard failed closed — docs history diverged from lastImportedCommit, or state.json is unreadable. Every later dispatch fails the same way until a manual run with skip_guard resets the baseline';
   if (name.startsWith(STEP.import))
     return 'import failed — a previously imported grouping vanished upstream, or an unsupported entry (symlink) in the skill tree; see run';
   if (name.startsWith(STEP.pr))
-    // The worst red: skills imported, PR never surfaced. Say so.
     return `skills imported but the rolling sync PR was NOT pushed/opened (check CTX_PIPELINE_PR_TOKEN) — ${groupings(outcome)}`;
   return `receive failed at "${name || 'unknown step'}"`;
 }
@@ -223,6 +223,10 @@ async function main() {
   const repo = args.repo || process.env.GITHUB_REPOSITORY;
   if (!args.runId || !repo) {
     console.error('usage: ctx-notify.mjs --run-id <id> [--repo owner/name] [--dry-run]');
+    process.exit(2);
+  }
+  if (!/^\d+$/.test(args.runId)) {
+    console.error(`--run-id must be numeric, got ${JSON.stringify(args.runId)}`);
     process.exit(2);
   }
   const run = ghJson(['api', `repos/${repo}/actions/runs/${args.runId}`]);

--- a/scripts/ctx-notify.test.mjs
+++ b/scripts/ctx-notify.test.mjs
@@ -148,6 +148,10 @@ test('red: docs checkout failure carries the requested ref when known', () => {
   assert.match(cls.detail, /netlify\/docs at deadbeef/);
   const bare = classifyRun(run({ conclusion: 'failure' }), jobs, null);
   assert.match(bare.detail, /at the requested ref/);
+  // docs_ref echoes the dispatch payload: Slack markup must not survive.
+  const hostile = classifyRun(run({ conclusion: 'failure' }), jobs, { docs_ref: '<!channel> ' + 'x'.repeat(100) });
+  assert.doesNotMatch(hostile.detail, /<!channel>/);
+  assert.match(hostile.detail, /&lt;!channel&gt; x+…/);
 });
 
 test('red: import step failure', () => {

--- a/scripts/ctx-notify.test.mjs
+++ b/scripts/ctx-notify.test.mjs
@@ -228,6 +228,28 @@ test('formatMessage: one field per line in contract order, docs sha shortened to
   assert.doesNotMatch(msg, /[<>]|&amp;/);
 });
 
+test('formatMessage: a populated pr_url never produces a PR line on a non-imported shape', () => {
+  const failed = run({ conclusion: 'failure' });
+  const cases = [
+    ['noop', run(), [receiveJob({ 'Open or update the rolling sync PR': 'skipped' })]],
+    ['stale', run(), [receiveJob({ 'Import changed skills': 'skipped', 'Open or update the rolling sync PR': 'skipped' })]],
+    ['red', failed, [receiveJob({ 'Open or update the rolling sync PR': 'failure' })]],
+    ['unclassified', run({ conclusion: 'cancelled' }), [receiveJob()]],
+  ];
+  for (const [shape, r, jobs] of cases) {
+    const cls = classifyRun(r, jobs, OUTCOME);
+    assert.equal(cls.shape, shape);
+    assert.doesNotMatch(formatMessage(cls, r, OUTCOME), /^PR:/m, shape);
+  }
+});
+
+test('formatMessage: PR line requires a GitHub pull URL, not whatever the artifact says', () => {
+  for (const bad of ['', 'not a url', 'https://example.com/pull/1', 'https://github.com/netlify/context-and-tools/pull/12 <!channel>']) {
+    const msg = formatMessage(classifyRun(run(), [receiveJob()], { ...OUTCOME, pr_url: bad }), run(), { ...OUTCOME, pr_url: bad });
+    assert.doesNotMatch(msg, /^PR:/m, JSON.stringify(bad));
+  }
+});
+
 test('formatMessage: docs n/a without an artifact; attempt number on re-runs; no PR line', () => {
   const r = run({ run_attempt: 2 });
   const lines = formatMessage(classifyRun(r, [receiveJob()], null), r, null).split('\n');

--- a/scripts/ctx-notify.test.mjs
+++ b/scripts/ctx-notify.test.mjs
@@ -14,32 +14,33 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   RECEIVE_WORKFLOW,
+  STEP,
+  TRUSTED_EVENTS,
   classifyRun,
   formatMessage,
+  outcomeForAttempt,
   parseOutcome,
   stripMarkup,
+  untrustedReason,
 } from './ctx-notify.mjs';
 
-// Step names exactly as .github/workflows/ctx-pipeline-receive.yml declares
-// them (and as the jobs API reports them, em dash included).
-const STEPS = [
-  'Set up job',
-  'Preflight — required secrets',
-  'Resolve docs ref',
-  'Checkout context-and-tools',
-  'Checkout netlify/docs at ref',
-  'Resolve docs commit',
-  'Resolve import baseline',
-  'Monotonicity guard',
-  'Import changed skills',
-  'Open or update the rolling sync PR',
-  'Record receive outcome',
-  'Upload receive outcome',
-  'Complete job',
-];
+const WORKFLOWS = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '.github', 'workflows');
+const RECEIVE_YML = fs.readFileSync(path.join(WORKFLOWS, 'ctx-pipeline-receive.yml'), 'utf8');
+const NOTIFY_YML = fs.readFileSync(path.join(WORKFLOWS, 'ctx-pipeline-notify.yml'), 'utf8');
+
+// Step names are read from the receive workflow itself, not copied by hand,
+// so a rename there fails here. The jobs API wraps them in the two runner
+// steps; the classifier never looks at those.
+const WORKFLOW_STEPS = RECEIVE_YML.split('\n')
+  .filter((l) => /^      - name: /.test(l))
+  .map((l) => l.replace(/^      - name: /, '').trim());
+const STEPS = ['Set up job', ...WORKFLOW_STEPS, 'Complete job'];
 
 // Build a receive job where every step is green except those named in
 // `overrides` (step name → conclusion). Steps after the first failure are
@@ -80,7 +81,51 @@ const OUTCOME = {
   changed_count: '2',
   state_changed: 'true',
   pr_url: 'https://github.com/netlify/context-and-tools/pull/123',
+  run_attempt: '1',
 };
+const OUTCOME_WITH_ATTEMPT_2 = { ...OUTCOME, run_attempt: '2' };
+
+// ── coupling to the workflows: names the classifier keys on must exist ──
+
+test('every STEP prefix matches exactly one step in ctx-pipeline-receive.yml', () => {
+  assert.ok(WORKFLOW_STEPS.length >= 5, 'parsed too few steps from the receive workflow');
+  for (const [key, prefix] of Object.entries(STEP)) {
+    const hits = WORKFLOW_STEPS.filter((s) => s.startsWith(prefix));
+    assert.equal(hits.length, 1, `STEP.${key} (${JSON.stringify(prefix)}) matched ${hits.length} steps: ${JSON.stringify(hits)}`);
+  }
+});
+
+test('the receive workflow name and the notify trigger both equal RECEIVE_WORKFLOW', () => {
+  assert.match(RECEIVE_YML, new RegExp(`^name: ${RECEIVE_WORKFLOW}$`, 'm'));
+  assert.match(NOTIFY_YML, new RegExp(`workflows: \\["${RECEIVE_WORKFLOW}"\\]`));
+});
+
+test('the receive workflow has no triggers beyond TRUSTED_EVENTS', () => {
+  const on = RECEIVE_YML.slice(RECEIVE_YML.indexOf('\non:\n') + 5, RECEIVE_YML.indexOf('\npermissions:'));
+  const triggers = on.split('\n').filter((l) => /^  \w/.test(l)).map((l) => l.trim().replace(/:$/, ''));
+  assert.deepEqual(triggers.sort(), [...TRUSTED_EVENTS].sort());
+});
+
+// ── trust boundary ──
+
+test('untrustedReason: same-repo dispatch runs pass; forks and other events are refused', () => {
+  const repo = 'netlify/context-and-tools';
+  const ok = { event: 'repository_dispatch', head_repository: { full_name: repo } };
+  assert.equal(untrustedReason(ok, repo), null);
+  assert.equal(untrustedReason({ ...ok, event: 'workflow_dispatch' }, repo), null);
+  assert.match(untrustedReason({ ...ok, head_repository: { full_name: 'attacker/context-and-tools' } }, repo), /attacker\/context-and-tools.*fork/);
+  assert.match(untrustedReason({ ...ok, head_repository: undefined }, repo), /unknown repository/);
+  assert.match(untrustedReason({ ...ok, event: 'pull_request' }, repo), /pull_request/);
+  assert.match(untrustedReason({ ...ok, event: 'push' }, repo), /push/);
+});
+
+test('outcomeForAttempt: the artifact only counts for the attempt that wrote it', () => {
+  const r = run({ run_attempt: 2 });
+  assert.deepEqual(outcomeForAttempt({ ...OUTCOME, run_attempt: '2' }, r), OUTCOME_WITH_ATTEMPT_2);
+  assert.equal(outcomeForAttempt({ ...OUTCOME, run_attempt: '1' }, r), null);
+  assert.equal(outcomeForAttempt({ ...OUTCOME }, r), null, 'an artifact without run_attempt predates the check and is not trusted');
+  assert.equal(outcomeForAttempt(null, r), null);
+});
 
 // ── shapes ──
 
@@ -155,11 +200,11 @@ test('red: docs checkout failure carries the requested ref when known', () => {
   assert.match(hostile.detail, /!channel x+…/);
 });
 
-test('red: import step failure', () => {
+test('red: import step failure points at the run log rather than guessing a cause', () => {
   const jobs = [receiveJob({ 'Import changed skills': 'failure' })];
   const cls = classifyRun(run({ conclusion: 'failure' }), jobs, OUTCOME);
   assert.equal(cls.shape, 'red');
-  assert.match(cls.detail, /^import failed/);
+  assert.match(cls.detail, /^import failed — ctx-receive exited non-zero/);
 });
 
 test('red: PR step failure says skills imported but PR not surfaced, with groupings', () => {

--- a/scripts/ctx-notify.test.mjs
+++ b/scripts/ctx-notify.test.mjs
@@ -20,7 +20,7 @@ import {
   classifyRun,
   formatMessage,
   parseOutcome,
-  slackEscape,
+  stripMarkup,
 } from './ctx-notify.mjs';
 
 // Step names exactly as .github/workflows/ctx-pipeline-receive.yml declares
@@ -84,11 +84,12 @@ const OUTCOME = {
 
 // ── shapes ──
 
-test('imported: PR step green → 📥 with groupings and PR link', () => {
+test('imported: PR step green → 📥 with groupings; the PR URL rides on its own line', () => {
   const cls = classifyRun(run(), [receiveJob()], OUTCOME);
   assert.equal(cls.shape, 'imported');
-  assert.match(cls.detail, /groupings: functions forms/);
-  assert.match(cls.detail, /PR <https:\/\/github\.com\/netlify\/context-and-tools\/pull\/123\|#123>/);
+  assert.equal(cls.detail, 'groupings: functions forms');
+  const msg = formatMessage(cls, run(), OUTCOME);
+  assert.equal(msg.split('\n').pop(), 'PR: https://github.com/netlify/context-and-tools/pull/123');
 });
 
 test('imported: ordering-only advance names itself rather than listing groupings', () => {
@@ -101,7 +102,7 @@ test('imported: no outcome artifact degrades the detail, not the shape', () => {
   const cls = classifyRun(run(), [receiveJob()], null);
   assert.equal(cls.shape, 'imported');
   assert.match(cls.detail, /groupings unknown/);
-  assert.match(cls.detail, /PR n\/a/);
+  assert.doesNotMatch(formatMessage(cls, run(), null), /^PR:/m);
 });
 
 test('noop: import green, PR skipped → 💤', () => {
@@ -150,8 +151,8 @@ test('red: docs checkout failure carries the requested ref when known', () => {
   assert.match(bare.detail, /at the requested ref/);
   // docs_ref echoes the dispatch payload: Slack markup must not survive.
   const hostile = classifyRun(run({ conclusion: 'failure' }), jobs, { docs_ref: '<!channel> ' + 'x'.repeat(100) });
-  assert.doesNotMatch(hostile.detail, /<!channel>/);
-  assert.match(hostile.detail, /&lt;!channel&gt; x+…/);
+  assert.doesNotMatch(hostile.detail, /[<>]/);
+  assert.match(hostile.detail, /!channel x+…/);
 });
 
 test('red: import step failure', () => {
@@ -212,34 +213,38 @@ test('unclassified: green run with a step layout the classifier does not know', 
   assert.equal(classifyRun(run(), [], null).shape, 'unclassified');
 });
 
-// ── message grammar: shape · run · docs sha · trigger · detail ──
+// ── message layout: status / docs+trigger / detail / run URL / PR URL ──
 
-test('formatMessage: five fields in contract order, docs sha shortened to 9', () => {
+test('formatMessage: one field per line in contract order, docs sha shortened to 9, plain-text only', () => {
   const msg = formatMessage(classifyRun(run(), [receiveJob()], OUTCOME), run(), OUTCOME);
-  const fields = msg.split(' · ');
-  assert.equal(fields[0], '📥 ctx-pipeline receive IMPORTED');
-  assert.equal(fields[1], '<https://github.com/netlify/context-and-tools/actions/runs/32073913019|run 32073913019>');
-  assert.equal(fields[2], `docs ${DOCS_SHA.slice(0, 9)}`);
-  assert.equal(fields[3], 'dispatch');
-  assert.ok(fields.slice(4).join(' · ').startsWith('groupings: functions forms'));
+  assert.deepEqual(msg.split('\n'), [
+    '📥 ctx-pipeline receive IMPORTED',
+    `docs ${DOCS_SHA.slice(0, 9)} · dispatch`,
+    'groupings: functions forms',
+    'run: https://github.com/netlify/context-and-tools/actions/runs/32073913019',
+    'PR: https://github.com/netlify/context-and-tools/pull/123',
+  ]);
+  // Workflow Builder renders the variable as plain text: no mrkdwn links, no entities.
+  assert.doesNotMatch(msg, /[<>]|&amp;/);
 });
 
-test('formatMessage: docs n/a without an artifact; attempt number on re-runs', () => {
+test('formatMessage: docs n/a without an artifact; attempt number on re-runs; no PR line', () => {
   const r = run({ run_attempt: 2 });
-  const msg = formatMessage(classifyRun(r, [receiveJob()], null), r, null);
-  assert.match(msg, /run 32073913019> \(attempt 2\) · docs n\/a · dispatch ·/);
+  const lines = formatMessage(classifyRun(r, [receiveJob()], null), r, null).split('\n');
+  assert.equal(lines[1], 'docs n/a · dispatch (attempt 2)');
+  assert.equal(lines.length, 4);
 });
 
 test('formatMessage: manual runs say so, and skip_guard bypasses are flagged', () => {
   const r = run({ event: 'workflow_dispatch' });
-  assert.match(formatMessage(classifyRun(r, [receiveJob()], OUTCOME), r, OUTCOME), / · manual · /);
+  assert.equal(formatMessage(classifyRun(r, [receiveJob()], OUTCOME), r, OUTCOME).split('\n')[1], `docs ${DOCS_SHA.slice(0, 9)} · manual`);
   const bypass = { ...OUTCOME, guard_bypassed: 'true' };
-  assert.match(formatMessage(classifyRun(r, [receiveJob()], bypass), r, bypass), / · manual \(skip_guard\) · /);
+  assert.equal(formatMessage(classifyRun(r, [receiveJob()], bypass), r, bypass).split('\n')[1], `docs ${DOCS_SHA.slice(0, 9)} · manual (skip_guard)`);
 });
 
 test('formatMessage: detail is capped at 300 chars', () => {
   const msg = formatMessage({ shape: 'red', detail: 'x'.repeat(500) }, run(), null);
-  const detail = msg.split(' · ').pop();
+  const detail = msg.split('\n')[2];
   assert.equal(detail.length, 300);
   assert.ok(detail.endsWith('…'));
 });
@@ -253,6 +258,6 @@ test('parseOutcome: object passes; garbage, arrays and null are absent', () => {
   assert.equal(parseOutcome('null'), null);
 });
 
-test('slackEscape escapes the three mrkdwn control characters', () => {
-  assert.equal(slackEscape('a<b>&c'), 'a&lt;b&gt;&amp;c');
+test('stripMarkup removes angle brackets and leaves everything else alone', () => {
+  assert.equal(stripMarkup('a<b>&c'), 'ab&c');
 });

--- a/scripts/ctx-notify.test.mjs
+++ b/scripts/ctx-notify.test.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// ctx-notify.test.mjs — zero-dependency test suite for scripts/ctx-notify.mjs.
+//
+// Exercises the pure classification and formatting layer (everything above
+// the I/O line) against run/jobs fixtures shaped like the GitHub Actions API
+// responses the watcher reads. Each shape in the header's table has a case,
+// plus the degradation rules: a missing outcome artifact must never change
+// the shape (only the docs sha / groupings / PR fields), and anything
+// unrecognized must land on ⚠️ rather than a confident guess.
+//
+// Zero dependencies, Node 18+ (node:test, node:assert/strict).
+//
+// Usage: node scripts/ctx-notify.test.mjs   (also wired as `npm test`)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  RECEIVE_WORKFLOW,
+  classifyRun,
+  formatMessage,
+  parseOutcome,
+  slackEscape,
+} from './ctx-notify.mjs';
+
+// Step names exactly as .github/workflows/ctx-pipeline-receive.yml declares
+// them (and as the jobs API reports them, em dash included).
+const STEPS = [
+  'Set up job',
+  'Preflight — required secrets',
+  'Resolve docs ref',
+  'Checkout context-and-tools',
+  'Checkout netlify/docs at ref',
+  'Resolve docs commit',
+  'Resolve import baseline',
+  'Monotonicity guard',
+  'Import changed skills',
+  'Open or update the rolling sync PR',
+  'Record receive outcome',
+  'Upload receive outcome',
+  'Complete job',
+];
+
+// Build a receive job where every step is green except those named in
+// `overrides` (step name → conclusion). Steps after the first failure are
+// skipped, as Actions reports them.
+function receiveJob(overrides = {}) {
+  let failed = false;
+  const steps = STEPS.map((name) => {
+    if (name in overrides) {
+      if (overrides[name] === 'failure') failed = true;
+      return { name, conclusion: overrides[name] };
+    }
+    if (failed && !name.startsWith('Record') && !name.startsWith('Upload') && name !== 'Complete job')
+      return { name, conclusion: 'skipped' };
+    return { name, conclusion: 'success' };
+  });
+  return { name: 'receive', conclusion: failed ? 'failure' : 'success', steps };
+}
+
+function run(overrides = {}) {
+  return {
+    name: RECEIVE_WORKFLOW,
+    conclusion: 'success',
+    id: 32073913019,
+    html_url: 'https://github.com/netlify/context-and-tools/actions/runs/32073913019',
+    event: 'repository_dispatch',
+    run_attempt: 1,
+    ...overrides,
+  };
+}
+
+const DOCS_SHA = 'e33a7260cd1ab02c53b80420d047044454a29833';
+const OUTCOME = {
+  docs_ref: DOCS_SHA,
+  docs_sha: DOCS_SHA,
+  guard_skip: '0',
+  guard_bypassed: 'false',
+  changed: 'functions,forms',
+  changed_count: '2',
+  state_changed: 'true',
+  pr_url: 'https://github.com/netlify/context-and-tools/pull/123',
+};
+
+// ── shapes ──
+
+test('imported: PR step green → 📥 with groupings and PR link', () => {
+  const cls = classifyRun(run(), [receiveJob()], OUTCOME);
+  assert.equal(cls.shape, 'imported');
+  assert.match(cls.detail, /groupings: functions forms/);
+  assert.match(cls.detail, /PR <https:\/\/github\.com\/netlify\/context-and-tools\/pull\/123\|#123>/);
+});
+
+test('imported: ordering-only advance names itself rather than listing groupings', () => {
+  const cls = classifyRun(run(), [receiveJob()], { ...OUTCOME, changed: '', changed_count: '0' });
+  assert.equal(cls.shape, 'imported');
+  assert.match(cls.detail, /ordering advanced only/);
+});
+
+test('imported: no outcome artifact degrades the detail, not the shape', () => {
+  const cls = classifyRun(run(), [receiveJob()], null);
+  assert.equal(cls.shape, 'imported');
+  assert.match(cls.detail, /groupings unknown/);
+  assert.match(cls.detail, /PR n\/a/);
+});
+
+test('noop: import green, PR skipped → 💤', () => {
+  const jobs = [receiveJob({ 'Open or update the rolling sync PR': 'skipped' })];
+  const cls = classifyRun(run(), jobs, { ...OUTCOME, changed: '', changed_count: '0', state_changed: 'false', pr_url: '' });
+  assert.equal(cls.shape, 'noop');
+});
+
+test('stale: guard green, import skipped → ⏭️ SKIPPED, not NO-OP', () => {
+  const jobs = [receiveJob({ 'Import changed skills': 'skipped', 'Open or update the rolling sync PR': 'skipped' })];
+  const cls = classifyRun(run(), jobs, { ...OUTCOME, guard_skip: '1', changed: '', changed_count: '' });
+  assert.equal(cls.shape, 'stale');
+  assert.match(cls.detail, /AX-159/);
+});
+
+test('skipped run (CTX_PIPELINE off) posts nothing', () => {
+  assert.equal(classifyRun(run({ conclusion: 'skipped' }), [], null), null);
+  assert.equal(formatMessage(null, run()), null);
+});
+
+// ── failures: each known step gets an actionable line ──
+
+test('red: guard failed closed names skip_guard as the recovery', () => {
+  const jobs = [receiveJob({ 'Monotonicity guard': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, OUTCOME);
+  assert.equal(cls.shape, 'red');
+  assert.match(cls.detail, /monotonicity guard failed closed/);
+  assert.match(cls.detail, /skip_guard/);
+  assert.match(cls.detail, /Every later dispatch fails the same way/);
+});
+
+test('red: preflight failure points at the two secrets', () => {
+  const jobs = [receiveJob({ 'Preflight — required secrets': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, null);
+  assert.equal(cls.shape, 'red');
+  assert.match(cls.detail, /DOCS_READ_TOKEN/);
+  assert.match(cls.detail, /CTX_PIPELINE_PR_TOKEN/);
+});
+
+test('red: docs checkout failure carries the requested ref when known', () => {
+  const jobs = [receiveJob({ 'Checkout netlify/docs at ref': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, { docs_ref: 'deadbeef' });
+  assert.equal(cls.shape, 'red');
+  assert.match(cls.detail, /netlify\/docs at deadbeef/);
+  const bare = classifyRun(run({ conclusion: 'failure' }), jobs, null);
+  assert.match(bare.detail, /at the requested ref/);
+});
+
+test('red: import step failure', () => {
+  const jobs = [receiveJob({ 'Import changed skills': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, OUTCOME);
+  assert.equal(cls.shape, 'red');
+  assert.match(cls.detail, /^import failed/);
+});
+
+test('red: PR step failure says skills imported but PR not surfaced, with groupings', () => {
+  const jobs = [receiveJob({ 'Open or update the rolling sync PR': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, OUTCOME);
+  assert.equal(cls.shape, 'red');
+  assert.match(cls.detail, /NOT pushed\/opened/);
+  assert.match(cls.detail, /CTX_PIPELINE_PR_TOKEN/);
+  assert.match(cls.detail, /groupings: functions forms/);
+});
+
+test('red: an unrecognized failing step is still named', () => {
+  const jobs = [receiveJob({ 'Checkout context-and-tools': 'failure' })];
+  const cls = classifyRun(run({ conclusion: 'failure' }), jobs, null);
+  assert.equal(cls.shape, 'red');
+  assert.equal(cls.detail, 'receive failed at "Checkout context-and-tools"');
+});
+
+test('red: failure with no failed step / no receive job is still red', () => {
+  const noStep = classifyRun(run({ conclusion: 'failure' }), [{ name: 'receive', conclusion: 'failure', steps: [] }], null);
+  assert.equal(noStep.shape, 'red');
+  assert.match(noStep.detail, /no failed step/);
+  const noJob = classifyRun(run({ conclusion: 'failure' }), [], null);
+  assert.equal(noJob.shape, 'red');
+  assert.match(noJob.detail, /no "receive" job/);
+});
+
+test('red: startup_failure is red, not unclassified', () => {
+  const cls = classifyRun(run({ conclusion: 'startup_failure' }), [], null);
+  assert.equal(cls.shape, 'red');
+});
+
+// ── unclassified: never guess ──
+
+test('unclassified: cancelled / timed_out / unknown conclusion / unknown workflow', () => {
+  for (const conclusion of ['cancelled', 'timed_out']) {
+    const cls = classifyRun(run({ conclusion }), [receiveJob()], null);
+    assert.equal(cls.shape, 'unclassified', conclusion);
+    assert.match(cls.detail, new RegExp(conclusion));
+  }
+  assert.equal(classifyRun(run({ conclusion: 'action_required' }), [], null).shape, 'unclassified');
+  const other = classifyRun(run({ name: 'Validate Skills' }), [], null);
+  assert.equal(other.shape, 'unclassified');
+  assert.match(other.detail, /unknown workflow "Validate Skills"/);
+});
+
+test('unclassified: green run with a step layout the classifier does not know', () => {
+  // Every interesting step skipped — not a shape the workflow can produce.
+  const jobs = [receiveJob({ 'Monotonicity guard': 'skipped', 'Import changed skills': 'skipped', 'Open or update the rolling sync PR': 'skipped' })];
+  assert.equal(classifyRun(run(), jobs, null).shape, 'unclassified');
+  assert.equal(classifyRun(run(), [], null).shape, 'unclassified');
+});
+
+// ── message grammar: shape · run · docs sha · trigger · detail ──
+
+test('formatMessage: five fields in contract order, docs sha shortened to 9', () => {
+  const msg = formatMessage(classifyRun(run(), [receiveJob()], OUTCOME), run(), OUTCOME);
+  const fields = msg.split(' · ');
+  assert.equal(fields[0], '📥 ctx-pipeline receive IMPORTED');
+  assert.equal(fields[1], '<https://github.com/netlify/context-and-tools/actions/runs/32073913019|run 32073913019>');
+  assert.equal(fields[2], `docs ${DOCS_SHA.slice(0, 9)}`);
+  assert.equal(fields[3], 'dispatch');
+  assert.ok(fields.slice(4).join(' · ').startsWith('groupings: functions forms'));
+});
+
+test('formatMessage: docs n/a without an artifact; attempt number on re-runs', () => {
+  const r = run({ run_attempt: 2 });
+  const msg = formatMessage(classifyRun(r, [receiveJob()], null), r, null);
+  assert.match(msg, /run 32073913019> \(attempt 2\) · docs n\/a · dispatch ·/);
+});
+
+test('formatMessage: manual runs say so, and skip_guard bypasses are flagged', () => {
+  const r = run({ event: 'workflow_dispatch' });
+  assert.match(formatMessage(classifyRun(r, [receiveJob()], OUTCOME), r, OUTCOME), / · manual · /);
+  const bypass = { ...OUTCOME, guard_bypassed: 'true' };
+  assert.match(formatMessage(classifyRun(r, [receiveJob()], bypass), r, bypass), / · manual \(skip_guard\) · /);
+});
+
+test('formatMessage: detail is capped at 300 chars', () => {
+  const msg = formatMessage({ shape: 'red', detail: 'x'.repeat(500) }, run(), null);
+  const detail = msg.split(' · ').pop();
+  assert.equal(detail.length, 300);
+  assert.ok(detail.endsWith('…'));
+});
+
+// ── helpers ──
+
+test('parseOutcome: object passes; garbage, arrays and null are absent', () => {
+  assert.deepEqual(parseOutcome('{"docs_sha":"abc"}'), { docs_sha: 'abc' });
+  assert.equal(parseOutcome('not json'), null);
+  assert.equal(parseOutcome('[1]'), null);
+  assert.equal(parseOutcome('null'), null);
+});
+
+test('slackEscape escapes the three mrkdwn control characters', () => {
+  assert.equal(slackEscape('a<b>&c'), 'a&lt;b&gt;&amp;c');
+});


### PR DESCRIPTION
Follow-on to #117 for EX-3057. docs' dispatch to us is fire-and-forget, so the docs-side notifier (AX-138) says "delivered" the moment the dispatch is accepted. If the receive run here fails, nothing says so: `workflow_run` can't watch across repos, the run has no PR or watched branch, and the failure mail goes to the dispatch token's identity. With #117's fail-closed divergence branch that's now a state you can sit in for weeks - every dispatch after a docs history rewrite fails the same way and Slack keeps reporting success.

## What changed

- `.github/workflows/ctx-pipeline-notify.yml` - `workflow_run` watcher on "Receive agent-context". Posts every outcome to `#notify-context-pipeline`; the only silent case is a run that concluded `skipped` (dispatch with `CTX_PIPELINE` off). `workflow_dispatch` replays any run ID, dry-run by default.
- `scripts/ctx-notify.mjs` - the classifier. Five shapes: 📥 IMPORTED, 💤 NO-OP, ⏭️ SKIPPED (stale delivery), 🔴 FAILED, ⚠️ UNCLASSIFIED. Failures name the step and what to do about it; the guard's fail-closed branch calls out `skip_guard`, since that state recurs on every dispatch until a human resets it. One field per line: status, docs sha + trigger, detail, run URL, PR URL when there is one. The docs sha pairs the message with the docs-side DELIVERED line.
- `.github/workflows/ctx-pipeline-receive.yml` - the PR step now outputs its URL, and two always-run, `continue-on-error` steps upload a `ctx-receive-outcome` artifact (docs sha, groupings, PR URL). Classification reads job step conclusions from the Actions API, so runs that die at checkout still classify; the artifact only enriches the message.
- `scripts/ctx-notify.test.mjs` - every shape, every known failing step, degradation without the artifact, and the exact message lines. Wired into `npm test` and the validate-skills path filter.

## Plain text on purpose

The channel's webhook is a Slack Workflow Builder trigger, not a classic incoming webhook (EX-3065). It drops `text` into a template as plain text, which is why every docs-side line in the channel today renders its links as `<<url>|run 123>`. A probe post confirmed the rest: newlines break lines, bare URLs auto-link, and `*bold*` / `&amp;` / `<url|label>` all come through literally. So this message uses bare URLs and newlines and nothing else. The one payload-derived field (`docs_ref`) has angle brackets stripped rather than entity-escaped. The docs-side notifier has the same rendering problem; that's a separate fix in `netlify/docs`.

## Why not reuse docs' notify.mjs

The ticket asks. Its classifier is entirely docs-specific (gate evidence artifact, case-B PR lookup); only the watcher pattern carries over, and after the plain-text finding its formatting layer doesn't either. Pulling private docs code into a public repo's CI just to post one message didn't seem worth it.

## Verified

- `npm test`: 68 pass, 23 new.
- Dry-run replay against real runs: 32073913019 (green dispatch) → IMPORTED; 31633992205 and 31633016533 (red manual) → FAILED at "Checkout context-and-tools".
- The outcome step's inline `node -e` snippet run locally with sample env and fed through the formatter end to end.
- One probe message with the exact IMPORTED layout posted through the real webhook by hand (tagged `[test EX-3057 · ignore]` in the channel).

## Before this does anything

- `SLACK_WEBHOOK_URL` needs to exist in a `ctx-pipeline` environment on this repo (same webhook docs uses; GitHub creates the environment on the first run that references it). When creating it, restrict deployment branches to `main` - this is a public repo and the environment is what keeps the secret off every other branch. Until the secret exists the notifier prints a dry-run message and exits 0.
- Neither trigger fires until the file is on `main`. First live check: `workflow_dispatch` with any run ID and `dry_run` on.
- Further formatting (bold, link labels) is a Workflow Builder template change under EX-3065, not something this payload can do.

Ref: EX-3057, AX-138, AX-159.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now include unclassified outcomes.
  * Notifications support manual replay and dry runs.
  * Receive results remain available as downloadable artifacts for 30 days.
  * Notifications stay inactive when Slack configuration is unavailable.

* **Bug Fixes**
  * Restricted notifications to trusted workflow runs from the current repository.
  * Prevented stale artifacts from being used for reruns.
  * Added timeouts and retries for GitHub and Slack requests.

* **Tests**
  * Expanded validation for workflow changes, trust boundaries, reruns, and outcome classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->